### PR TITLE
Proposal to reduce names in /aspects folder, rename XParser traits to XAspect, and replace 'name' token fields with str

### DIFF
--- a/parser/src/aspects.rs
+++ b/parser/src/aspects.rs
@@ -1,8 +1,8 @@
-pub(super) mod binary_operation_parser;
-pub(super) mod call_parser;
-pub(super) mod group_parser;
-pub(super) mod literal_parser;
-pub(super) mod redirection_parser;
-pub(super) mod substitution_parser;
-pub(super) mod var_declaration_parser;
-pub(super) mod var_reference_parser;
+pub(super) mod binary_operation;
+pub(super) mod call;
+pub(super) mod group;
+pub(super) mod literal;
+pub(super) mod redirection;
+pub(super) mod substitution;
+pub(super) mod var_declaration;
+pub(super) mod var_reference;

--- a/parser/src/aspects/binary_operation.rs
+++ b/parser/src/aspects/binary_operation.rs
@@ -4,7 +4,7 @@ use crate::moves::{bin_op, eox, spaces, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 
 /// a parser aspect to parse any kind of binary operations
-pub trait BinaryOperationsParser<'p> {
+pub trait BinaryOperationsAspect<'p> {
     ///Parses a binary operation expression
     /// `eox`: a selector to define where the binary operation expression hits it end.
     fn binary_operation<P>(&mut self, parse_next: P) -> ParseResult<Expr<'p>>
@@ -19,7 +19,7 @@ pub trait BinaryOperationsParser<'p> {
         P: FnMut(&mut Self) -> ParseResult<Expr<'p>>;
 }
 
-impl<'p> BinaryOperationsParser<'p> for Parser<'p> {
+impl<'p> BinaryOperationsAspect<'p> for Parser<'p> {
     fn binary_operation<P>(&mut self, mut parse: P) -> ParseResult<Expr<'p>>
     where
         P: FnMut(&mut Self) -> ParseResult<Expr<'p>>,
@@ -154,7 +154,7 @@ mod tests {
 
     use lexer::lexer::lex;
 
-    use crate::aspects::binary_operation_parser::BinaryOperationsParser;
+    use crate::aspects::binary_operation::BinaryOperationsAspect;
     use crate::ast::callable::Call;
     use crate::ast::group::{Parenthesis, Subshell};
     use crate::ast::literal::Literal;

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -1,4 +1,4 @@
-use crate::aspects::redirection_parser::RedirectionParser;
+use crate::aspects::redirection::RedirectionAspect;
 use crate::ast::callable::Call;
 use crate::ast::Expr;
 use crate::moves::{eox, of_types, predicate, space, spaces, MoveOperations};
@@ -6,12 +6,12 @@ use crate::parser::{ParseResult, Parser};
 use lexer::token::TokenType::{And, Or};
 
 /// A parse aspect for command and function calls
-pub trait CallParser<'a> {
+pub trait CallAspect<'a> {
     /// Attempts to parse the next call expression
     fn call(&mut self) -> ParseResult<Expr<'a>>;
 }
 
-impl<'a> CallParser<'a> for Parser<'a> {
+impl<'a> CallAspect<'a> for Parser<'a> {
     fn call(&mut self) -> ParseResult<Expr<'a>> {
         let mut arguments = vec![self.next_value()?];
         // Continue reading arguments until we reach the end of the input or a closing ponctuation

--- a/parser/src/aspects/group.rs
+++ b/parser/src/aspects/group.rs
@@ -114,7 +114,6 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use lexer::lexer::lex;
-    use lexer::token::{Token, TokenType};
 
     use crate::aspects::group::GroupAspect;
     use crate::ast::callable::Call;
