### PR TITLE
Use the raw lexme in string literals

### DIFF
--- a/parser/src/aspects/block_parser.rs
+++ b/parser/src/aspects/block_parser.rs
@@ -171,12 +171,12 @@ mod tests {
                                         ty: None,
                                     },
                                     initializer: Some(Box::from(Expr::Literal(Literal {
-                                        token: Token::new(TokenType::IntLiteral, "8"),
+                                        lexme: "8",
                                         parsed: Int(8),
                                     }))),
                                 }),
                                 Expr::Literal(Literal {
-                                    token: Token::new(TokenType::IntLiteral, "8"),
+                                    lexme: "8",
                                     parsed: Int(8),
                                 }),
                             ]
@@ -191,7 +191,7 @@ mod tests {
                                     ty: None,
                                 },
                                 initializer: Some(Box::from(Expr::Literal(Literal {
-                                    token: Token::new(TokenType::IntLiteral, "89"),
+                                    lexme: "89",
                                     parsed: Int(89),
                                 }))),
                             }),
@@ -202,20 +202,14 @@ mod tests {
                                     ty: None,
                                 },
                                 initializer: Some(Box::from(Expr::Literal(Literal {
-                                    token: Token::new(TokenType::IntLiteral, "77"),
+                                    lexme: "77",
                                     parsed: Int(77),
                                 }))),
                             }),
                             Expr::Call(Call {
                                 arguments: vec![
-                                    Expr::Literal(Literal {
-                                        token: Token::new(TokenType::Identifier, "command"),
-                                        parsed: "command".into(),
-                                    }),
-                                    Expr::Literal(Literal {
-                                        token: Token::new(TokenType::Identifier, "call"),
-                                        parsed: "call".into(),
-                                    }),
+                                    Expr::Literal("command".into()),
+                                    Expr::Literal("call".into()),
                                 ],
                             }),
                         ]
@@ -247,7 +241,7 @@ mod tests {
                             ty: Some(Token::new(TokenType::Identifier, "int")),
                         },
                         initializer: Some(Box::new(Expr::Literal(Literal {
-                            token: Token::new(TokenType::FloatLiteral, "7.0"),
+                            lexme: "7.0",
                             parsed: Float(7.0),
                         }))),
                     }),
@@ -258,7 +252,7 @@ mod tests {
                             ty: None,
                         },
                         initializer: Some(Box::new(Expr::Literal(Literal {
-                            token: Token::new(TokenType::IntLiteral, "8"),
+                            lexme: "8",
                             parsed: Int(8),
                         }))),
                     }),

--- a/parser/src/aspects/call_parser.rs
+++ b/parser/src/aspects/call_parser.rs
@@ -160,7 +160,6 @@ mod tests {
     use crate::parse;
     use crate::parser::Parser;
     use lexer::lexer::lex;
-    use lexer::token::{Token, TokenType};
 
     #[test]
     fn redirection() {
@@ -170,18 +169,12 @@ mod tests {
             parsed,
             Expr::Redirected(Redirected {
                 expr: Box::new(Expr::Call(Call {
-                    arguments: vec![Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "ls"),
-                        parsed: "ls".into(),
-                    })]
+                    arguments: vec![Expr::Literal("ls".into())]
                 })),
                 redirections: vec![Redir {
                     fd: RedirFd::Default,
                     operator: RedirOp::Write,
-                    operand: Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "out"),
-                        parsed: "/tmp/out".into(),
-                    }),
+                    operand: Expr::Literal("/tmp/out".into()),
                 }],
             })
         );
@@ -195,16 +188,13 @@ mod tests {
             parsed,
             Expr::Redirected(Redirected {
                 expr: Box::new(Expr::Call(Call {
-                    arguments: vec![Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "ls"),
-                        parsed: "ls".into(),
-                    })]
+                    arguments: vec![Expr::Literal("ls".into())]
                 })),
                 redirections: vec![Redir {
                     fd: RedirFd::Default,
                     operator: RedirOp::FdOut,
                     operand: Expr::Literal(Literal {
-                        token: Token::new(TokenType::IntLiteral, "2"),
+                        lexme: "2",
                         parsed: 2.into(),
                     }),
                 }],
