### PR TITLE
Support variable references and arbitrary arguments

### DIFF
--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -19,7 +19,7 @@ pub enum TokenType {
     #[token("val")]
     Val,
 
-    #[regex("[\\./\\p{XID_Start}](?:[^\\s'\"$@]|\\\\.)*")]
+    #[regex("[\\./\\p{XID_Start}](?:[^\\s'\"$@}]|\\\\.)*")]
     Identifier,
 
     #[regex("-?[0-9]+", priority = 2)]

--- a/parser/src/aspects.rs
+++ b/parser/src/aspects.rs
@@ -2,3 +2,4 @@ pub(super) mod base_parser;
 pub(super) mod call_parser;
 pub(super) mod literal_parser;
 pub(super) mod var_declaration_parser;
+pub(super) mod var_reference_parser;

--- a/parser/src/aspects/base_parser.rs
+++ b/parser/src/aspects/base_parser.rs
@@ -7,7 +7,13 @@ use crate::parser::{ParseError, ParseResult, Parser};
 pub trait BaseParser<'a> {
     fn meet_token(&mut self, expected: TokenType) -> bool;
     fn match_token(&mut self, expected: TokenType) -> Option<Token<'a>>;
+    fn match_token_space_aware(&mut self, expected: TokenType) -> Option<Token<'a>>;
     fn expect_token(&mut self, expected: TokenType, message: &str) -> ParseResult<Token<'a>>;
+    fn expect_token_space_aware(
+        &mut self,
+        expected: TokenType,
+        message: &str,
+    ) -> ParseResult<Token<'a>>;
     fn expect_separated_token(
         &mut self,
         expected: TokenType,
@@ -38,8 +44,28 @@ impl<'a> BaseParser<'a> for Parser<'a> {
         None
     }
 
+    fn match_token_space_aware(&mut self, expected: TokenType) -> Option<Token<'a>> {
+        self.tokens.get(self.current).and_then(|token| {
+            if token.token_type == expected {
+                self.current += 1;
+                Some(token.clone())
+            } else {
+                None
+            }
+        })
+    }
+
     fn expect_token(&mut self, expected: TokenType, message: &str) -> ParseResult<Token<'a>> {
         self.match_token(expected)
+            .ok_or_else(|| self.mk_parse_error(message))
+    }
+
+    fn expect_token_space_aware(
+        &mut self,
+        expected: TokenType,
+        message: &str,
+    ) -> ParseResult<Token<'a>> {
+        self.match_token_space_aware(expected)
             .ok_or_else(|| self.mk_parse_error(message))
     }
 

--- a/parser/src/aspects/call_parser.rs
+++ b/parser/src/aspects/call_parser.rs
@@ -2,7 +2,6 @@ use lexer::token::TokenType;
 
 use crate::aspects::base_parser::BaseParser;
 use crate::ast::callable::Call;
-use crate::ast::literal::{Literal, LiteralValue};
 use crate::ast::Expr;
 use crate::parser::{ParseResult, Parser};
 
@@ -12,12 +11,7 @@ pub trait CallParser<'a> {
 
 impl<'a> CallParser<'a> for Parser<'a> {
     fn call(&mut self) -> ParseResult<Expr<'a>> {
-        let name = self.expect_token(TokenType::Identifier, "Expected command name.")?;
-
-        let mut args = vec![Expr::Literal(Literal {
-            token: name.clone(),
-            parsed: LiteralValue::String(name.value.to_string()),
-        })];
+        let mut args = vec![self.expression()?];
         while !self.is_at_end() && !self.meet_token(TokenType::NewLine) {
             args.push(self.expression()?);
         }

--- a/parser/src/aspects/literal_parser.rs
+++ b/parser/src/aspects/literal_parser.rs
@@ -10,6 +10,7 @@ use crate::parser::{ParseResult, Parser};
 pub(crate) trait LiteralParser<'a> {
     fn literal(&mut self) -> ParseResult<Expr<'a>>;
     fn string_literal(&mut self) -> ParseResult<Expr<'a>>;
+    fn argument(&mut self) -> ParseResult<Expr<'a>>;
     fn parse_literal(&mut self) -> ParseResult<LiteralValue>;
 }
 
