### PR TITLE
Parse command substitution

### DIFF
--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -152,6 +152,8 @@ impl TokenType {
             TokenType::Ampersand
                 | TokenType::Less
                 | TokenType::Greater
+                | TokenType::And
+                | TokenType::Or
                 | TokenType::Pipe
                 | TokenType::SquareLeftBracket
                 | TokenType::SquareRightBracket

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -165,4 +165,12 @@ impl TokenType {
                 | TokenType::Error
         )
     }
+
+    pub fn is_closing_ponctuation(self) -> bool {
+        matches!(
+            self,
+            |TokenType::SquareRightBracket| TokenType::RoundedRightBracket
+                | TokenType::CurlyRightBracket
+        )
+    }
 }

--- a/parser/src/aspects.rs
+++ b/parser/src/aspects.rs
@@ -1,5 +1,6 @@
 pub(super) mod block_parser;
 pub(super) mod call_parser;
 pub(super) mod literal_parser;
+pub(super) mod substitution_parser;
 pub(super) mod var_declaration_parser;
 pub(super) mod var_reference_parser;

--- a/parser/src/aspects/call_parser.rs
+++ b/parser/src/aspects/call_parser.rs
@@ -21,7 +21,7 @@ pub trait CallParser<'a> {
 impl<'a> CallParser<'a> for Parser<'a> {
     fn call(&mut self) -> ParseResult<Expr<'a>> {
         let mut arguments = vec![self.expression()?];
-        // End Of Expression \!(; + \n)
+        // Continue reading arguments until we reach the end of the input or a closing ponctuation
         while !self.cursor.is_at_end()
             && self
                 .cursor

--- a/parser/src/aspects/call_parser.rs
+++ b/parser/src/aspects/call_parser.rs
@@ -1,6 +1,6 @@
 use crate::ast::callable::{Call, Pipeline, Redir, RedirFd, RedirOp, Redirected};
 use crate::ast::Expr;