@@ -221,31 +211,13 @@ mod tests {
             vec![
                 Expr::Call(Call {
                     arguments: vec![
-                        Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "grep"),
-                            parsed: "grep".into(),
-                        }),
-                        Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "E"),
-                            parsed: "-E".into(),
-                        }),
-                        Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "regex"),
-                            parsed: "regex".into(),
-                        }),
+                        Expr::Literal("grep".into()),
+                        Expr::Literal("-E".into()),
+                        Expr::Literal("regex".into()),
                     ],
                 }),
                 Expr::Call(Call {
-                    arguments: vec![
-                        Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "echo"),
-                            parsed: "echo".into(),
-                        }),
-                        Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "test"),
-                            parsed: "test".into(),
-                        }),
-                    ],
+                    arguments: vec![Expr::Literal("echo".into()), Expr::Literal("test".into()),],
                 }),
             ]
         )
@@ -259,30 +231,15 @@ mod tests {
             parsed,
             vec![Expr::Call(Call {
                 arguments: vec![
+                    Expr::Literal("grep".into()),
+                    Expr::Literal("-E".into()),
+                    Expr::Literal("regex".into()),
                     Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "grep"),
-                        parsed: "grep".into(),
-                    }),
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "E"),
-                        parsed: "-E".into(),
-                    }),
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "regex"),
-                        parsed: "regex".into(),
-                    }),
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::BackSlash, "\\"),
+                        lexme: "\\;",
                         parsed: ";".into(),
                     }),
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "echo"),
-                        parsed: "echo".into(),
-                    }),
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "test"),
-                        parsed: "test".into(),
-                    }),
+                    Expr::Literal("echo".into()),
+                    Expr::Literal("test".into()),
                 ],
             }),]
         )

--- a/parser/src/aspects/literal_parser.rs
+++ b/parser/src/aspects/literal_parser.rs
@@ -7,6 +7,7 @@ use crate::ast::literal::{Literal, LiteralValue};
 use crate::ast::*;
 use crate::moves::{next, of_type};
 use crate::parser::{ParseResult, Parser};
+use crate::source::try_join_str;
 
 pub(crate) trait LiteralParser<'a> {
     fn literal(&mut self) -> ParseResult<Expr<'a>>;
@@ -19,15 +20,16 @@ pub(crate) trait LiteralParser<'a> {
 impl<'a> LiteralParser<'a> for Parser<'a> {
     fn literal(&mut self) -> ParseResult<Expr<'a>> {
         Ok(Expr::Literal(Literal {
-            token: self.cursor.peek().clone(),
+            lexme: self.cursor.peek().value,
             parsed: self.parse_literal()?,
         }))
     }
 
     fn string_literal(&mut self) -> ParseResult<Expr<'a>> {
-        let token = self
+        let mut lexme = self
             .cursor
-            .force(of_type(TokenType::Quote), "Expected quote.")?;
+            .force(of_type(TokenType::Quote), "Expected quote.")?
+            .value;
 
         let mut value = String::new();
 
@@ -39,14 +41,20 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
 
                 Some(token) => {
                     if token.token_type == TokenType::Quote {
+                        if let Some(joined) = try_join_str(lexme, token.value) {
+                            lexme = joined;
+                        }
                         break;
                     }
                     value.push_str(token.value);
+                    if let Some(joined) = try_join_str(lexme, token.value) {
+                        lexme = joined;
+                    }
                 }
             };
         }
         Ok(Expr::Literal(Literal {
-            token,
+            lexme,
             parsed: LiteralValue::String(value),
         }))
     }
@@ -54,7 +62,7 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
     fn templated_string_literal(&mut self) -> ParseResult<Expr<'a>> {
         self.cursor
             .force(of_type(TokenType::DoubleQuote), "Expected quote.")?;
