### PR TITLE
Support local parser errors

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,3 +11,4 @@ parser = { path = "../parser" }
 miette = { version = "5.5.0", features = ["fancy"] }
 thiserror = "1.0.38"
 dbg-pls = { version = "0.3.5", features = ["pretty", "colors"] }
+clap = { version = "4.2.2", features = ["derive"] }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -1,0 +1,11 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
+    /// Defines the source file to parse
+    #[arg(short, long, value_name = "FILE")]
+    pub(crate) source: Option<PathBuf>,
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -42,8 +42,6 @@ fn main() -> io::Result<()> {
             eprintln!("{msg}");
         }
         exit(1);
-    } else {
-        prompt(handler)?;
     }
-    Ok(())
+    prompt(handler)
 }

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -1,0 +1,59 @@
+use crate::report::{print_flush, FormattedError};
+use context::source::Source;
+use dbg_pls::color;
+use miette::GraphicalReportHandler;
+use parser::parse;
+use std::io;
+use std::io::BufRead;
+use std::io::Write;
+
+pub fn prompt(handler: GraphicalReportHandler) -> io::Result<()> {
+    let stdin = io::stdin();
+    let mut lines = stdin.lock().lines();
+
+    print_flush!("=> ");
+    let mut content = String::new();
+    while let Some(line) = lines.next() {
+        let line = line?;
+        content.push_str(&line);
+        if line.ends_with('\\') {
+            content.push('\n');
+            print_flush!(".. ");
+            continue;
+        }
+
+        let source = Source::new(&content, "stdin");
+        let report = parse(source.clone());
+        if !report.stack_ended {
+            content.push('\n');
+            print_flush!(".. ");
+            continue; // Silently ignore incomplete input
+        }
+
+        let errors = report
+            .errors
+            .into_iter()
+            .map(|err| FormattedError::from(err, &source))
+            .collect::<Vec<_>>();
+
+        if errors.is_empty() {
+            print_flush!("{}\n=> ", color(&report.expr));
+            content.clear();
+            continue;
+        }
+
+        let mut msg = String::new();
+        for err in &errors {
+            if let Err(fmt_err) = handler.render_report(&mut msg, err) {
+                eprintln!("{fmt_err}");
+            } else {
+                eprintln!("{msg}");
+            }
+            msg.clear();
+        }
+        content.clear();
+        print_flush!("=> ");
+    }
+
+    Ok(())
+}