-use crate::moves::{eox, next, of_type, of_types, space, spaces, MoveOperations};
+use crate::moves::{eox, next, of_type, of_types, predicate, space, spaces, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 use lexer::token::TokenType;
 
@@ -22,7 +22,14 @@ impl<'a> CallParser<'a> for Parser<'a> {
     fn call(&mut self) -> ParseResult<Expr<'a>> {
         let mut arguments = vec![self.expression()?];
         // End Of Expression \!(; + \n)
-        while !self.cursor.is_at_end() && self.cursor.lookahead(spaces().then(eox())).is_none() {
+        while !self.cursor.is_at_end()
+            && self
+                .cursor
+                .lookahead(
+                    spaces().then(eox().or(predicate(|t| t.token_type.is_closing_ponctuation()))),
+                )
+                .is_none()
+        {
             self.cursor.advance(space());
             if self.is_redirection_sign() {
                 return self.redirectable(Expr::Call(Call { arguments }));

--- a/parser/src/aspects/call_parser.rs
+++ b/parser/src/aspects/call_parser.rs
@@ -22,7 +22,7 @@ impl<'a> CallParser<'a> for Parser<'a> {
     fn call(&mut self) -> ParseResult<Expr<'a>> {
         let mut arguments = vec![self.expression()?];
         // End Of Expression \!(; + \n)
-        while !self.cursor.is_at_end() && self.cursor.advance(spaces().then(eox())).is_none() {
+        while !self.cursor.is_at_end() && self.cursor.lookahead(spaces().then(eox())).is_none() {
             self.cursor.advance(space());
             if self.is_redirection_sign() {
                 return self.redirectable(Expr::Call(Call { arguments }));

--- a/parser/src/aspects/literal_parser.rs
+++ b/parser/src/aspects/literal_parser.rs
@@ -9,10 +9,24 @@ use crate::moves::{next, of_type};
 use crate::parser::{ParseResult, Parser};
 use crate::source::try_join_str;
 
+/// A trait that contains all the methods for parsing literals.
 pub(crate) trait LiteralParser<'a> {
+    /// Parses a number-like literal expression.
     fn literal(&mut self) -> ParseResult<Expr<'a>>;
+
+    /// Parses a string literal expression.
+    ///
+    /// This method is only used for single quoted strings.
     fn string_literal(&mut self) -> ParseResult<Expr<'a>>;
+
+    /// Parses a string template literal expression.
+    ///
+    /// This method is only used for double quoted strings, which may contain variable references for instance.
     fn templated_string_literal(&mut self) -> ParseResult<Expr<'a>>;
+
+    /// Parse a raw argument.
+    ///
+    /// Arguments are not quoted and are separated by spaces.
     fn argument(&mut self) -> ParseResult<Expr<'a>>;
     fn parse_literal(&mut self) -> ParseResult<LiteralValue>;
 }

--- a/parser/src/aspects/literal_parser.rs
+++ b/parser/src/aspects/literal_parser.rs
@@ -111,7 +111,7 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
         }
 
         match current.token_type {
-            TokenType::Dollar => parts.push(self.substitution()?),
+            TokenType::At | TokenType::Dollar => parts.push(self.substitution()?),
             TokenType::BackSlash => {
                 //never retain first backslash
                 self.cursor.next()?; //advance so we are not pointing to token after '\'
@@ -133,7 +133,7 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
                     push_current!();
                 }
 
-                TokenType::Dollar => {
+                TokenType::At | TokenType::Dollar => {
                     if !builder.is_empty() {
                         parts.push(Expr::Literal(Literal {
                             token: current.clone(),

--- a/parser/src/aspects/literal_parser.rs
+++ b/parser/src/aspects/literal_parser.rs
@@ -1,8 +1,8 @@
 use std::num::IntErrorKind;
 
+use crate::aspects::substitution_parser::SubstitutionParser;
 use lexer::token::TokenType;
 
-use crate::aspects::var_reference_parser::VarReferenceParser;
 use crate::ast::literal::{Literal, LiteralValue};
 use crate::ast::*;
 use crate::moves::{next, of_type};
@@ -77,8 +77,7 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
                         literal_value.clear();
                     }
 
-                    let var_ref = self.var_reference()?;
-                    parts.push(var_ref);
+                    parts.push(self.substitution()?);
                     current_start = self.cursor.peek();
                 }
 
@@ -112,7 +111,7 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
         }
 
         match current.token_type {
-            TokenType::Dollar => parts.push(self.var_reference()?),
+            TokenType::Dollar => parts.push(self.substitution()?),
             TokenType::BackSlash => {
                 //never retain first backslash
                 self.cursor.next()?; //advance so we are not pointing to token after '\'
@@ -142,7 +141,7 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
                         }));
                         builder.clear();
                     }
-                    parts.push(self.var_reference()?);
+                    parts.push(self.substitution()?);
                 }
                 _ if pivot.is_ponctuation() => break,
                 _ => {

--- a/parser/src/aspects/literal_parser.rs
+++ b/parser/src/aspects/literal_parser.rs
@@ -97,8 +97,8 @@ impl<'a> LiteralParser<'a> for Parser<'a> {
                             parsed: LiteralValue::String(literal_value.clone()),
                         }));
                         literal_value.clear();
-                        lexme = "";
                     }
+                    lexme = "";
 
                     parts.push(self.substitution()?);
                 }

--- a/parser/src/aspects/substitution_parser.rs
+++ b/parser/src/aspects/substitution_parser.rs
@@ -1,0 +1,35 @@
+use crate::aspects::var_reference_parser::VarReferenceParser;
+use crate::ast::substitution::{Substitution, SubstitutionKind};
+use crate::ast::Expr;
+use crate::moves::of_type;
+use crate::parser::{ParseResult, Parser};
+use lexer::token::TokenType;
+
+pub(crate) trait SubstitutionParser<'a> {
+    /// Parse a substitution expression, i.e. a variable reference or a command capture.
+    fn substitution(&mut self) -> ParseResult<Expr<'a>>;
+}
+
+impl<'a> SubstitutionParser<'a> for Parser<'a> {
+    fn substitution(&mut self) -> ParseResult<Expr<'a>> {
+        self.cursor
+            .force(of_type(TokenType::Dollar), "Expected dollar sign.")?;
+        if self
+            .cursor
+            .advance(of_type(TokenType::RoundedLeftBracket))
+            .is_some()
+        {
+            let expr = Box::new(self.statement()?);
+            self.cursor.force(
+                of_type(TokenType::RoundedRightBracket),
+                "Expected closing bracket.",
+            )?;
+            Ok(Expr::Substitution(Substitution {
+                expr,
+                kind: SubstitutionKind::Capture,
+            }))
+        } else {
+            self.var_reference()
+        }
+    }
+}