-        let mut current_start = self.cursor.peek();
+        let mut lexme = self.cursor.peek().value;
         let mut literal_value = String::new();
         let mut parts = Vec::new();
         loop {
@@ -71,23 +79,31 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
                 TokenType::Dollar => {
                     if !literal_value.is_empty() {
                         parts.push(Expr::Literal(Literal {
-                            token: current_start,
+                            lexme,
                             parsed: LiteralValue::String(literal_value.clone()),
                         }));
                         literal_value.clear();
+                        lexme = "";
                     }
 
                     let var_ref = self.var_reference()?;
                     parts.push(var_ref);
-                    current_start = self.cursor.peek();
                 }
 
-                _ => literal_value.push_str(self.cursor.next()?.value),
+                _ => {
+                    let value = self.cursor.next()?.value;
+                    literal_value.push_str(value);
+                    if lexme.is_empty() {
+                        lexme = value;
+                    } else if let Some(joined) = try_join_str(lexme, value) {
+                        lexme = joined;
+                    }
+                }
             };
         }
         if !literal_value.is_empty() {
             parts.push(Expr::Literal(Literal {
-                token: current_start,
+                lexme,
                 parsed: LiteralValue::String(literal_value),
             }));
         }
@@ -100,14 +116,22 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
     /// An argument is usually a single identifier, but can also be
     /// composed of multiple tokens if not separated with a space.
     fn argument(&mut self) -> ParseResult<Expr<'a>> {
-        let mut current = self.cursor.peek();
+        let current = self.cursor.peek();
         let mut parts = Vec::new();
         let mut builder = String::new();
+        let mut lexme = current.value;
 
         //pushes current token then advance
         macro_rules! push_current {
             () => {
-                builder.push_str(self.cursor.next()?.value)
+                let value = self.cursor.next()?.value;
+                builder.push_str(value);
+                if lexme.is_empty() {
+                    lexme = value;
+                } else if let Some(joined) = try_join_str(lexme, value) {
+                    lexme = joined;
+                }
+                ()
             };
         }
 
@@ -119,8 +143,10 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
                                      //will append the escaped value (token after the backslash)
                 push_current!();
             }
-            _ => push_current!(),
-        }
+            _ => {
+                push_current!();
+            }
+        };
         while !self.cursor.is_at_end() {
             let pivot = self.cursor.peek().token_type;
             match pivot {
@@ -137,28 +163,23 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
                 TokenType::Dollar => {
                     if !builder.is_empty() {
                         parts.push(Expr::Literal(Literal {
-                            token: current.clone(),
+                            lexme,
                             parsed: LiteralValue::String(builder.clone()),
                         }));
                         builder.clear();
+                        lexme = "";
                     }
                     parts.push(self.var_reference()?);
                 }
                 _ if pivot.is_ponctuation() => break,
                 _ => {
-                    if !builder.is_empty() {
-                        current = self.cursor.peek();
-                    }
-                    if !builder.is_empty() {
-                        current = self.cursor.peek();
-                    }
-                    push_current!()
+                    push_current!();
                 }
             }
         }
         if !builder.is_empty() {
             parts.push(Expr::Literal(Literal {
-                token: current,
+                lexme,
                 parsed: LiteralValue::String(builder),
             }));
         }
@@ -225,10 +246,8 @@ mod tests {
         assert_eq!(
             parsed,
             Expr::Literal(Literal {
-                token: Token::new(TokenType::Quote, "'"),
-                parsed: LiteralValue::String(
-                    "hello $world! $(this is a test) @(of course)".to_string()
-                ),
+                lexme: "'hello $world! $(this is a test) @(of course)'",
+                parsed: "hello $world! $(this is a test) @(of course)".into(),
             })
         );
     }
@@ -240,7 +259,7 @@ mod tests {
         assert_eq!(
             parsed,
             Expr::Literal(Literal {
-                token: Token::new(TokenType::Identifier, "a"),
+                lexme: "a",
                 parsed: "aa".into(),
             })
         );

--- a/parser/src/aspects/var_declaration_parser.rs
+++ b/parser/src/aspects/var_declaration_parser.rs
@@ -126,7 +126,7 @@ mod tests {
                     ty: None,
                 },
                 initializer: Some(Box::from(Expr::Literal(Literal {
-                    token: Token::new(TokenType::Quote, "'"),
+                    lexme: "'hello $test'",
                     parsed: "hello $test".into(),
                 }))),
             })