--- a/cli/src/report.rs
+++ b/cli/src/report.rs
@@ -1,3 +1,9 @@
+use context::source::{Source, SourceSegment};
+use miette::{Diagnostic, SourceSpan};
+use parser::err::{ParseError, ParseErrorKind};
+use std::fmt::Display;
+use thiserror::Error;
+
 macro_rules! print_flush {
     ( $($t:tt)* ) => {
         {
@@ -9,3 +15,49 @@ macro_rules! print_flush {
 }
 
 pub(crate) use print_flush;
+
+#[derive(Error, Debug, Diagnostic)]
+pub struct FormattedError<'s> {
+    #[source_code]
+    src: &'s Source<'s>,
+    #[label("Here")]
+    cursor: SourceSpan,
+    #[label("Start")]
+    related: Option<SourceSpan>,
+    message: String,
+    #[help]
+    help: Option<String>,
+}
+
+impl Display for FormattedError<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+fn offset_empty_span(span: SourceSegment) -> SourceSpan {
+    if span.start == span.end {
+        (span.start - 1..span.end).into()
+    } else {
+        span.into()
+    }
+}
+
+impl<'a> FormattedError<'a> {
+    pub fn from(err: ParseError, source: &'a Source<'a>) -> Self {
+        Self {
+            src: source,
+            cursor: offset_empty_span(err.position),
+            related: match &err.kind {
+                ParseErrorKind::Unpaired(pos) => Some(pos.clone().into()),
+                _ => None,
+            },
+            message: err.message,
+            help: match &err.kind {
+                ParseErrorKind::Expected(expected) => Some(format!("Expected: {:?}", expected)),
+                ParseErrorKind::UnexpectedInContext(help) => Some(help.clone()),
+                _ => None,
+            },
+        }
+    }
+}

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -262,6 +262,12 @@ impl TokenType {
         matches!(self, Comma | DotDot | Arrow | FatArrow | Not)
     }
 
+    ///is this lexeme a opening punctuation
+    pub fn is_opening_ponctuation(self) -> bool {
+        matches!(self, |SquaredLeftBracket| RoundedLeftBracket
+            | CurlyLeftBracket)
+    }
+
     ///is this lexeme a closing punctuation
     pub fn is_closing_ponctuation(self) -> bool {
         matches!(self, |SquaredRightBracket| RoundedRightBracket

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -265,10 +265,20 @@ impl<'a> Parser<'a> {
                 segment.end = self.cursor.relative_pos(closing_parenthesis).end;
                 return Ok((args, segment));
             }
-            if self.cursor.lookahead(of_type(TokenType::Comma)).is_some() {
-                self.expected("Expected argument.", ParseErrorKind::Unexpected)?;
+            if let Some(comma) = self.cursor.advance(of_type(TokenType::Comma)) {
+                self.report_error(self.mk_parse_error(
+                    "Expected argument.",
+                    comma,
+                    ParseErrorKind::Unexpected,
+                ));
+                continue;
             }
-            args.push(self.value()?);
+            match self.value() {
+                Ok(arg) => args.push(arg),
+                Err(err) => {
+                    self.recover_from(err);
+                }
+            }
             self.cursor.advance(spaces());
 
             // Check if the arg list is abnormally terminated.

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -80,7 +80,7 @@ impl<'a> CallAspect<'a> for Parser<'a> {
             self.delimiter_stack.push_back(open_parenthesis.clone());
             let (arguments, segment) = self.parse_comma_separated_arguments(open_parenthesis)?;
 
-            let start = path.first().unwrap_or(&value).clone();
+            let start = *path.first().unwrap_or(&value);
             Ok(Expr::ProgrammaticCall(ProgrammaticCall {
                 path,
                 name: value,
@@ -126,7 +126,7 @@ impl<'a> CallAspect<'a> for Parser<'a> {
         )?;
         self.delimiter_stack.push_back(open_parenthesis.clone());
         let (arguments, segment) = self.parse_comma_separated_arguments(open_parenthesis)?;
-        let start = path.first().unwrap_or(&name.value).clone();
+        let start = *path.first().unwrap_or(&name.value);
         let segment = self.cursor.relative_pos(start).start..segment.end;
         Ok(Expr::ProgrammaticCall(ProgrammaticCall {
             path,

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -276,7 +276,7 @@ impl<'a> Parser<'a> {
             match self.value() {
                 Ok(arg) => args.push(arg),
                 Err(err) => {
-                    self.recover_from(err);
+                    self.recover_from(err, of_type(TokenType::Comma));
                 }
             }
             self.cursor.advance(spaces());

--- a/parser/src/aspects/expr_list.rs
+++ b/parser/src/aspects/expr_list.rs
@@ -4,7 +4,7 @@ use crate::moves::{blanks, eod, lookahead, of_type, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 use context::source::{SourceSegment, SourceSegmentHolder};
 use lexer::token::TokenType;
-use lexer::token::TokenType::Comma;
+use lexer::token::TokenType::{Comma, EndOfFile};
 
 ///An aspect to parse expression lists
 pub(super) trait ExpressionListAspect<'a> {
@@ -74,7 +74,12 @@ impl<'a> ExpressionListAspect<'a> for Parser<'a> {
         self.delimiter_stack.push_back(start.clone());
         let mut elements = vec![];
 
-        while self.cursor.lookahead(blanks().then(eod())).is_none() {
+        while self
+            .cursor
+            .lookahead(blanks().then(eod().or(of_type(EndOfFile))))
+            .is_none()
+        {
+            self.cursor.advance(blanks());
             while let Some(comma) = self.cursor.advance(of_type(Comma)) {
                 self.report_error(self.mk_parse_error(
                     "Expected value.",

--- a/parser/src/aspects/expr_list.rs
+++ b/parser/src/aspects/expr_list.rs
@@ -1,3 +1,4 @@
+use crate::err::ParseErrorKind;
 use crate::err::ParseErrorKind::Expected;
 use crate::moves::{blanks, eod, lookahead, of_type, MoveOperations};
 use crate::parser::{ParseResult, Parser};
@@ -74,6 +75,13 @@ impl<'a> ExpressionListAspect<'a> for Parser<'a> {
         let mut elements = vec![];
 
         while self.cursor.lookahead(blanks().then(eod())).is_none() {
+            while let Some(comma) = self.cursor.advance(of_type(Comma)) {
+                self.report_error(self.mk_parse_error(
+                    "Expected value.",
+                    comma,
+                    ParseErrorKind::Unexpected,
+                ));
+            }
             match parse_element(self) {
                 Err(err) => {
                     self.recover_from(err);

--- a/parser/src/aspects/expr_list.rs
+++ b/parser/src/aspects/expr_list.rs
@@ -74,13 +74,14 @@ impl<'a> ExpressionListAspect<'a> for Parser<'a> {
         let mut elements = vec![];
 
         while self.cursor.lookahead(blanks().then(eod())).is_none() {
-            elements.push(match parse_element(self) {
+            match parse_element(self) {
                 Err(err) => {
-                    self.delimiter_stack.pop_back();
-                    return Err(err);
+                    self.recover_from(err);
                 }
-                Ok(val) => val,
-            });
+                Ok(val) => {
+                    elements.push(val);
+                }
+            };
             self.cursor.force_with(
                 blanks().then(of_type(Comma).or(lookahead(eod()))),
                 "A comma or a closing bracket was expected here",

--- a/parser/src/aspects/expr_list.rs
+++ b/parser/src/aspects/expr_list.rs
@@ -84,7 +84,7 @@ impl<'a> ExpressionListAspect<'a> for Parser<'a> {
             }
             match parse_element(self) {
                 Err(err) => {
-                    self.recover_from(err);
+                    self.recover_from(err, of_type(Comma));
                 }
                 Ok(val) => {
                     elements.push(val);

--- a/parser/src/aspects/function_declaration.rs
+++ b/parser/src/aspects/function_declaration.rs
@@ -134,7 +134,7 @@ impl<'a> Parser<'a> {
             match param {
                 Ok(param) => params.push(param),
                 Err(err) => {
-                    self.recover_from(err);
+                    self.recover_from(err, of_type(Comma));
                 }
             }
             if let Err(err) = self.cursor.force(

--- a/parser/src/aspects/group.rs
+++ b/parser/src/aspects/group.rs
@@ -113,7 +113,7 @@ impl<'a> Parser<'a> {
                     statements.push(statement);
                 }
                 Err(err) => {
-                    self.recover_from(err);
+                    self.recover_from(err, eox());
                 }
             }
 

--- a/parser/src/aspects/group.rs
+++ b/parser/src/aspects/group.rs
@@ -107,8 +107,15 @@ impl<'a> Parser<'a> {
                     ParseErrorKind::Unpaired(self.cursor.relative_pos(&start_token)),
                 )?;
             }
-            let statement = parser(self)?;
-            statements.push(statement);
+            let statement = parser(self);
+            match statement {
+                Ok(statement) => {
+                    statements.push(statement);
+                }
+                Err(err) => {
+                    self.recover_from(err);
+                }
+            }
 
             //expects at least one newline or ';'
             let eox_res = self.cursor.force(

--- a/parser/src/aspects/literal.rs
+++ b/parser/src/aspects/literal.rs
@@ -61,14 +61,14 @@ impl<'a> LiteralAspect<'a> for Parser<'a> {
             DoubleQuote => self.templated_string_literal().map(Expr::TemplateString),
 
             _ if pivot.is_keyword() => self.expected(
-                &format!("Unexpected keyword '{}'", token.value),
+                format!("Unexpected keyword '{}'", token.value),
                 ParseErrorKind::Unexpected,
             ),
             _ if pivot.is_ponctuation()
                 || (leniency == LiteralLeniency::Strict && pivot.is_extended_ponctuation()) =>
             {
                 self.expected(
-                    &format!("Unexpected token '{}'.", token.value),
+                    format!("Unexpected token '{}'.", token.value),
                     ParseErrorKind::Unexpected,
                 )
             }

--- a/parser/src/aspects/match.rs
+++ b/parser/src/aspects/match.rs
@@ -62,7 +62,11 @@ impl<'a> Parser<'a> {
 
         let mut arms: Vec<MatchArm<'a>> = Vec::new();
 
-        while self.cursor.lookahead(blanks().then(eod())).is_none() {
+        while self
+            .cursor
+            .lookahead(blanks().then(eox().or(eod())))
+            .is_none()
+        {
             match self.parse_match_arm(parse_arm.clone()) {
                 Ok(arm) => arms.push(arm),
                 Err(err) => {

--- a/parser/src/aspects/match.rs
+++ b/parser/src/aspects/match.rs
@@ -180,7 +180,7 @@ impl<'a> Parser<'a> {
         if !is_at_pattern_end!() {
             let token = self.cursor.lookahead(blanks().then(any())).unwrap().value;
             return self.expected(
-                &format!("unexpected token, expected '|', 'if' or '=>', found '{token}'"),
+                format!("unexpected token, expected '|', 'if' or '=>', found '{token}'"),
                 ParseErrorKind::Unexpected,
             );
         }

--- a/parser/src/aspects/match.rs
+++ b/parser/src/aspects/match.rs
@@ -63,8 +63,12 @@ impl<'a> Parser<'a> {
         let mut arms: Vec<MatchArm<'a>> = Vec::new();
 
         while self.cursor.lookahead(blanks().then(eod())).is_none() {
-            let arm = self.parse_match_arm(parse_arm.clone())?;
-            arms.push(arm);
+            match self.parse_match_arm(parse_arm.clone()) {
+                Ok(arm) => arms.push(arm),
+                Err(err) => {
+                    self.recover_from(err);
+                }
+            }
         }
         let closing_bracket = self.cursor.force_with(
             blanks().then(of_type(CurlyRightBracket)),

--- a/parser/src/aspects/match.rs
+++ b/parser/src/aspects/match.rs
@@ -70,7 +70,7 @@ impl<'a> Parser<'a> {
             match self.parse_match_arm(parse_arm.clone()) {
                 Ok(arm) => arms.push(arm),
                 Err(err) => {
-                    self.recover_from(err);
+                    self.recover_from(err, eox());
                 }
             }
         }

--- a/parser/src/aspects/modules.rs
+++ b/parser/src/aspects/modules.rs
@@ -33,7 +33,7 @@ impl<'a> ModulesAspect<'a> for Parser<'a> {
 
         self.cursor.advance(spaces()); //consume spaces
 
-        if self.cursor.advance(eox()).is_none() {
+        if self.cursor.lookahead(eox()).is_none() {
             return self.expected(
                 "expected new line or semicolon",
                 ParseErrorKind::Expected("<new_line> or ';'".to_string()),
@@ -220,15 +220,15 @@ impl<'a> Parser<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::aspects::modules::ModulesAspect;
     use crate::err::{ParseError, ParseErrorKind};
     use crate::parse;
-    use crate::parser::{ParseResult, Parser};
+    use crate::parser::ParseResult;
     use ast::r#use::{Import, ImportList, ImportedSymbol, Use};
     use ast::Expr;
     use context::source::{Source, SourceSegmentHolder};
     use context::str_find::find_in;
     use pretty_assertions::assert_eq;
+    use std::vec;
 
     #[test]
     fn simple_use() {
@@ -269,77 +269,69 @@ mod tests {
     #[test]
     fn wrong_env_name() {
         let source = Source::unknown("use @9");
-        let result = Parser::new(source.clone())
-            .parse_use()
-            .expect_err("no error thrown");
+        let result: ParseResult<_> = parse(source.clone()).into();
         assert_eq!(
             result,
-            ParseError {
+            Err(ParseError {
                 message: "Environment variable name expected.".to_string(),
                 kind: ParseErrorKind::Expected("<identifier>".to_string()),
                 position: source.source.len()..source.source.len(),
-            }
+            })
         )
     }
 
     #[test]
     fn list_use_aliased() {
         let source = Source::unknown("use std::foo::{bar} as X");
-        let result = Parser::new(source.clone())
-            .parse_use()
-            .expect_err("no error thrown");
+        let result: ParseResult<_> = parse(source.clone()).into();
         assert_eq!(
             result,
-            ParseError {
+            Err(ParseError {
                 message: "expected new line or semicolon".to_string(),
                 kind: ParseErrorKind::Expected("<new_line> or ';'".to_string()),
                 position: source.source.find("as").map(|i| i..i + 2).unwrap(),
-            }
+            })
         )
     }
 
     #[test]
     fn use_empty_list() {
         let source = Source::unknown("use {}");
-        let result = Parser::new(source.clone())
-            .parse_use()
-            .expect_err("no error raised");
+        let result: ParseResult<_> = parse(source.clone()).into();
         assert_eq!(
             result,
-            ParseError {
+            Err(ParseError {
                 message: "empty brackets".to_string(),
                 kind: ParseErrorKind::Expected("non-empty brackets".to_string()),
                 position: source.source.find("{}").map(|i| i..i + 2).unwrap(),
-            }
+            })
         )
     }
 
     #[test]
     fn use_all() {
         let source = Source::unknown("use *");
-        let result = Parser::new(source.clone())
-            .parse_use()
-            .expect_err("no error raised");
+        let result: ParseResult<_> = parse(source.clone()).into();
         assert_eq!(
             result,
-            ParseError {
+            Err(ParseError {
                 message: "import all statement needs a symbol prefix.".to_string(),
                 kind: ParseErrorKind::Expected("module or file path".to_string()),
                 position: source.source.find("*").map(|i| i..i + 1).unwrap(),
-            }
+            })
         )
     }
 
     #[test]
     fn use_all_in() {
         let source = Source::unknown("use std::*");
-        let result = Parser::new(source.clone()).parse_use().expect("parse fail");
+        let result = parse(source.clone()).expect("parser failed");
         assert_eq!(
             result,
-            Expr::Use(Use {
+            vec![Expr::Use(Use {
                 import: Import::AllIn(vec!["std"], find_in(source.source, "std::*"),),
                 segment: source.segment(),
-            })
+            })]
         )
     }
 

--- a/parser/src/aspects/modules.rs
+++ b/parser/src/aspects/modules.rs
@@ -156,7 +156,7 @@ impl<'a> Parser<'a> {
         tokens.pop(); //remove trailing '::' token
 
         if let Some((head, tail)) = tokens.split_first() {
-            let first_path_element = tail.into_iter().fold(head.value, |acc, t| {
+            let first_path_element = tail.iter().fold(head.value, |acc, t| {
                 try_join_str(self.source.source, acc, t.value).expect("collect should be adjacent")
             });
 

--- a/parser/src/aspects/type.rs
+++ b/parser/src/aspects/type.rs
@@ -1,7 +1,7 @@
 use crate::aspects::expr_list::ExpressionListAspect;
 use crate::aspects::modules::ModulesAspect;
 use crate::err::ParseErrorKind::{Expected, Unexpected};
-use crate::moves::{any, blanks, not, of_type, spaces, MoveOperations};
+use crate::moves::{blanks, not, of_type, spaces, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 
 use context::source::{SourceSegment, SourceSegmentHolder};
@@ -188,11 +188,13 @@ impl<'a> Parser<'a> {
         self.cursor.advance(spaces());
         let start = self.cursor.peek();
         let path = self.parse_inclusion_path()?;
-        let name_token = self.cursor.advance(spaces().then(any())).unwrap();
+        self.cursor.advance(spaces());
+        let name_token = self.cursor.peek();
         let mut segment = self.cursor.relative_pos_ctx(start..name_token.clone());
 
         return match name_token.token_type {
             Identifier => {
+                self.cursor.next_opt();
                 let (params, params_segment) = self.parse_type_parameter_list()?;
                 if !params.is_empty() {
                     segment.end = params_segment.end;

--- a/parser/src/aspects/type.rs
+++ b/parser/src/aspects/type.rs
@@ -220,7 +220,7 @@ impl<'a> Parser<'a> {
             ),
 
             _ => self.expected_with(
-                &format!("'{}' is not a valid type identifier.", name_token.value),
+                format!("'{}' is not a valid type identifier.", name_token.value),
                 name_token.value,
                 Unexpected,
             ),

--- a/parser/src/aspects/var_declaration.rs
+++ b/parser/src/aspects/var_declaration.rs
@@ -195,15 +195,15 @@ mod tests {
     fn val_declaration_more_expressions() {
         let content = "val x = (1 + 2\n3+ 1)";
         let source = Source::unknown(content);
-        let err = parse(source);
+        let result: ParseResult<_> = parse(source).into();
         assert_eq!(
-            err.errors,
-            vec![ParseError {
+            result,
+            Err(ParseError {
                 message: "parenthesis in value expression can only contain one expression"
                     .to_string(),
-                position: content.rfind('3').map(|p| (p..p + 1)).unwrap(),
+                position: content.find('\n').map(|p| (p..p + 1)).unwrap(),
                 kind: ParseErrorKind::Unexpected,
-            }]
+            })
         )
     }
 

--- a/parser/src/aspects/var_reference.rs
+++ b/parser/src/aspects/var_reference.rs
@@ -35,10 +35,15 @@ impl<'a> VarReferenceAspect<'a> for Parser<'a> {
             .leak();
 
         if tokens.is_empty() {
-            return self.expected(
+            let err = self.mk_parse_error(
                 "variable reference with empty name",
+                self.cursor.peek(),
                 ParseErrorKind::Unexpected,
             );
+            if bracket.is_some() {
+                self.repos_delimiter_due_to(&err);
+            }
+            return Err(err);
         }
 
         let first = tokens[0].value;

--- a/parser/src/moves.rs
+++ b/parser/src/moves.rs
@@ -140,8 +140,8 @@ pub(crate) fn none() -> PredicateMove<fn(Token) -> bool> {
 }
 
 ///repeats until it finds a token that's not a space
-pub(crate) fn spaces() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool) + Copy> {
-    of_type(Space)
+pub(crate) fn spaces() -> RepeatedMove<PredicateMove<impl Fn(Token) -> bool + Copy>> {
+    repeat_n(1, of_type(Space))
 }
 
 ///a move to consume any space or any newline

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -551,7 +551,7 @@ impl<'a> Parser<'a> {
     /// Goes to the next closing delimiter of the top delimiter on the stack.
     ///
     /// If the stack is empty, this does nothing.
-    fn repos_to_top_delimiter(&mut self) {
+    pub(crate) fn repos_to_top_delimiter(&mut self) {
         while !self.cursor.is_at_end() {
             if let Some(last) = self.delimiter_stack.back() {
                 if let Some(token) = self.cursor.advance(next()) {

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -35,6 +35,11 @@ fn repos_delimiter_stack() {
                     kind: ParseErrorKind::Unpaired(content.find('(').map(|p| p..p + 1).unwrap())
                 },
                 ParseError {
+                    message: "Mismatched closing delimiter.".to_string(),
+                    position: content.find(']').map(|p| p..p + 1).unwrap(),
+                    kind: ParseErrorKind::Unpaired(content.find('{').map(|p| p..p + 1).unwrap())
+                },
+                ParseError {
                     message: "invalid infix operator".to_string(),
                     position: content.rfind('!').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -71,6 +71,21 @@ fn repos_delimiter_stack() {
 }
 
 #[test]
+fn repos_delimiter_in_var_reference() {
+    let content = "echo $(var m = ${..}); echo b";
+    let source = Source::unknown(content);
+    let report = parse(source);
+    assert_eq!(
+        report.errors,
+        vec![ParseError {
+            message: "variable reference with empty name".to_string(),
+            position: find_in(content, "..",),
+            kind: ParseErrorKind::Unexpected
+        }]
+    )
+}
+
+#[test]
 fn what_is_an_import() {
     let content = "{
         use {a, b}

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -142,6 +142,37 @@ fn no_comma_or_two() {
 }
 
 #[test]
+fn multiple_errors_in_parameters() {
+    let content = "f(1 + , if true; $, (2 + 3)";
+    let source = Source::unknown(content);
+    let report = parse(source.clone());
+    assert_eq!(
+        report,
+        ParseReport {
+            expr: vec![],
+            errors: vec![
+                ParseError {
+                    message: "Unexpected token ','.".to_owned(),
+                    position: content.find(',').map(|p| p..p + 1).unwrap(),
+                    kind: ParseErrorKind::Unexpected
+                },
+                ParseError {
+                    message: "variable reference with empty name".to_owned(),
+                    position: content.find('$').map(|p| p + 1..p + 2).unwrap(),
+                    kind: ParseErrorKind::Unexpected
+                },
+                ParseError {
+                    message: "Expected closing parenthesis.".to_owned(),
+                    position: content.len()..content.len(),
+                    kind: ParseErrorKind::Unpaired(content.find('(').map(|p| p..p + 1).unwrap())
+                }
+            ],
+            stack_ended: false,
+        }
+    );
+}
+
+#[test]
 fn do_not_self_lock() {
     let content = "fun g[, ](, ) = {}";
     let source = Source::unknown(content);

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -143,7 +143,7 @@ fn no_comma_or_two() {
 
 #[test]
 fn do_not_self_lock() {
-    let content = "fun g(, ) = {}";
+    let content = "fun g[, ](, ) = {}";
     let source = Source::unknown(content);
     let report = parse(source.clone());
     assert_eq!(
@@ -160,11 +160,23 @@ fn do_not_self_lock() {
                 return_type: None,
                 segment: source.segment()
             })],
-            errors: vec![ParseError {
-                message: "Expected parameter.".to_owned(),
-                position: content.find(',').map(|p| p..p + 1).unwrap(),
-                kind: ParseErrorKind::Unexpected
-            }],
+            errors: vec![
+                ParseError {
+                    message: "Expected value.".to_owned(),
+                    position: content.find(',').map(|p| p..p + 1).unwrap(),
+                    kind: ParseErrorKind::Unexpected
+                },
+                ParseError {
+                    message: "expected types".to_owned(),
+                    position: content.find(']').map(|p| p..p + 1).unwrap(),
+                    kind: ParseErrorKind::Expected("<types>".to_owned())
+                },
+                ParseError {
+                    message: "Expected parameter.".to_owned(),
+                    position: content.rfind(',').map(|p| p..p + 1).unwrap(),
+                    kind: ParseErrorKind::Unexpected
+                }
+            ],
             stack_ended: true,
         }
     );

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -1,6 +1,6 @@
-use ast::call::Call;
+use ast::call::{Call, ProgrammaticCall};
 use ast::Expr;
-use context::source::Source;
+use context::source::{Source, SourceSegmentHolder};
 use parser::err::{ParseError, ParseErrorKind, ParseReport};
 use parser::parse;
 use parser::source::{literal, literal_nth};
@@ -149,13 +149,19 @@ fn expected_double_delimiter_for() {
 
 #[test]
 fn double_comma_parentheses() {
-    let content = "Bar(4 , ,)";
+    let content = "Bar(m , ,)";
     let source = Source::unknown(content);
-    let report = parse(source);
+    let report = parse(source.clone());
     assert_eq!(
         report,
         ParseReport {
-            expr: vec![],
+            expr: vec![Expr::ProgrammaticCall(ProgrammaticCall {
+                path: vec![],
+                name: "Bar",
+                arguments: vec![literal(content, "m")],
+                type_parameters: Vec::new(),
+                segment: source.segment(),
+            })],
             errors: vec![ParseError {
                 message: "Expected argument.".to_string(),
                 position: content.rfind(',').map(|p| p..p + 1).unwrap(),

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -87,19 +87,23 @@ fn what_is_an_import() {
     let report = parse(source.clone());
     assert_eq!(
         report.errors,
-        vec![ParseError {
-            message: "'break' is not a valid type identifier.".to_owned(),
-            position: content.find("break").map(|p| p..p + 5).unwrap(),
-            kind: ParseErrorKind::Unexpected
-        }, ParseError {
-            message: "invalid expression operator".to_owned(),
-            position: content.find('%').map(|p| p..p + 1).unwrap(),
-            kind: ParseErrorKind::Unexpected
-        }, ParseError {
-            message: "Expected value".to_owned(),
-            position: content.find(';').map(|p| p..p + 1).unwrap(),
-            kind: ParseErrorKind::Unexpected
-        }]
+        vec![
+            ParseError {
+                message: "'break' is not a valid type identifier.".to_owned(),
+                position: content.find("break").map(|p| p..p + 5).unwrap(),
+                kind: ParseErrorKind::Unexpected
+            },
+            ParseError {
+                message: "invalid expression operator".to_owned(),
+                position: content.find('%').map(|p| p..p + 1).unwrap(),
+                kind: ParseErrorKind::Unexpected
+            },
+            ParseError {
+                message: "Expected value".to_owned(),
+                position: content.find(';').map(|p| p..p + 1).unwrap(),
+                kind: ParseErrorKind::Unexpected
+            }
+        ]
     );
 }
 

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -150,6 +150,36 @@ fn invalid_binary_operator_cause_one_error() {
 }
 
 #[test]
+fn do_not_accumulate_delimiters() {
+    let content = "fun cube(x: List[/[\nStr, Str]]) = {}";
+    let source = Source::unknown(content);
+    let report = parse(source);
+    assert_eq!(
+        report.errors,
+        vec![ParseError {
+            message: "'/' is not a valid type identifier.".to_owned(),
+            position: content.find('/').map(|p| p..p + 1).unwrap(),
+            kind: ParseErrorKind::Unexpected
+        }]
+    );
+}
+
+#[test]
+fn do_not_accumulate_delimiters2() {
+    let content = "fun cube(x: List[)[\nStr, Str]]) = {}";
+    let source = Source::unknown(content);
+    let report = parse(source);
+    assert_eq!(
+        report.errors,
+        vec![ParseError {
+            message: "Mismatched closing delimiter.".to_owned(),
+            position: content.find(')').map(|p| p..p + 1).unwrap(),
+            kind: ParseErrorKind::Unpaired(content.find('[').map(|p| p..p + 1).unwrap())
+        }]
+    );
+}
+
+#[test]
 fn no_comma_or_two() {
     let content = "fun test[@](a b,,c) = '";
     let source = Source::unknown(content);

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -51,6 +51,32 @@ fn repos_delimiter_stack() {
 }
 
 #[test]
+fn tolerance_in_multiple_groups() {
+    let content = "fun f[T, $](x: T, y: $) = x + y";
+    let source = Source::unknown(content);
+    let report = parse(source.clone());
+    assert_eq!(
+        report,
+        ParseReport {
+            expr: vec![],
+            errors: vec![
+                ParseError {
+                    message: "'$' is not a valid type identifier.".to_owned(),
+                    position: content.find('$').map(|p| p..p + 1).unwrap(),
+                    kind: ParseErrorKind::Unexpected
+                },
+                ParseError {
+                    message: "'$' is not a valid type identifier.".to_owned(),
+                    position: content.rfind('$').map(|p| p..p + 1).unwrap(),
+                    kind: ParseErrorKind::Unexpected
+                }
+            ],
+            stack_ended: true,
+        }
+    );
+}
+
+#[test]
 fn expected_value_found_eof() {
     let content = "val i =\n";
     let source = Source::unknown(content);

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -71,6 +71,39 @@ fn repos_delimiter_stack() {
 }
 
 #[test]
+fn what_is_an_import() {
+    let content = "{
+        use {a, b}
+        loop {
+            val n =42 as
+            break
+        } %
+        var res = match 42 {
+            42 => 21
+        }
+        res = List(5..;, $a)
+    }";
+    let source = Source::unknown(content);
+    let report = parse(source.clone());
+    assert_eq!(
+        report.errors,
+        vec![ParseError {
+            message: "'break' is not a valid type identifier.".to_owned(),
+            position: content.find("break").map(|p| p..p + 5).unwrap(),
+            kind: ParseErrorKind::Unexpected
+        }, ParseError {
+            message: "invalid expression operator".to_owned(),
+            position: content.find('%').map(|p| p..p + 1).unwrap(),
+            kind: ParseErrorKind::Unexpected
+        }, ParseError {
+            message: "Expected value".to_owned(),
+            position: content.find(';').map(|p| p..p + 1).unwrap(),
+            kind: ParseErrorKind::Unexpected
+        }]
+    );
+}
+
+#[test]
 fn tolerance_in_multiple_groups() {
     let content = "fun f[T, $](x: T, y: +) = $x";
     let source = Source::unknown(content);

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -174,7 +174,7 @@ fn multiple_errors_in_parameters() {
 
 #[test]
 fn do_not_self_lock() {
-    let content = "fun g[, ](, ) = {}";
+    let content = "fun g[\n, ](, ) = {}";
     let source = Source::unknown(content);
     let report = parse(source.clone());
     assert_eq!(
@@ -209,6 +209,25 @@ fn do_not_self_lock() {
                 }
             ],
             stack_ended: true,
+        }
+    );
+}
+
+#[test]
+fn list_are_not_tricked_by_blanks() {
+    let content = "fun pow[\n";
+    let source = Source::unknown(content);
+    let report = parse(source.clone());
+    assert_eq!(
+        report,
+        ParseReport {
+            expr: vec![],
+            errors: vec![ParseError {
+                message: "Expected ']' delimiter.".to_owned(),
+                position: content.len()..content.len(),
+                kind: ParseErrorKind::Unpaired(content.find('[').map(|p| p..p + 1).unwrap())
+            }],
+            stack_ended: false,
         }
     );
 }

--- a/parser/tests/expr.rs
+++ b/parser/tests/expr.rs
@@ -666,6 +666,32 @@ fn method_call_with_type_params_and_ref() {
 }
 
 #[test]
+fn comments_mix_with_spaces() {
+    let source = Source::unknown(
+        "{
+    //
+    //
+    ping localhost
+}",
+    );
+    let parsed = parse(source.clone()).expect("Failed to parse");
+    assert_eq!(
+        parsed,
+        vec![Expr::Block(Block {
+            expressions: vec![Expr::Call(Call {
+                path: Vec::new(),
+                arguments: vec![
+                    literal(source.source, "ping"),
+                    literal(source.source, "localhost")
+                ],
+                type_parameters: Vec::new()
+            })],
+            segment: source.segment()
+        })]
+    );
+}
+
+#[test]
 fn classic_call_no_regression() {
     let source = Source::unknown("test '=>' ,,here, ->..3 54a2 => 1..=9");
     let parsed = parse(source.clone()).expect("Failed to parse");


### PR DESCRIPTION
Error messages are an important part of Moshell, so this PR goes further by allowing more than one error in a single expression. Some work has been done here to have a smart repositioning to ensure that an error causes the least false positives after. Fix #46 

Repositioning strategy
----------------------

Cursor repositioning depends on two factors :
- The error kind that occurs. If it is a mismatched delimiter error, always advances to the next valid closing delimiter. This is a punctuation error, so it is expected that it could easily go to the end of the file.
- The parser's context. There may sometimes have only one error per line, but if there are clearly defined delimiters like parenthesis or commas, there is no need to go that far.

Repositioning heavily depends on the group which is currently parsed, so it becomes important that those group always keep the delimiter stack in a valid state. In other words, a delimiter scope should always be bound to the appropriate method and should not leak to the caller if there is an error, for instance. It may sound a good use case for a *RAII* object, but that would require a mutable reference to the delimiter stack, which inherently goes against the borrow checker (two mutable references would be required at the same time).

To panic or not to panic
------------------------

Errors were so far returned as `Result<T, ParseError>`. Only one error could be present at a time. This mode can now be called the *panic mode*. When an error has been encountered and the parser don't know how to recover from it, move up the call stack. Some parsers, like list parsers, can handle errors by repositioning to the next `)` or `,` (simplified here). The error is reported - *pushed* - to the error vector shared by the whole parser. Then the parser can continue like nothing happened.

In summary, here are the error phases:

```mermaid
flowchart LR
    raised[Raised]
    panic["Panic mode:\nmove up the call stack"]
    catch[Catched:\nrepositioning and reporting]
    normal[Normal mode]
    raised --> panic
    panic --> catch
    catch --> normal
```

Command Line Interface upgrade
------------------------------

The CLI clearly became a useful tool to quickly test the parser. This PR also updates the CLI to allow parsing an entire file. The REPL style interface is still present and still the default, but adding the `-s` option, handled by the *Clap* crate, makes the CLI reads from a file instead of the standard input.

Existing errors fixed
---------------------

Allowing more than one error reveals some missed cases. Function declarations didn't add the `(` token to the delimiter stack. The group parser failed to parser `{ }` because of the space character. Parsing `use` statements would consume the end of expression character. Fix #89.