@@ -30,6 +31,25 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
             }
             let token = self.next_token_space_aware()?;
             if token.token_type == TokenType::Quote {
+                break;
+            }
+            value.push_str(token.value);
+        }
+        Ok(Expr::Literal(Literal {
+            token,
+            parsed: LiteralValue::String(value),
+        }))
+    }
+
+    fn argument(&mut self) -> ParseResult<Expr<'a>> {
+        let token = self.next_token()?;
+        let mut value = token.value.to_string();
+        loop {
+            if self.is_at_end() {
+                break;
+            }
+            let token = self.next_token_space_aware()?;
+            if token.token_type == TokenType::Space {
                 break;
             }
             value.push_str(token.value);

--- a/parser/src/aspects/var_declaration_parser.rs
+++ b/parser/src/aspects/var_declaration_parser.rs
@@ -26,7 +26,7 @@ impl<'a> VarDeclarationParser<'a> for Parser<'a> {
 
         let initializer = match self.match_token(TokenType::Equal) {
             None => None,
-            Some(_) => Some(self.expression()?),
+            Some(_) => Some(self.statement()?),
         };
 
         Ok(Expr::VarDeclaration(VarDeclaration {

--- a/parser/src/aspects/var_declaration_parser.rs
+++ b/parser/src/aspects/var_declaration_parser.rs
@@ -26,7 +26,7 @@ impl<'a> VarDeclarationParser<'a> for Parser<'a> {
 
         let initializer = match self.match_token(TokenType::Equal) {
             None => None,
-            Some(_) => Some(self.statement()?),
+            Some(_) => Some(self.expression()?),
         };
 
         Ok(Expr::VarDeclaration(VarDeclaration {

--- a/parser/src/aspects/var_reference_parser.rs
+++ b/parser/src/aspects/var_reference_parser.rs
@@ -1,0 +1,20 @@
+use crate::aspects::base_parser::BaseParser;
+use crate::ast::variable::VarReference;
+use crate::ast::Expr;
+use crate::parser::{ParseResult, Parser};
+use lexer::token::TokenType;
+
+pub trait VarReferenceParser<'a> {
+    /// Parses a variable reference.
+    fn var_reference(&mut self) -> ParseResult<Expr<'a>>;
+}
+
+impl<'a> VarReferenceParser<'a> for Parser<'a> {
+    /// Parses a variable reference.
+    fn var_reference(&mut self) -> ParseResult<Expr<'a>> {
+        self.expect_token(TokenType::Dollar, "Expected dollar sign.")?;
+        let name =
+            self.expect_token_space_aware(TokenType::Identifier, "Expected variable name.")?;
+        Ok(Expr::VarReference(VarReference { name }))
+    }
+}

--- a/parser/src/aspects/var_reference_parser.rs
+++ b/parser/src/aspects/var_reference_parser.rs
@@ -13,8 +13,17 @@ impl<'a> VarReferenceParser<'a> for Parser<'a> {
     /// Parses a variable reference.
     fn var_reference(&mut self) -> ParseResult<Expr<'a>> {
         self.expect_token(TokenType::Dollar, "Expected dollar sign.")?;
+        let has_bracket = self
+            .match_token_space_aware(TokenType::CurlyLeftBracket)
+            .is_some();
         let name =
             self.expect_token_space_aware(TokenType::Identifier, "Expected variable name.")?;
+        if has_bracket {
+            self.expect_token(
+                TokenType::CurlyRightBracket,
+                "Expected closing curly bracket.",
+            )?;
+        }
         Ok(Expr::VarReference(VarReference { name }))
     }
 }

--- a/parser/src/ast.rs
+++ b/parser/src/ast.rs
@@ -4,11 +4,11 @@ use crate::ast::operation::BinaryOperation;
 use crate::ast::substitution::Substitution;
 use crate::ast::variable::{Assign, VarDeclaration, VarReference};
 
-pub mod variable;
-pub mod operation;
-pub mod literal;
-pub mod substitution;
 pub mod callable;
+pub mod literal;
+pub mod operation;
+pub mod substitution;
+pub mod variable;
 
 /// A expression that can be evaluated.
 #[derive(Debug, Clone, PartialEq)]
@@ -20,6 +20,7 @@ pub enum Expr<'a> {
     Literal(Literal<'a>),
     //Grouping(Grouping<'a>),
     Substitution(Substitution<'a>),
+    TemplateString(Vec<Expr<'a>>),
     VarReference(VarReference<'a>),
     VarDeclaration(VarDeclaration<'a>),
 }
@@ -31,4 +32,3 @@ pub struct Grouping<'a> {
     pub expr: Box<Expr<'a>>,
 }
 */
-

--- a/parser/src/ast/variable.rs
+++ b/parser/src/ast/variable.rs
@@ -1,5 +1,5 @@
-use lexer::token::Token;
 use crate::ast::Expr;
+use lexer::token::Token;
 
 /// A typed variable.
 #[derive(Debug, Clone, PartialEq)]
@@ -34,7 +34,6 @@ pub struct VarReference<'a> {
     pub name: Token<'a>,
 }
 
-
 /// A variable assignation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Assign<'a> {
@@ -43,4 +42,3 @@ pub struct Assign<'a> {
     /// The value of the variable to be evaluated.
     pub value: Box<Expr<'a>>,
 }
-

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -4,6 +4,7 @@ use lexer::token::{Token, TokenType};
 use crate::aspects::call_parser::CallParser;
 use crate::aspects::literal_parser::LiteralParser;
 use crate::aspects::var_declaration_parser::VarDeclarationParser;
+use crate::aspects::var_reference_parser::VarReferenceParser;
 use crate::ast::variable::VarKind;
 use crate::ast::Expr;
 
@@ -35,6 +36,7 @@ impl<'a> Parser<'a> {
         match self.peek_token().token_type {
             TokenType::IntLiteral | TokenType::FloatLiteral => self.literal(),
             TokenType::Quote => self.string_literal(),
+            TokenType::Dollar => self.var_reference(),
             _ => self.call(),
         }
     }
@@ -46,6 +48,7 @@ impl<'a> Parser<'a> {
         match self.peek_token().token_type {
             TokenType::Var => self.var_declaration(VarKind::Var),
             TokenType::Val => self.var_declaration(VarKind::Val),
+            TokenType::Identifier => self.call(),
             _ => self.expression(),
         }
     }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -4,7 +4,6 @@ use lexer::token::{Token, TokenType};
 use crate::aspects::call_parser::CallParser;
 use crate::aspects::literal_parser::LiteralParser;
 use crate::aspects::var_declaration_parser::VarDeclarationParser;
-use crate::aspects::var_reference_parser::VarReferenceParser;
 use crate::ast::variable::VarKind;
 use crate::ast::Expr;
 
@@ -36,7 +35,7 @@ impl<'a> Parser<'a> {
         match self.peek_token().token_type {
             TokenType::IntLiteral | TokenType::FloatLiteral => self.literal(),
             TokenType::Quote => self.string_literal(),
-            TokenType::Dollar => self.var_reference(),
+            TokenType::DoubleQuote => self.templated_string_literal(),
             _ => self.argument(),
         }
     }
@@ -46,9 +45,11 @@ impl<'a> Parser<'a> {
     /// Statements are usually on their own line.
     pub(crate) fn statement(&mut self) -> ParseResult<Expr<'a>> {
         match self.peek_token().token_type {
+            TokenType::Identifier => self.call(),
+            TokenType::Quote => self.call(),
+            TokenType::DoubleQuote => self.call(),
             TokenType::Var => self.var_declaration(VarKind::Var),
             TokenType::Val => self.var_declaration(VarKind::Val),
-            TokenType::Identifier => self.call(),
             _ => self.expression(),
         }
     }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -37,7 +37,7 @@ impl<'a> Parser<'a> {
             TokenType::IntLiteral | TokenType::FloatLiteral => self.literal(),
             TokenType::Quote => self.string_literal(),
             TokenType::Dollar => self.var_reference(),
-            _ => self.call(),
+            _ => self.argument(),
         }
     }
 

--- a/parser/tests/expr.rs
+++ b/parser/tests/expr.rs
@@ -29,13 +29,14 @@ fn variable_type_and_initializer() {
             parsed: LiteralValue::Int(1),
         }))),
     })];