--- a/parser/src/ast/literal.rs
+++ b/parser/src/ast/literal.rs
@@ -1,9 +1,7 @@
-use lexer::token::Token;
-
 /// A literal value that can be used directly.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Literal<'a> {
-    pub token: Token<'a>,
+    pub lexme: &'a str,
     pub parsed: LiteralValue,
 }
 
@@ -24,5 +22,14 @@ impl From<&str> for LiteralValue {
 impl From<i64> for LiteralValue {
     fn from(s: i64) -> Self {
         Self::Int(s)
+    }
+}
+
+impl<'a> From<&'a str> for Literal<'a> {
+    fn from(s: &'a str) -> Self {
+        Self {
+            lexme: s,
+            parsed: LiteralValue::from(s),
+        }
     }
 }

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -12,6 +12,7 @@ pub mod ast;
 mod cursor;
 mod moves;
 mod parser;
+mod source;
 
 pub fn parse(tokens: Vec<Token>) -> ParseResult<Vec<Expr>> {
     Parser::new(tokens).parse()

--- a/parser/src/source.rs
+++ b/parser/src/source.rs
@@ -1,0 +1,21 @@
+/// Joins two slices that are adjacent in memory into one slice.
+///
+/// Returns None in the case the slices aren't adjacent.
+pub fn try_join<'a, T>(a: &'a [T], b: &'a [T]) -> Option<&'a [T]> {
+    let a_len = a.len();
+    let a_tail = a[a_len..].as_ptr();
+    if std::ptr::eq(a_tail, b.as_ptr()) {
+        // SAFETY: The two slices are adjacent in memory.
+        Some(unsafe { std::slice::from_raw_parts(a.as_ptr(), a.len() + b.len()) })
+    } else {
+        None
+    }
+}
+
+/// Joins two string slices that are adjacent in memory into one string slice.
+///
+/// Returns None in the case the slices aren't adjacent.
+pub fn try_join_str<'a>(a: &'a str, b: &'a str) -> Option<&'a str> {
+    // SAFETY: The two slices are already valid UTF-8.
+    try_join(a.as_bytes(), b.as_bytes()).map(|s| unsafe { std::str::from_utf8_unchecked(s) })
+}

--- a/parser/tests/expr.rs
+++ b/parser/tests/expr.rs
@@ -26,7 +26,7 @@ fn variable_type_and_initializer() {
             ty: Some(Token::new(TokenType::Identifier, "int")),
         },
         initializer: Some(Box::new(Expr::Literal(Literal {
-            token: Token::new(TokenType::IntLiteral, "1"),
+            lexme: "1",
             parsed: LiteralValue::Int(1),
         }))),
     })];
@@ -38,23 +38,12 @@ fn command_echo() {
     let tokens = vec![
         Token::new(TokenType::Identifier, "echo"),
         Token::new(TokenType::Space, " "),
-        Token::new(TokenType::Quote, "'"),
         Token::new(TokenType::Identifier, "hello"),
-        Token::new(TokenType::Quote, "'"),
     ];
     let parsed = parse(tokens).expect("Failed to parse");
 
     let expected = vec![Expr::Call(Call {
-        arguments: vec![
-            Expr::Literal(Literal {
-                token: Token::new(TokenType::Identifier, "echo"),
-                parsed: "echo".into(),
-            }),
-            Expr::Literal(Literal {
-                token: Token::new(TokenType::Quote, "'"),
-                parsed: "hello".into(),
-            }),
-        ],
+        arguments: vec![Expr::Literal("echo".into()), Expr::Literal("hello".into())],
     })];
     assert_eq!(parsed, expected);
 }

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -21,7 +21,7 @@ fn with_lexer_variable() {
                 ty: None,
             },
             initializer: Some(Box::new(Expr::Literal(Literal {
-                token: Token::new(TokenType::Quote, "'"),
+                lexme: "'hello world!'",
                 parsed: "hello world!".into(),
             }))),
         })]