--- a/parser/src/aspects/substitution_parser.rs
+++ b/parser/src/aspects/substitution_parser.rs
@@ -46,6 +46,7 @@ impl<'a> SubstitutionParser<'a> for Parser<'a> {
 #[cfg(test)]
 mod tests {
     use crate::aspects::substitution_parser::SubstitutionParser;
+    use crate::parse;
     use crate::parser::{ParseError, Parser};
     use lexer::lexer::lex;
     use pretty_assertions::assert_eq;
@@ -58,6 +59,18 @@ mod tests {
             ast,
             Err(ParseError {
                 message: "Expected closing bracket.".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn unexpected_closing_parenthesis() {
+        let tokens = lex("some stuff)");
+        let ast = parse(tokens);
+        assert_eq!(
+            ast,
+            Err(ParseError {
+                message: "Unexpected closing bracket.".to_string()
             })
         );
     }

--- a/parser/src/aspects/substitution_parser.rs
+++ b/parser/src/aspects/substitution_parser.rs
@@ -5,8 +5,9 @@ use crate::moves::{of_type, of_types, space, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 use lexer::token::TokenType;
 
+/// A parser for substitution expressions.
 pub(crate) trait SubstitutionParser<'a> {
-    /// Parse a substitution expression, i.e. a variable reference or a command capture.
+    /// Parses a substitution expression, i.e. a variable reference or a command capture.
     fn substitution(&mut self) -> ParseResult<Expr<'a>>;
 }
 
@@ -14,9 +15,10 @@ impl<'a> SubstitutionParser<'a> for Parser<'a> {
     fn substitution(&mut self) -> ParseResult<Expr<'a>> {
         let start_token = self.cursor.force(
             of_types(&[TokenType::At, TokenType::Dollar]),
-            "Expected dollar sign.",
+            "Expected at or dollar sign.",
         )?;
 
+        // Short pass for variable references
         if self
             .cursor
             .advance(of_type(TokenType::RoundedLeftBracket))
@@ -26,12 +28,14 @@ impl<'a> SubstitutionParser<'a> for Parser<'a> {
             return self.var_reference();
         }
 
+        // Read the expression inside the parentheses as a new statement
         let expr = Box::new(self.statement()?);
         self.cursor.force(
             space().then(of_type(TokenType::RoundedRightBracket)),
             "Expected closing bracket.",
         )?;
 
+        // Finally return the expression
         Ok(Expr::Substitution(Substitution {
             expr,
             kind: if start_token.token_type == TokenType::At {

--- a/parser/src/aspects/var_reference_parser.rs
+++ b/parser/src/aspects/var_reference_parser.rs
@@ -13,9 +13,8 @@ pub trait VarReferenceParser<'a> {
 impl<'a> VarReferenceParser<'a> for Parser<'a> {
     /// Parses a variable reference.
     fn var_reference(&mut self) -> ParseResult<Expr<'a>> {
-        let cursor = &mut self.cursor;
-        cursor.force(of_type(TokenType::Dollar), "Expected dollar sign.")?;
-        let has_bracket = cursor
+        let has_bracket = self
+            .cursor
             .advance(of_type(TokenType::CurlyLeftBracket))
             .is_some();
         let name = self
@@ -36,7 +35,7 @@ mod tests {
     use lexer::lexer::lex;
     use lexer::token::{Token, TokenType};
 
-    use crate::aspects::var_reference_parser::VarReferenceParser;
+    use crate::aspects::substitution_parser::SubstitutionParser;
     use crate::ast::variable::VarReference;
     use crate::ast::Expr;
     use crate::parser::Parser;
@@ -45,9 +44,7 @@ mod tests {
     #[test]
     fn test_simple_ref() {
         let tokens = lex("$VARIABLE");
-        let ast = Parser::new(tokens)
-            .var_reference()
-            .expect("failed to parse");
+        let ast = Parser::new(tokens).substitution().expect("failed to parse");
         assert_eq!(
             ast,
             Expr::VarReference(VarReference {
@@ -59,9 +56,7 @@ mod tests {
     #[test]
     fn test_wrapped_ref() {
         let tokens = lex("${VAR}IABLE");
-        let ast = Parser::new(tokens)
-            .var_reference()
-            .expect("failed to parse");
+        let ast = Parser::new(tokens).substitution().expect("failed to parse");
         assert_eq!(
             ast,
             Expr::VarReference(VarReference {

--- a/parser/src/moves.rs
+++ b/parser/src/moves.rs
@@ -267,7 +267,7 @@ pub(crate) fn eox() -> OrMove<
     //if it's escaped then it's not an EOX
     (of_type(BackSlash).and_then(escapable().negate()))
         //else it must be either new line or ';'
-        .or(of_types(&[NewLine, SemiColon, RoundedRightBracket]))
+        .or(of_types(&[NewLine, SemiColon]))
 }
 
 ///a move that consumes a character if it can be escaped.

--- a/parser/src/moves.rs
+++ b/parser/src/moves.rs
@@ -272,15 +272,7 @@ pub(crate) fn eox() -> OrMove<
 
 ///a move that consumes a character if it can be escaped.
 pub(crate) fn escapable() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool)> {
-    of_types(&[
-        NewLine,
-        Pipe,
-        And,
-        Or,
-        SemiColon,
-        Ampersand,
-        RoundedRightBracket,
-    ])
+    predicate(|t| t.token_type.is_ponctuation())
 }
 
 #[cfg(test)]

--- a/parser/src/moves.rs
+++ b/parser/src/moves.rs
@@ -267,12 +267,20 @@ pub(crate) fn eox() -> OrMove<
     //if it's escaped then it's not an EOX
     (of_type(BackSlash).and_then(escapable().negate()))
         //else it must be either new line or ';'
-        .or(of_types(&[NewLine, SemiColon]))
+        .or(of_types(&[NewLine, SemiColon, RoundedRightBracket]))
 }
 
 ///a move that consumes a character if it can be escaped.
 pub(crate) fn escapable() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool)> {
-    of_types(&[NewLine, Pipe, And, Or, SemiColon, Ampersand])
+    of_types(&[
+        NewLine,
+        Pipe,
+        And,
+        Or,
+        SemiColon,
+        Ampersand,
+        RoundedRightBracket,
+    ])
 }
 
 #[cfg(test)]

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -40,6 +40,7 @@ impl<'a> Parser<'a> {
             TokenType::Quote => self.string_literal(),
             TokenType::CurlyLeftBracket => self.block(),
             TokenType::DoubleQuote => self.templated_string_literal(),
+            _ if pivot.is_closing_ponctuation() => self.expected("Unexpected closing bracket."),
             _ => self.argument(),
         }
     }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -6,7 +6,7 @@ use crate::aspects::literal_parser::LiteralParser;
 use crate::aspects::var_declaration_parser::VarDeclarationParser;
 use crate::ast::Expr;
 use crate::cursor::ParserCursor;
-use crate::moves::{eox, spaces};
+use crate::moves::{eox, space, spaces, MoveOperations};
 
 pub type ParseResult<T> = Result<T, ParseError>;
 
@@ -76,6 +76,7 @@ impl<'a> Parser<'a> {
 
         while !self.cursor.is_at_end() {
             statements.push(self.statement()?);
+            self.cursor.advance(space().then(eox()));
         }
 
         Ok(statements)

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -372,3 +372,34 @@ fn with_lexer_substitution_in_substitution() {
         })]
     );
 }
+
+#[test]
+fn with_lexer_here_invoke() {
+    let tokens = lex("val valid = @(nginx -t)");
+    let parsed = parse(tokens).expect("Failed to parse");
+    assert_eq!(
+        parsed,
+        vec![Expr::VarDeclaration(VarDeclaration {
+            kind: VarKind::Val,
+            var: TypedVariable {
+                name: Token::new(TokenType::Identifier, "valid"),
+                ty: None,
+            },
+            initializer: Some(Box::new(Expr::Substitution(Substitution {
+                expr: Box::new(Expr::Call(Call {
+                    arguments: vec![
+                        Expr::Literal(Literal {
+                            token: Token::new(TokenType::Identifier, "nginx"),
+                            parsed: "nginx".into(),
+                        }),
+                        Expr::Literal(Literal {
+                            token: Token::new(TokenType::Identifier, "t"),
+                            parsed: "-t".into(),
+                        }),
+                    ],
+                })),
+                kind: SubstitutionKind::Return,
+            }))),
+        })]
+    );
+}

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -335,3 +335,40 @@ fn with_lexer_substitution() {
         })]
     );
 }
+
+#[test]
+fn with_lexer_substitution_in_substitution() {
+    let tokens = lex("echo $( ls $(pwd) )");
+    let parsed = parse(tokens).expect("Failed to parse");
+    assert_eq!(
+        parsed,
+        vec![Expr::Call(Call {
+            arguments: vec![
+                Expr::Literal(Literal {
+                    token: Token::new(TokenType::Identifier, "echo"),
+                    parsed: "echo".into(),
+                }),
+                Expr::Substitution(Substitution {
+                    expr: Box::new(Expr::Call(Call {
+                        arguments: vec![
+                            Expr::Literal(Literal {
+                                token: Token::new(TokenType::Identifier, "ls"),
+                                parsed: "ls".into(),
+                            }),
+                            Expr::Substitution(Substitution {
+                                expr: Box::new(Expr::Call(Call {
+                                    arguments: vec![Expr::Literal(Literal {
+                                        token: Token::new(TokenType::Identifier, "pwd"),
+                                        parsed: "pwd".into(),
+                                    })],
+                                })),
+                                kind: SubstitutionKind::Capture,
+                            }),
+                        ],
+                    })),
+                    kind: SubstitutionKind::Capture,
+                }),
+            ],
+        })]
+    );
+}

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -254,7 +254,7 @@ fn with_lexer_substitution() {
 
 #[test]
 fn with_lexer_substitution_in_substitution() {
-    let tokens = lex("echo $( ls $(pwd) )");
+    let tokens = lex("echo $( ls \"$(pwd)/test\" )");
     let parsed = parse(tokens).expect("Failed to parse");
     assert_eq!(
         parsed,
@@ -265,12 +265,15 @@ fn with_lexer_substitution_in_substitution() {
                     expr: Box::new(Expr::Call(Call {
                         arguments: vec![
                             Expr::Literal("ls".into()),
-                            Expr::Substitution(Substitution {
-                                expr: Box::new(Expr::Call(Call {
-                                    arguments: vec![Expr::Literal("pwd".into())],
-                                })),
-                                kind: SubstitutionKind::Capture,
-                            }),
+                            Expr::TemplateString(vec![
+                                Expr::Substitution(Substitution {
+                                    expr: Box::new(Expr::Call(Call {
+                                        arguments: vec![Expr::Literal("pwd".into())],
+                                    })),
+                                    kind: SubstitutionKind::Capture,
+                                }),
+                                Expr::Literal("/test".into()),
+                            ]),
                         ],
                     })),
                     kind: SubstitutionKind::Capture,


### PR DESCRIPTION
This PR adds support for parsing command substitution.

A substitution is a way to start a new statement in the middle of another.

Command capture:
```kt
val current = $(pwd)
```

Command evaluation:
```kt
val shifted = @(shift)
```

Arithmetic evaluation would wait for #19.

Fix #16