### PR TITLE
Fix cursor usages around variable parsing

### DIFF
--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -185,7 +185,10 @@ impl TokenType {
 
     ///is this lexeme a valid reference name for a variable ?
     pub fn is_valid_var_ref_name(self) -> bool {
-        matches!(self, Identifier | Ampersand | At | Not | IntLiteral)
+        matches!(
+            self,
+            Identifier | Ampersand | At | Not | IntLiteral | Dollar
+        )
     }
 
     ///is this lexeme a binary operator ?

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -326,7 +326,7 @@ mod tests {
             Parser::new(source).parse_next(),
             Err(ParseError {
                 message: "expected end of expression or file".to_string(),
-                position: content.len()..content.len(),
+                position: content.find(')').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected,
             })
         );

--- a/parser/src/aspects/lambda_def.rs
+++ b/parser/src/aspects/lambda_def.rs
@@ -197,7 +197,7 @@ mod tests {
             parsed,
             ParseError {
                 message: "Expected name.".to_string(),
-                position: 1..3,
+                position: find_in(source.source, "=>"),
                 kind: Unexpected,
             }
         );

--- a/parser/src/aspects/substitution.rs
+++ b/parser/src/aspects/substitution.rs
@@ -156,7 +156,7 @@ mod tests {
             ast,
             Err(ParseError {
                 message: "expected end of expression or file".to_string(),
-                position: content.len()..content.len(),
+                position: content.find(')').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             })
         );

--- a/parser/src/aspects/var_declaration.rs
+++ b/parser/src/aspects/var_declaration.rs
@@ -142,12 +142,12 @@ mod tests {
 
     #[test]
     fn val_declaration_with_type_no_colon() {
-        let source = Source::unknown("{val variable Array}");
+        let source = Source::unknown("val variable Array");
         let res: ParseResult<_> = parse(source).into();
         assert_eq!(
             res,
             Err(ParseError {
-                message: "expected new line or semicolon".to_owned(),
+                message: "expected end of expression or file".to_owned(),
                 position: find_in(source.source, "Array"),
                 kind: ParseErrorKind::Unexpected
             })

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -454,6 +454,9 @@ impl<'a> Parser<'a> {
             return self.parse_binary_expr(expr);
         }
 
+        if self.cursor.lookahead(bin_op()).is_none() {
+            return Ok(expr);
+        }
         //else, we hit an invalid binary expression.
         self.expected("invalid expression operator", Unexpected)
     }

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -536,7 +536,7 @@ fn quotes_are_delimiters() {
             expr: vec![],
             errors: vec![ParseError {
                 message: "expected end of expression or file".to_owned(),
-                position: content.rfind('$').map(|p| p..p + 1).unwrap(),
+                position: content.find('"').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
             stack_ended: true,

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -78,7 +78,7 @@ fn repos_delimiter_in_var_reference() {
     assert_eq!(
         report.errors,
         vec![ParseError {
-            message: "variable reference with empty name".to_string(),
+            message: "Expected variable name.".to_string(),
             position: find_in(content, "..",),
             kind: ParseErrorKind::Unexpected
         }]
@@ -283,8 +283,8 @@ fn multiple_errors_in_parameters() {
                     kind: ParseErrorKind::Unexpected
                 },
                 ParseError {
-                    message: "variable reference with empty name".to_owned(),
-                    position: content.find('$').map(|p| p + 1..p + 2).unwrap(),
+                    message: "Expected variable name.".to_owned(),
+                    position: content.rfind(',').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected
                 },
                 ParseError {

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -467,3 +467,28 @@ fn inner_var_ref() {
         })]
     );
 }
+
+#[test]
+fn variable_without_initializer() {
+    let source = Source::unknown("var bar; $bar");
+    let parsed = parse(source).expect("Failed to parse");
+    assert_eq!(
+        parsed,
+        vec![
+            Expr::VarDeclaration(VarDeclaration {
+                kind: VarKind::Var,
+                var: TypedVariable {
+                    name: "bar",
+                    ty: None,
+                    segment: find_in(source.source, "bar"),
+                },
+                initializer: None,
+                segment: find_in(source.source, "var bar"),
+            }),
+            Expr::VarReference(VarReference {
+                name: "bar",
+                segment: find_in(source.source, "$bar"),
+            })
+        ]
+    );
+}

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -1,16 +1,16 @@
 use ast::call::{Call, Pipeline, Redir, RedirFd, RedirOp, Redirected};
 use ast::control_flow::While;
+use ast::function::Return;
 use ast::group::{Block, Subshell};
 use ast::substitution::{Substitution, SubstitutionKind};
 use ast::value::TemplateString;
-use ast::variable::{TypedVariable, VarDeclaration, VarKind, VarReference};
+use ast::variable::{Assign, TypedVariable, VarDeclaration, VarKind, VarReference};
 use ast::Expr;
 use context::source::{Source, SourceSegmentHolder};
 use context::str_find::{find_in, find_in_nth};
 use parser::parse;
 use parser::source::{literal, literal_nth};
 use pretty_assertions::assert_eq;
-use ast::function::Return;
 
 #[test]
 fn with_lexer_variable() {
@@ -434,6 +434,36 @@ fn empty_return() {
                 }),
             ],
             segment: source.segment(),
+        })]
+    );
+}
+#[test]
+fn inner_var_ref() {
+    let source = Source::unknown("dest = \"$DEST/shard_$SHARD_NUMBER/$L\"");
+    let parsed = parse(source).expect("Failed to parse");
+    assert_eq!(
+        parsed,
+        vec![Expr::Assign(Assign {
+            name: "dest",
+            value: Box::new(Expr::TemplateString(TemplateString {
+                parts: vec![
+                    Expr::VarReference(VarReference {
+                        name: "DEST",
+                        segment: find_in(source.source, "$DEST"),
+                    }),
+                    literal(source.source, "/shard_"),
+                    Expr::VarReference(VarReference {
+                        name: "SHARD_NUMBER",
+                        segment: find_in(source.source, "$SHARD_NUMBER"),
+                    }),
+                    literal_nth(source.source, "/", 1),
+                    Expr::VarReference(VarReference {
+                        name: "L",
+                        segment: find_in(source.source, "$L"),
+                    }),
+                ]
+            })),
+            segment: 0..source.len() - 1,
         })]
     );
 }


### PR DESCRIPTION
The original goal was to fix #98, by allowing only one token after the `$` sign in a variable reference. Updating this parser revealed that the square brackets were not properly popped from the delimiter stack if an error occurred.

#100 could originally use the parser directly, but it was encountered that variable declarations without an initializer would actually consume the *end of expression* token, disallowing any subsequent expressions.

Another found corner case is that `val variable cast Array` indicates the error on the whitespace between `cast` and `Array`, while `{ val variable cast Array }` indicates the error on `cast`. The root cause is that the "expected end of expression" message is handled differently in a block. More specifically, the group parser does not use a `force()` move to generate the error. This move historically generated the error on the current position offset by one. This is actually invalid in most cases, but the offset was present to workaround composed moves (like `spaces().then(...)`). To fix that, a move returns a `Result<usize, usize>` where the error case contains where the move has actually ended.

In order to appear on the master branch, the `if` block must be added to the `parser.rs` file:

```diff
         // parser.rs
+        if self.cursor.lookahead(bin_op()).is_none() {
+            return Ok(expr);
+        }
         //else, we hit an invalid binary expression.
         self.expected("invalid expression operator", Unexpected)
```
Or use 65fd9eaf8b36b02ab1594a39049f4bc68baa3bb8