@@ -37,12 +37,9 @@ fn with_lexer_var_reference_one() {
         parsed,
         vec![Expr::Call(Call {
             arguments: vec![
+                Expr::Literal("echo".into()),
                 Expr::Literal(Literal {
-                    token: Token::new(TokenType::Identifier, "echo"),
-                    parsed: "echo".into(),
-                }),
-                Expr::Literal(Literal {
-                    token: Token::new(TokenType::Quote, "'"),
+                    lexme: "'$var5'",
                     parsed: "$var5".into(),
                 }),
                 Expr::VarReference(VarReference {
@@ -63,18 +60,12 @@ fn with_lexer_var_reference_two() {
         vec![Expr::Call(Call {
             arguments: vec![
                 Expr::TemplateString(vec![
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "fake"),
-                        parsed: "fake".into(),
-                    }),
+                    Expr::Literal("fake".into()),
                     Expr::VarReference(VarReference {
                         name: Token::new(TokenType::Identifier, "cmd"),
                     }),
                 ]),
-                Expr::Literal(Literal {
-                    token: Token::new(TokenType::Identifier, "do"),
-                    parsed: "do".into(),
-                }),
+                Expr::Literal("do".into()),
                 Expr::VarReference(VarReference {
                     name: Token::new(TokenType::Identifier, "arg2"),
                 }),
@@ -92,32 +83,20 @@ fn with_lexer_var_reference_three() {
         parsed,
         vec![Expr::Call(Call {
             arguments: vec![
-                Expr::Literal(Literal {
-                    token: Token::new(TokenType::Identifier, "echo"),
-                    parsed: "echo".into(),
-                }),
+                Expr::Literal("echo".into()),
                 Expr::TemplateString(vec![
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "hello"),
-                        parsed: "hello ".into(),
-                    }),
+                    Expr::Literal("hello ".into()),
                     Expr::VarReference(VarReference {
                         name: Token::new(TokenType::Identifier, "world"),
                     }),
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Space, " "),
-                        parsed: " everyone ".into(),
-                    }),
+                    Expr::Literal(" everyone ".into()),
                     Expr::VarReference(VarReference {
                         name: Token::new(TokenType::Identifier, "verb"),
                     }),
                     Expr::VarReference(VarReference {
                         name: Token::new(TokenType::Identifier, "ready"),
                     }),
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Not, "!"),
-                        parsed: "!".into(),
-                    }),
+                    Expr::Literal("!".into()),
                 ]),
             ],
         })]
@@ -132,18 +111,12 @@ fn with_lexer_redirection() {
         parsed,
         vec![Expr::Redirected(Redirected {
             expr: Box::new(Expr::Call(Call {
-                arguments: vec![Expr::Literal(Literal {
-                    token: Token::new(TokenType::Identifier, "test"),
-                    parsed: "test".into(),
-                })]
+                arguments: vec![Expr::Literal("test".into())],
             })),
             redirections: vec![Redir {
                 fd: RedirFd::Wildcard,
                 operator: RedirOp::Write,
-                operand: Expr::Literal(Literal {
-                    token: Token::new(TokenType::Identifier, "null"),
-                    parsed: "/dev/null".into(),
-                }),
+                operand: Expr::Literal("/dev/null".into()),
             }],
         })]
     );
@@ -157,27 +130,18 @@ fn with_lexer_redirections() {
         parsed,
         vec![Expr::Redirected(Redirected {
             expr: Box::new(Expr::Call(Call {
-                arguments: vec![Expr::Literal(Literal {
-                    token: Token::new(TokenType::Identifier, "command"),
-                    parsed: "command".into(),
-                })]
+                arguments: vec![Expr::Literal("command".into())],
             })),
             redirections: vec![
                 Redir {
                     fd: RedirFd::Default,
                     operator: RedirOp::Read,
-                    operand: Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "input"),
-                        parsed: "/tmp/input".into(),
-                    }),
+                    operand: Expr::Literal("/tmp/input".into()),
                 },
                 Redir {
                     fd: RedirFd::Fd(2),
                     operator: RedirOp::Write,
-                    operand: Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "output"),
-                        parsed: "/tmp/output".into(),
-                    }),
+                    operand: Expr::Literal("/tmp/output".into()),
                 },
             ],
         })]