-    assert_eq!(expected, parsed);
+    assert_eq!(parsed, expected);
 }
 
 #[test]
 fn command_echo() {
     let tokens = vec![
         Token::new(TokenType::Identifier, "echo"),
+        Token::new(TokenType::Space, " "),
         Token::new(TokenType::Quote, "'"),
         Token::new(TokenType::Identifier, "hello"),
         Token::new(TokenType::Quote, "'"),
@@ -54,5 +55,5 @@ fn command_echo() {
             }),
         ],
     })];
-    assert_eq!(expected, parsed);
+    assert_eq!(parsed, expected);
 }

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -84,7 +84,7 @@ fn with_lexer_var_reference_two() {
 
 #[test]
 fn with_lexer_var_reference_three() {
-    let tokens = lex("echo \"hello $world everyone $verb$ready !\"");
+    let tokens = lex("echo \"hello $world everyone $verb${ready}!\"");
     let parsed = parse(tokens).expect("Failed to parse");
 
     assert_eq!(
@@ -114,8 +114,8 @@ fn with_lexer_var_reference_three() {
                         name: Token::new(TokenType::Identifier, "ready"),
                     }),
                     Expr::Literal(Literal {
-                        token: Token::new(TokenType::Space, " "),
-                        parsed: LiteralValue::String(" !".to_string()),
+                        token: Token::new(TokenType::Not, "!"),
+                        parsed: LiteralValue::String("!".to_string()),
                     }),
                 ]),
             ],

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -58,13 +58,28 @@ fn with_lexer_var_call() {
 
 #[test]
 fn with_lexer_var_reference() {
-    let tokens = lex("$cmd");
+    let tokens = lex("fake $cmd do $arg2");
     let parsed = parse(tokens).expect("Failed to parse");
 
     assert_eq!(
         parsed,
-        vec![Expr::VarReference(VarReference {
-            name: Token::new(TokenType::Identifier, "cmd"),
+        vec![Expr::Call(Call {
+            arguments: vec![
+                Expr::Literal(Literal {
+                    token: Token::new(TokenType::Identifier, "fake"),
+                    parsed: LiteralValue::String("fake".to_string()),
+                }),
+                Expr::VarReference(VarReference {
+                    name: Token::new(TokenType::Identifier, "cmd"),
+                }),
+                Expr::Literal(Literal {
+                    token: Token::new(TokenType::Identifier, "do"),
+                    parsed: LiteralValue::String("do".to_string()),
+                }),
+                Expr::VarReference(VarReference {
+                    name: Token::new(TokenType::Identifier, "arg2"),
+                }),
+            ],
         })]
     );
 }

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -2,7 +2,7 @@ use lexer::lexer::lex;
 use lexer::token::{Token, TokenType};
 use parser::ast::callable::Call;
 use parser::ast::literal::{Literal, LiteralValue};
-use parser::ast::variable::{TypedVariable, VarDeclaration, VarKind};
+use parser::ast::variable::{TypedVariable, VarDeclaration, VarKind, VarReference};
 use parser::ast::Expr;
 use parser::parse;
 
@@ -52,6 +52,19 @@ fn with_lexer_var_call() {
                     })
                 ],
             }))),
+        })]
+    );
+}
+
+#[test]
+fn with_lexer_var_reference() {
+    let tokens = lex("$cmd");
+    let parsed = parse(tokens).expect("Failed to parse");
+
+    assert_eq!(
+        parsed,
+        vec![Expr::VarReference(VarReference {
+            name: Token::new(TokenType::Identifier, "cmd"),
         })]
     );
 }


### PR DESCRIPTION
This PR adds support for template strings and variable references in different places:
```kt
// Template strings
val prefix = 'my-'
val cmd = 'ssh'
"$prefix$cmd" root@vm // Now correctly expand to `my-ssh root@vm`
```

```kt
// Standard arguments
val count = 1
grep p$count // Now correctly expand to `grep p1`
```

```kt
// Variable names can be delimited with curly brackets
val verb = 'is '
val ready = 'ready'
echo "${verb}${ready}!" // Now correctly expand to `echo is ready!`
```

Variable references are not interpreted in literals with simple quotes:
```kt
val n = 10
grep '$n' // Expand as usual to `grep $n`
```

Fix #6 