### PR TITLE
Allow any expression in a pipeline

### DIFF
--- a/parser/src/aspects/redirection.rs
+++ b/parser/src/aspects/redirection.rs
@@ -1,4 +1,3 @@
-use crate::aspects::call::CallAspect;
 use crate::err::ParseErrorKind;
 use crate::moves::{eox, like, next, of_type, of_types, spaces, MoveOperations};
 use crate::parser::{ParseResult, Parser};
@@ -30,7 +29,7 @@ impl<'a> RedirectionAspect<'a> for Parser<'a> {
             .advance(spaces().then(of_type(TokenType::Bar)))
             .is_some()
         {
-            match self.call()? {
+            match self.statement()? {
                 Expr::Pipeline(pipeline) => commands.extend(pipeline.commands),
                 call => commands.push(call),
             }

--- a/parser/src/aspects/redirection.rs
+++ b/parser/src/aspects/redirection.rs
@@ -5,7 +5,6 @@ use ast::call::{Pipeline, Redir, RedirFd, RedirOp, Redirected};
 use ast::Expr;
 use context::source::SourceSegmentHolder;
 use lexer::token::TokenType;
-use lexer::token::TokenType::{BackSlash, DoubleQuote, Quote};
 
 pub(crate) trait RedirectionAspect<'a> {
     /// Attempts to parse the next pipeline expression
@@ -153,16 +152,7 @@ impl<'a> RedirectionAspect<'a> for Parser<'a> {
     }
 
     fn is_at_redirection_sign(&self) -> bool {
-        //handle escaped redirection signs (can be \\ for one-character signs or quoted signs)
-        if self
-            .cursor
-            .lookahead(of_types(&[BackSlash, Quote, DoubleQuote]))
-            .is_some()
-        {
-            return false;
-        }
-
-        let pivot = self.cursor.peek(); //repeat() always succeeds
+        let pivot = self.cursor.peek();
         match pivot.token_type {
             TokenType::Ampersand | TokenType::Less | TokenType::Greater | TokenType::Bar => true,
             //search for '>' or '<' in case of std-determined redirection sign (ex: 2>>)

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -51,7 +51,6 @@ macro_rules! non_infix {
                 RoundedLeftBracket,
                 CurlyLeftBracket,
                 SquaredLeftBracket,
-                Bar,
                 Comma,
                 FatArrow,
             ]))

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -385,3 +385,32 @@ fn pipe_expressions() {
         })]
     );
 }
+
+#[test]
+fn pipe_to_command() {
+    let source = Source::unknown("{ echo '1\n2' } | cat");
+    let parsed = parse(source).expect("Failed to parse");
+    assert_eq!(
+        parsed,
+        vec![Expr::Pipeline(Pipeline {
+            commands: vec![
+                Expr::Block(Block {
+                    expressions: vec![Expr::Call(Call {
+                        path: Vec::new(),
+                        arguments: vec![
+                            literal(source.source, "echo"),
+                            literal(source.source, "'1\n2'")
+                        ],
+                        type_parameters: Vec::new(),
+                    })],
+                    segment: find_in(source.source, "{ echo '1\n2' }"),
+                }),
+                Expr::Call(Call {
+                    path: Vec::new(),
+                    arguments: vec![literal(source.source, "cat")],
+                    type_parameters: Vec::new(),
+                }),
+            ],
+        })]
+    );
+}


### PR DESCRIPTION
Removes the bar character from the non-infix operator list, and use a more generic parser when looking for the next parts of a pipeline.

Fix #95 