@@ -217,7 +216,7 @@ mod tests {
                     Expr::VarDeclaration(VarDeclaration {
                         kind: VarKind::Val,
                         var: TypedVariable {
-                            name: Token::new(TokenType::Identifier, "test"),
+                            name: "test",
                             ty: None,
                         },
                         initializer: Some(Box::from(Expr::Block(Block {
@@ -225,7 +224,7 @@ mod tests {
                                 Expr::VarDeclaration(VarDeclaration {
                                     kind: VarKind::Val,
                                     var: TypedVariable {
-                                        name: Token::new(TokenType::Identifier, "x"),
+                                        name: "x",
                                         ty: None,
                                     },
                                     initializer: Some(Box::from(Expr::Literal(Literal {
@@ -245,7 +244,7 @@ mod tests {
                             Expr::VarDeclaration(VarDeclaration {
                                 kind: VarKind::Val,
                                 var: TypedVariable {
-                                    name: Token::new(TokenType::Identifier, "x"),
+                                    name: "x",
                                     ty: None,
                                 },
                                 initializer: Some(Box::from(Expr::Literal(Literal {
@@ -288,8 +287,8 @@ mod tests {
                     Expr::VarDeclaration(VarDeclaration {
                         kind: VarKind::Var,
                         var: TypedVariable {
-                            name: Token::new(TokenType::Identifier, "test"),
-                            ty: Some(Token::new(TokenType::Identifier, "int")),
+                            name: "test",
+                            ty: Some("int"),
                         },
                         initializer: Some(Box::new(Expr::Literal(Literal {
                             lexme: "7.0",
@@ -299,7 +298,7 @@ mod tests {
                     Expr::VarDeclaration(VarDeclaration {
                         kind: VarKind::Val,
                         var: TypedVariable {
-                            name: Token::new(TokenType::Identifier, "x"),
+                            name: "x",
                             ty: None,
                         },
                         initializer: Some(Box::new(Expr::Literal(Literal {

--- a/parser/src/aspects/group.rs
+++ b/parser/src/aspects/group.rs
@@ -6,7 +6,7 @@ use crate::moves::{eox, of_type, repeat, repeat_n, spaces, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 
 ///A parser aspect for parsing block expressions
-pub trait GroupParser<'a> {
+pub trait GroupAspect<'a> {
     ///Parse a block expression.
     /// Block expressions will parse contained expressions as statements.
     /// see `Parser::statement` for further details.
@@ -24,7 +24,7 @@ pub trait GroupParser<'a> {
     fn parenthesis(&mut self) -> ParseResult<Parenthesis<'a>>;
 }
 
-impl<'a> GroupParser<'a> for Parser<'a> {
+impl<'a> GroupAspect<'a> for Parser<'a> {
     fn block(&mut self) -> ParseResult<Block<'a>> {
         self.ensure_at_group_start(TokenType::CurlyLeftBracket, '{')?;
         Ok(Block {
@@ -116,7 +116,7 @@ mod tests {
     use lexer::lexer::lex;
     use lexer::token::{Token, TokenType};
 
-    use crate::aspects::group_parser::GroupParser;
+    use crate::aspects::group::GroupAspect;
     use crate::ast::callable::Call;
     use crate::ast::group::{Block, Subshell};
     use crate::ast::literal::Literal;

--- a/parser/src/aspects/literal.rs
+++ b/parser/src/aspects/literal.rs
@@ -1,6 +1,6 @@
 use std::num::IntErrorKind;
 
-use crate::aspects::substitution_parser::SubstitutionParser;
+use crate::aspects::substitution::SubstitutionAspect;
 use lexer::token::TokenType;
 
 use crate::ast::literal::{Literal, LiteralValue};
@@ -10,7 +10,7 @@ use crate::parser::{ParseResult, Parser};
 use crate::source::try_join_str;
 
 /// A trait that contains all the methods for parsing literals.
-pub(crate) trait LiteralParser<'a> {
+pub(crate) trait LiteralAspect<'a> {
     /// Parses a number-like literal expression.
     fn literal(&mut self) -> ParseResult<Expr<'a>>;
 
@@ -31,7 +31,7 @@ pub(crate) trait LiteralParser<'a> {
     fn parse_literal(&mut self) -> ParseResult<LiteralValue>;
 }
 
-impl<'a> LiteralParser<'a> for Parser<'a> {
+impl<'a> LiteralAspect<'a> for Parser<'a> {
     fn literal(&mut self) -> ParseResult<Expr<'a>> {
         Ok(Expr::Literal(Literal {
             lexme: self.cursor.peek().value,

--- a/parser/src/aspects/redirection.rs
+++ b/parser/src/aspects/redirection.rs
@@ -1,4 +1,4 @@
-use crate::aspects::call_parser::CallParser;
+use crate::aspects::call::CallAspect;
 use crate::ast::callable::{Pipeline, Redir, RedirFd, RedirOp, Redirected};
 use crate::ast::Expr;
 use crate::moves::{eox, next, of_type, of_types, space, spaces, MoveOperations};
@@ -6,7 +6,7 @@ use crate::parser::{ParseResult, Parser};
 use lexer::token::TokenType;
 use lexer::token::TokenType::{BackSlash, DoubleQuote, Quote};
 
-pub(crate) trait RedirectionParser<'a> {
+pub(crate) trait RedirectionAspect<'a> {
     /// Attempts to parse the next pipeline expression
     /// inputs an "end of call" statements to determine where the call can stop.
     fn pipeline(&mut self, first_call: Expr<'a>) -> ParseResult<Expr<'a>>;
@@ -19,7 +19,7 @@ pub(crate) trait RedirectionParser<'a> {
     fn is_at_redirection_sign(&self) -> bool;
 }
 
-impl<'a> RedirectionParser<'a> for Parser<'a> {
+impl<'a> RedirectionAspect<'a> for Parser<'a> {
     fn pipeline(&mut self, first_call: Expr<'a>) -> ParseResult<Expr<'a>> {
         let mut commands = vec![first_call];
         // Continue as long as we have a pipe
@@ -157,7 +157,7 @@ impl<'a> RedirectionParser<'a> for Parser<'a> {
 mod test {
     use pretty_assertions::assert_eq;
 
-    use crate::aspects::call_parser::CallParser;
+    use crate::aspects::call::CallAspect;
     use crate::ast::callable::{Call, Redir, RedirFd, RedirOp, Redirected};
     use crate::ast::group::Block;
     use crate::ast::literal::Literal;

--- a/parser/src/aspects/substitution.rs
+++ b/parser/src/aspects/substitution.rs
@@ -1,5 +1,5 @@
-use crate::aspects::group_parser::GroupParser;
-use crate::aspects::var_reference_parser::VarReferenceParser;
+use crate::aspects::group::GroupAspect;
+use crate::aspects::var_reference::VarReferenceAspect;
 use crate::ast::substitution::{Substitution, SubstitutionKind};
 use crate::ast::Expr;
 use crate::moves::{of_type, of_types};
@@ -7,12 +7,12 @@ use crate::parser::{ParseResult, Parser};
 use lexer::token::TokenType;
 
 /// A parser for substitution expressions.
-pub(crate) trait SubstitutionParser<'a> {
+pub(crate) trait SubstitutionAspect<'a> {
     /// Parses a substitution expression, i.e. a variable reference or a command capture.
     fn substitution(&mut self) -> ParseResult<Expr<'a>>;
 }
 
-impl<'a> SubstitutionParser<'a> for Parser<'a> {
+impl<'a> SubstitutionAspect<'a> for Parser<'a> {
     fn substitution(&mut self) -> ParseResult<Expr<'a>> {
         let start_token = self.cursor.force(
             of_types(&[TokenType::At, TokenType::Dollar]),
@@ -46,7 +46,7 @@ impl<'a> SubstitutionParser<'a> for Parser<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::aspects::substitution_parser::SubstitutionParser;
+    use crate::aspects::substitution::SubstitutionAspect;
     use crate::ast::callable::Call;
     use crate::ast::substitution::{Substitution, SubstitutionKind};
     use crate::ast::Expr;

--- a/parser/src/aspects/var_declaration.rs
+++ b/parser/src/aspects/var_declaration.rs
@@ -6,12 +6,12 @@ use crate::ast::Expr;
 use crate::moves::{of_type, of_types, space, spaces, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 
-pub trait VarDeclarationParser<'a> {
+pub trait VarDeclarationAspect<'a> {
     /// Parses a variable declaration.
     fn var_declaration(&mut self) -> ParseResult<Expr<'a>>;
 }
 
-impl<'a> VarDeclarationParser<'a> for Parser<'a> {
+impl<'a> VarDeclarationAspect<'a> for Parser<'a> {
     /// Parses a variable declaration.
     fn var_declaration(&mut self) -> ParseResult<Expr<'a>> {
         let kind = match self.cursor.next()?.token_type {

--- a/parser/src/aspects/var_declaration.rs
+++ b/parser/src/aspects/var_declaration.rs
@@ -22,7 +22,7 @@ impl<'a> VarDeclarationAspect<'a> for Parser<'a> {
         let name = self.cursor.force(
             space().and_then(of_type(TokenType::Identifier)),
             "Expected variable name.",
-        )?;
+        )?.value;
 
         let ty = match self
             .cursor
@@ -32,7 +32,7 @@ impl<'a> VarDeclarationAspect<'a> for Parser<'a> {
             Some(_) => Some(self.cursor.force(
                 spaces().then(of_type(TokenType::Identifier)),
                 "Expected identifier for variable type",
-            )?),
+            )?.value),
         };
         let initializer = match self
             .cursor
@@ -68,8 +68,6 @@ mod tests {
     use crate::ast::Expr;
     use crate::parser::{ParseError, Parser};
     use lexer::lexer::lex;
-    use lexer::token::Token;
-    use lexer::token::TokenType::Identifier;
     use pretty_assertions::assert_eq;
 
     #[test]
@@ -83,7 +81,7 @@ mod tests {
             Expr::VarDeclaration(VarDeclaration {
                 kind: VarKind::Val,
                 var: TypedVariable {
-                    name: Token::new(TokenType::Identifier, "variable"),
+                    name: "variable",
                     ty: None
                 },
                 initializer: None,
@@ -102,8 +100,8 @@ mod tests {
             Expr::VarDeclaration(VarDeclaration {
                 kind: VarKind::Val,
                 var: TypedVariable {
-                    name: Token::new(TokenType::Identifier, "variable"),
-                    ty: Some(Token::new(TokenType::Identifier, "Array")),
+                    name: "variable",
+                    ty: Some("Array"),
                 },
                 initializer: None,
             })
@@ -129,7 +127,7 @@ mod tests {
             Expr::VarDeclaration(VarDeclaration {
                 kind: VarKind::Val,
                 var: TypedVariable {
-                    name: Token::new(TokenType::Identifier, "variable"),
+                    name: "variable",
                     ty: None,
                 },
                 initializer: Some(Box::from(Expr::Literal(Literal {
@@ -161,7 +159,7 @@ mod tests {
             Expr::VarDeclaration(VarDeclaration {
                 kind: VarKind::Val,
                 var: TypedVariable {
-                    name: Token::new(Identifier, "x"),
+                    name: "x",
                     ty: None,
                 },
                 initializer: Some(Box::new(Expr::Block(Block {
@@ -193,7 +191,7 @@ mod tests {
             Expr::VarDeclaration(VarDeclaration {
                 kind: VarKind::Val,
                 var: TypedVariable {
-                    name: Token::new(TokenType::Identifier, "variable"),
+                    name: "variable",
                     ty: None,
                 },
                 initializer: Some(Box::from(Expr::Binary(BinaryOperation {

--- a/parser/src/aspects/var_reference.rs
+++ b/parser/src/aspects/var_reference.rs
@@ -19,21 +19,20 @@ impl<'a> VarReferenceAspect<'a> for Parser<'a> {
             .is_some();
         let name = self
             .cursor
-            .force(of_type(TokenType::Identifier), "Expected variable name.")?;
+            .force(of_type(TokenType::Identifier), "Expected variable name.")?.value;
         if has_bracket {
             self.cursor.force(
                 of_type(TokenType::CurlyRightBracket),
                 "Expected closing curly bracket.",
             )?;
         }
-        Ok(Expr::VarReference(VarReference { name: name.clone() }))
+        Ok(Expr::VarReference(VarReference { name }))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use lexer::lexer::lex;
-    use lexer::token::{Token, TokenType};
 
     use crate::aspects::substitution::SubstitutionAspect;
     use crate::ast::variable::VarReference;
@@ -48,7 +47,7 @@ mod tests {
         assert_eq!(
             ast,
             Expr::VarReference(VarReference {
-                name: Token::new(TokenType::Identifier, "VARIABLE")
+                name: "VARIABLE"
             })
         )
     }
@@ -60,7 +59,7 @@ mod tests {
         assert_eq!(
             ast,
             Expr::VarReference(VarReference {
-                name: Token::new(TokenType::Identifier, "VAR")
+                name: "VAR"
             })
         )
     }

--- a/parser/src/aspects/var_reference.rs
+++ b/parser/src/aspects/var_reference.rs
@@ -5,12 +5,12 @@ use crate::ast::Expr;
 use crate::moves::of_type;
 use crate::parser::{ParseResult, Parser};
 
-pub trait VarReferenceParser<'a> {
+pub trait VarReferenceAspect<'a> {
     /// Parses a variable reference.
     fn var_reference(&mut self) -> ParseResult<Expr<'a>>;
 }
 
-impl<'a> VarReferenceParser<'a> for Parser<'a> {
+impl<'a> VarReferenceAspect<'a> for Parser<'a> {
     /// Parses a variable reference.
     fn var_reference(&mut self) -> ParseResult<Expr<'a>> {
         let has_bracket = self
@@ -35,7 +35,7 @@ mod tests {
     use lexer::lexer::lex;
     use lexer::token::{Token, TokenType};
 
-    use crate::aspects::substitution_parser::SubstitutionParser;
+    use crate::aspects::substitution::SubstitutionAspect;
     use crate::ast::variable::VarReference;
     use crate::ast::Expr;
     use crate::parser::Parser;

--- a/parser/src/ast/variable.rs
+++ b/parser/src/ast/variable.rs
@@ -1,13 +1,12 @@
 use crate::ast::Expr;
-use lexer::token::Token;
 
 /// A typed variable.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TypedVariable<'a> {
     /// The name of the variable.
-    pub name: Token<'a>,
+    pub name: &'a str,
     /// The type of the variable.
-    pub ty: Option<Token<'a>>,
+    pub ty: Option<&'a str>,
 }
 
 /// A variable declaration.
@@ -31,14 +30,14 @@ pub enum VarKind {
 #[derive(Debug, Clone, PartialEq)]
 pub struct VarReference<'a> {
     /// The name of the variable.
-    pub name: Token<'a>,
+    pub name: &'a str,
 }
 
 /// A variable assignation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Assign<'a> {
     /// The identifier of the variable.
-    pub name: Token<'a>,
+    pub name: &'a str,
     /// The value of the variable to be evaluated.
     pub value: Box<Expr<'a>>,
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,12 +1,12 @@
 use lexer::token::Token;
 use lexer::token::TokenType::*;
 
-use crate::aspects::binary_operation_parser::BinaryOperationsParser;
-use crate::aspects::call_parser::CallParser;
-use crate::aspects::group_parser::GroupParser;
-use crate::aspects::literal_parser::LiteralParser;
-use crate::aspects::redirection_parser::RedirectionParser;
-use crate::aspects::var_declaration_parser::VarDeclarationParser;
+use crate::aspects::binary_operation::BinaryOperationsAspect;
+use crate::aspects::call::CallAspect;
+use crate::aspects::group::GroupAspect;
+use crate::aspects::literal::LiteralAspect;
+use crate::aspects::redirection::RedirectionAspect;
+use crate::aspects::var_declaration::VarDeclarationAspect;
 use crate::ast::Expr;
 use crate::cursor::ParserCursor;
 use crate::moves::{bin_op, eod, eox, next, of_types, spaces, MoveOperations};

--- a/parser/tests/expr.rs
+++ b/parser/tests/expr.rs
@@ -22,8 +22,8 @@ fn variable_type_and_initializer() {
     let expected = vec![Expr::VarDeclaration(VarDeclaration {
         kind: VarKind::Var,
         var: TypedVariable {
-            name: Token::new(TokenType::Identifier, "a"),
-            ty: Some(Token::new(TokenType::Identifier, "int")),
+            name: "a",
+            ty: Some("int"),
         },
         initializer: Some(Box::new(Expr::Literal(Literal {
             lexme: "1",

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -1,5 +1,4 @@
 use lexer::lexer::lex;
-use lexer::token::{Token, TokenType};
 use parser::ast::callable::{Call, Pipeline, Redir, RedirFd, RedirOp, Redirected};
 use parser::ast::group::Subshell;
 use parser::ast::literal::Literal;
@@ -19,7 +18,7 @@ fn with_lexer_variable() {
         vec![Expr::VarDeclaration(VarDeclaration {
             kind: VarKind::Var,
             var: TypedVariable {
-                name: Token::new(TokenType::Identifier, "a"),
+                name: "a",
                 ty: None,
             },
             initializer: Some(Box::new(Expr::Literal(Literal {
@@ -45,7 +44,7 @@ fn with_lexer_var_reference_one() {
                     parsed: "$var5".into(),
                 }),
                 Expr::VarReference(VarReference {
-                    name: Token::new(TokenType::Identifier, "var5"),
+                    name: "var5",
                 }),
             ],
         })]
@@ -64,12 +63,12 @@ fn with_lexer_var_reference_two() {
                 Expr::TemplateString(vec![
                     Expr::Literal("fake".into()),
                     Expr::VarReference(VarReference {
-                        name: Token::new(TokenType::Identifier, "cmd"),
+                        name:"cmd",
                     }),
                 ]),
                 Expr::Literal("do".into()),
                 Expr::VarReference(VarReference {
-                    name: Token::new(TokenType::Identifier, "arg2"),
+                    name: "arg2",
                 }),
             ],
         })]
@@ -89,14 +88,14 @@ fn with_lexer_var_reference_three() {
                 Expr::TemplateString(vec![
                     Expr::Literal("hello ".into()),
                     Expr::VarReference(VarReference {
-                        name: Token::new(TokenType::Identifier, "world"),
+                        name:"world",
                     }),
                     Expr::Literal(" everyone ".into()),
                     Expr::VarReference(VarReference {
-                        name: Token::new(TokenType::Identifier, "verb"),
+                        name:"verb",
                     }),
                     Expr::VarReference(VarReference {
-                        name: Token::new(TokenType::Identifier, "ready"),
+                        name:  "ready",
                     }),
                     Expr::Literal("!".into()),
                 ]),
@@ -299,7 +298,7 @@ fn with_lexer_here_invoke() {
         vec![Expr::VarDeclaration(VarDeclaration {
             kind: VarKind::Val,
             var: TypedVariable {
-                name: Token::new(TokenType::Identifier, "valid"),
+                name: "valid",
                 ty: None,
             },
             initializer: Some(Box::new(Expr::Substitution(Substitution {


### PR DESCRIPTION
- The `_aspect` suffix is redundant for files as they already are in the `/aspects`.
- There was a little misleading naming convention for parser aspects, as they were named `<name>Parser` instead of `<name>Aspect`.
- Reduced `VarReference` and `TypedVariable` size by changing type of `name` fields by actual name str slice instead of a token, which also removes some useless checks for further steps