@@ -193,26 +157,14 @@ fn with_lexer_pipe_and_redirection() {
         vec![Expr::Pipeline(Pipeline {
             commands: vec![
                 Expr::Call(Call {
-                    arguments: vec![
-                        Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "ls"),
-                            parsed: "ls".into(),
-                        }),
-                        Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "l"),
-                            parsed: "-l".into()
-                        }),
-                    ],
+                    arguments: vec![Expr::Literal("ls".into()), Expr::Literal("-l".into()),],
                 }),
                 Expr::Redirected(Redirected {
                     expr: Box::new(Expr::Call(Call {
                         arguments: vec![
+                            Expr::Literal("grep".into()),
                             Expr::Literal(Literal {
-                                token: Token::new(TokenType::Identifier, "grep"),
-                                parsed: "grep".into()
-                            }),
-                            Expr::Literal(Literal {
-                                token: Token::new(TokenType::Quote, "'"),
+                                lexme: "'hello'",
                                 parsed: "hello".into()
                             }),
                         ]
@@ -220,10 +172,7 @@ fn with_lexer_pipe_and_redirection() {
                     redirections: vec![Redir {
                         fd: RedirFd::Default,
                         operator: RedirOp::Write,
-                        operand: Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "txt"),
-                            parsed: "out.txt".into(),
-                        }),
+                        operand: Expr::Literal("out.txt".into()),
                     }],
                 }),
             ],
@@ -240,29 +189,17 @@ fn with_lexer_pipe_and_pipe() {
         vec![Expr::Pipeline(Pipeline {
             commands: vec![
                 Expr::Call(Call {
-                    arguments: vec![Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "ls"),
-                        parsed: "ls".into(),
-                    })],
+                    arguments: vec![Expr::Literal("ls".into())],
                 }),
                 Expr::Call(Call {
-                    arguments: vec![Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "wc"),
-                        parsed: "wc".into(),
-                    })],
+                    arguments: vec![Expr::Literal("wc".into())],
                 }),
                 Expr::Call(Call {
                     arguments: vec![
+                        Expr::Literal("tr".into()),
+                        Expr::Literal("-s".into()),
                         Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "tr"),
-                            parsed: "tr".into(),
-                        }),
-                        Expr::Literal(Literal {
-                            token: Token::new(TokenType::Identifier, "s"),
-                            parsed: "-s".into(),
-                        }),
-                        Expr::Literal(Literal {
-                            token: Token::new(TokenType::Quote, "'"),
+                            lexme: "' '",
                             parsed: " ".into(),
                         }),
                     ],
@@ -280,22 +217,13 @@ fn with_lexer_here_string() {
         parsed,
         vec![Expr::Redirected(Redirected {
             expr: Box::new(Expr::Call(Call {
-                arguments: vec![
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "grep"),
-                        parsed: "grep".into(),
-                    }),
-                    Expr::Literal(Literal {
-                        token: Token::new(TokenType::Identifier, "e"),
-                        parsed: "e".into(),
-                    }),
-                ]
+                arguments: vec![Expr::Literal("grep".into()), Expr::Literal("e".into()),]
             })),
             redirections: vec![Redir {
                 fd: RedirFd::Default,
                 operator: RedirOp::String,
                 operand: Expr::Literal(Literal {
-                    token: Token::new(TokenType::Quote, "'"),
+                    lexme: "'hello'",
                     parsed: "hello".into(),
                 }),
             }],


### PR DESCRIPTION
Some tests that don't use the lexer have been shortened since strings in those tests are not guaranteed to be adjacent in memory.

Fix #17