### PR TITLE
Redefine end of expressions

### DIFF
--- a/lexer/src/lexer.rs
+++ b/lexer/src/lexer.rs
@@ -70,8 +70,7 @@ impl<'a> Lexer<'a> {
             }
             '/' if !self.is_in_string() => {
                 if self.matches_next('/', &mut size) {
-                    self.skip_line();
-                    return self.next_token();
+                    return self.skip_line();
                 } else if self.matches_next('*', &mut size) {
                     self.skip_multiline_comment();
                     return self.next_token();
@@ -221,12 +220,13 @@ impl<'a> Lexer<'a> {
     }
 
     /// Skip the remaining characters of the current line.
-    fn skip_line(&mut self) {
-        for (_, c) in self.iter.by_ref() {
+    fn skip_line(&mut self) -> Token<'a> {
+        for (pos, c) in self.iter.by_ref() {
             if c == '\n' {
-                break;
+                return Token::new(TokenType::NewLine, &self.input[pos..pos + 1]);
             }
         }
+        Token::new(TokenType::EndOfFile, "")
     }
 
     /// Skip the remaining characters of the current multiline comment.

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -248,6 +248,8 @@ impl TokenType {
                 | Bar
                 | Or
                 | And
+                | Quote
+                | DoubleQuote
                 | SquaredLeftBracket
                 | SquaredRightBracket
                 | RoundedLeftBracket
@@ -280,6 +282,27 @@ impl TokenType {
             | CurlyRightBracket
             | Quote
             | DoubleQuote)
+    }
+
+    /// Tests if this token ends an expression, where newlines are not allowed.
+    pub fn ends_expression(self) -> bool {
+        matches!(
+            self,
+            SemiColon
+                | NewLine
+                | EndOfFile
+                | SquaredRightBracket
+                | RoundedRightBracket
+                | CurlyRightBracket
+        )
+    }
+
+    /// Tests if this token ends a group, where newlines are allowed.
+    pub fn ends_group(self) -> bool {
+        matches!(
+            self,
+            EndOfFile | SquaredRightBracket | RoundedRightBracket | CurlyRightBracket
+        )
     }
 
     pub fn closing_pair(self) -> Option<TokenType> {

--- a/lexer/tests/sample.rs
+++ b/lexer/tests/sample.rs
@@ -22,6 +22,7 @@ fn string_literal() {
             Token::new(TokenType::Identifier, "/true"),
             Token::new(TokenType::Quote, "'"),
             Token::new(TokenType::Space, " "),
+            Token::new(TokenType::NewLine, "\n"),
             Token::new(TokenType::Identifier, "yes"),
         ]
     );

--- a/parser/src/aspects/binary_operation.rs
+++ b/parser/src/aspects/binary_operation.rs
@@ -1,4 +1,4 @@
-use crate::moves::{bin_op, eox, spaces, MoveOperations};
+use crate::moves::{bin_op, line_end, spaces, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 use ast::operation::{BinaryOperation, BinaryOperator};
 use ast::Expr;
@@ -52,7 +52,7 @@ impl<'p> Parser<'p> {
         let mut operation = self.binary_operation_internal(left, parse)?;
         macro_rules! has_content {
             () => {
-                self.cursor.lookahead(spaces().then(eox())).is_none()
+                self.cursor.lookahead(spaces().then(line_end())).is_none()
             };
         }
 

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -7,8 +7,8 @@ use crate::aspects::r#type::TypeAspect;
 use crate::aspects::redirection::RedirectionAspect;
 use crate::err::ParseErrorKind;
 use crate::moves::{
-    blanks, eod, eox, identifier_parenthesis, like, lookahead, of_type, of_types, repeat, spaces,
-    MoveOperations,
+    blanks, eog, identifier_parenthesis, like, line_end, lookahead, of_type, of_types, repeat,
+    spaces, MoveOperations,
 };
 use crate::parser::{ParseResult, Parser};
 use ast::call::{Call, MethodCall, ProgrammaticCall};
@@ -195,7 +195,7 @@ impl<'a> CallAspect<'a> for Parser<'a> {
         while !self.cursor.is_at_end()
             && self
                 .cursor
-                .lookahead(spaces().then(eox().or(like(TokenType::is_call_bound))))
+                .lookahead(spaces().then(line_end().or(like(TokenType::is_call_bound))))
                 .is_none()
         {
             arguments.push(self.call_argument()?);
@@ -282,19 +282,19 @@ impl<'a> Parser<'a> {
             self.cursor.advance(spaces());
 
             // Check if the arg list is abnormally terminated.
-            if self.cursor.lookahead(eox()).is_some() {
+            if self.cursor.lookahead(line_end()).is_some() {
                 self.expected(
                     "Expected closing parenthesis.",
                     ParseErrorKind::Unpaired(self.cursor.relative_pos(open_parenthesis.clone())),
                 )?;
             }
-            if self.cursor.lookahead(eod()).is_some() {
+            if self.cursor.lookahead(eog()).is_some() {
                 let closing_parenthesis = self.expect_delimiter(TokenType::RoundedRightBracket)?;
                 segment.end = self.cursor.relative_pos_ctx(closing_parenthesis).end;
                 break;
             }
             self.cursor.force(
-                spaces().then(of_type(TokenType::Comma).or(lookahead(eod()))),
+                spaces().then(of_type(TokenType::Comma).or(lookahead(eog()))),
                 &format!("expected ',', found {}", self.cursor.peek().value),
             )?;
         }

--- a/parser/src/aspects/expr_list.rs
+++ b/parser/src/aspects/expr_list.rs
@@ -1,10 +1,10 @@
 use crate::err::ParseErrorKind;
 use crate::err::ParseErrorKind::Expected;
-use crate::moves::{blanks, eod, lookahead, of_type, MoveOperations};
+use crate::moves::{blanks, eog, lookahead, of_type, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 use context::source::{SourceSegment, SourceSegmentHolder};
 use lexer::token::TokenType;
-use lexer::token::TokenType::{Comma, EndOfFile};
+use lexer::token::TokenType::Comma;
 
 ///An aspect to parse expression lists
 pub(super) trait ExpressionListAspect<'a> {
@@ -74,11 +74,7 @@ impl<'a> ExpressionListAspect<'a> for Parser<'a> {
         self.delimiter_stack.push_back(start.clone());
         let mut elements = vec![];
 
-        while self
-            .cursor
-            .lookahead(blanks().then(eod().or(of_type(EndOfFile))))
-            .is_none()
-        {
+        while self.cursor.lookahead(blanks().then(eog())).is_none() {
             self.cursor.advance(blanks());
             while let Some(comma) = self.cursor.advance(of_type(Comma)) {
                 self.report_error(self.mk_parse_error(
@@ -96,7 +92,7 @@ impl<'a> ExpressionListAspect<'a> for Parser<'a> {
                 }
             };
             self.cursor.force_with(
-                blanks().then(of_type(Comma).or(lookahead(eod()))),
+                blanks().then(of_type(Comma).or(lookahead(eog()))),
                 "A comma or a closing bracket was expected here",
                 Expected(format!("',' or '{}'", end.str().unwrap_or("<undefined>")).to_string()),
             )?;

--- a/parser/src/aspects/group.rs
+++ b/parser/src/aspects/group.rs
@@ -1,7 +1,7 @@
 use lexer::token::{Token, TokenType};
 
 use crate::err::ParseErrorKind;
-use crate::moves::{eox, of_type, of_types, repeat, repeat_n, spaces, MoveOperations};
+use crate::moves::{line_end, of_type, of_types, repeat, repeat_n, spaces, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 use ast::group::{Block, Parenthesis, Subshell};
 use ast::Expr;
@@ -129,12 +129,12 @@ impl<'a> Parser<'a> {
                     statements.push(statement);
                 }
                 Err(err) => {
-                    self.recover_from(err, eox());
+                    self.recover_from(err, line_end());
                 }
             }
 
             //expects at least one newline or ';'
-            let eox_res = self.cursor.advance(repeat_n(1, spaces().then(eox())));
+            let eox_res = self.cursor.advance(repeat_n(1, spaces().then(line_end())));
 
             //checks if this group expression is closed after the parsed expression
             let closed = self.cursor.advance(spaces().then(of_type(eog)));

--- a/parser/src/aspects/loop.rs
+++ b/parser/src/aspects/loop.rs
@@ -1,7 +1,7 @@
 use lexer::token::{Token, TokenType};
 
 use crate::err::ParseErrorKind;
-use crate::moves::{blanks, eod, eox, of_type, MoveOperations};
+use crate::moves::{blanks, eog, line_end, of_type, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 use ast::control_flow::{ConditionalFor, For, ForKind, Loop, RangeFor, While};
 use ast::range::FilePattern;
@@ -30,7 +30,7 @@ impl<'a> LoopAspect<'a> for Parser<'a> {
         //consume blanks
         self.cursor.advance(blanks());
         //then consume eox (if any)
-        self.cursor.advance(eox());
+        self.cursor.advance(line_end());
 
         let body = Box::new(self.expression_statement()?);
         let segment = self.cursor.relative_pos(start).start..body.segment().end;
@@ -61,7 +61,7 @@ impl<'a> LoopAspect<'a> for Parser<'a> {
         )?;
         self.cursor.advance(blanks());
         let kind = Box::new(self.parse_for_kind()?);
-        self.cursor.advance(eox());
+        self.cursor.advance(line_end());
         let body = Box::new(self.expression_statement()?);
         let segment = self.cursor.relative_pos(start).start..body.segment().end;
 
@@ -203,7 +203,7 @@ impl<'a> Parser<'a> {
         &mut self,
         outer_opening_parenthesis: Token<'a>,
     ) -> ParseResult<Token<'a>> {
-        if self.cursor.lookahead(eod()).is_some() {
+        if self.cursor.lookahead(eog()).is_some() {
             self.expect_delimiter(TokenType::RoundedRightBracket)
         } else {
             let mut segment = self.cursor.relative_pos(outer_opening_parenthesis.value);

--- a/parser/src/aspects/match.rs
+++ b/parser/src/aspects/match.rs
@@ -6,7 +6,7 @@ use lexer::token::TokenType::{
 use crate::aspects::literal::{LiteralAspect, LiteralLeniency};
 use crate::err::ParseErrorKind;
 use crate::moves::{
-    aerated, any, blanks, eod, eox, not, of_type, of_types, repeat, MoveOperations,
+    aerated, any, blanks, eox, line_end, not, of_type, of_types, repeat, MoveOperations,
 };
 use crate::parser::{ParseResult, Parser};
 use ast::r#match::MatchPattern::{Literal, Template, VarRef, Wildcard};
@@ -62,15 +62,11 @@ impl<'a> Parser<'a> {
 
         let mut arms: Vec<MatchArm<'a>> = Vec::new();
 
-        while self
-            .cursor
-            .lookahead(blanks().then(eox().or(eod())))
-            .is_none()
-        {
+        while self.cursor.lookahead(blanks().then(eox())).is_none() {
             match self.parse_match_arm(parse_arm.clone()) {
                 Ok(arm) => arms.push(arm),
                 Err(err) => {
-                    self.recover_from(err, eox());
+                    self.recover_from(err, line_end());
                 }
             }
         }
@@ -219,7 +215,7 @@ impl<'a> Parser<'a> {
         self.cursor
             .force(aerated(of_type(FatArrow)), "missing '=>'")?;
         let body = parse_arm(self);
-        self.cursor.advance(repeat(eox()));
+        self.cursor.advance(repeat(line_end()));
         body
     }
 }

--- a/parser/src/aspects/substitution.rs
+++ b/parser/src/aspects/substitution.rs
@@ -1,7 +1,7 @@
 use crate::aspects::group::GroupAspect;
 use crate::aspects::var_reference::VarReferenceAspect;
 use crate::err::ParseErrorKind;
-use crate::moves::{eox, not, of_type, repeat_n, spaces, MoveOperations};
+use crate::moves::{line_end, not, of_type, repeat_n, spaces, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 use ast::substitution::{Substitution, SubstitutionKind};
 use ast::value::{Literal, LiteralValue};
@@ -50,7 +50,11 @@ impl<'a> SubstitutionAspect<'a> for Parser<'a> {
         }
 
         // Short pass for variable references
-        if self.cursor.lookahead(not(spaces().or(eox()))).is_some() {
+        if self
+            .cursor
+            .lookahead(not(spaces().or(line_end())))
+            .is_some()
+        {
             return self.var_reference();
         }
 

--- a/parser/src/moves.rs
+++ b/parser/src/moves.rs
@@ -346,19 +346,23 @@ pub(crate) fn lookahead<M: Move + Copy>(m: M) -> LookaheadMove<M> {
 
 //////////////////// STANDARD MOVES ////////////////////
 
-///End of _group_ Delimiter, any closing punctuation as long as they are unescaped
-pub(crate) fn eod() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool) + Copy> {
-    like(TokenType::is_closing_ponctuation)
+/// Tests if the token ends an expression.
+///
+/// Use this move in expressions where line endings are important. If not, use [`eog`].
+pub(crate) fn eox() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool) + Copy> {
+    like(TokenType::ends_expression)
 }
 
-///a move to consume default eox tokens as long as they are not escaped.
-/// default eox tokens are semicolon (;) and newline (\n)
-pub(crate) fn eox() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool) + Copy> {
-    of_types(&[NewLine, SemiColon, EndOfFile])
+/// Tests if the token ends a group.
+///
+/// Use this move in expressions where line endings does not matter. If not, use [`eox`].
+pub(crate) fn eog() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool) + Copy> {
+    like(TokenType::ends_group)
 }
-///a move that consumes a character if it can be escaped.
-pub(crate) fn escapable() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool) + Copy> {
-    like(TokenType::is_ponctuation)
+
+/// Tests if the token acts as a line ending.
+pub(crate) fn line_end() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool) + Copy> {
+    of_types(&[NewLine, SemiColon, EndOfFile])
 }
 
 ///a move that consumes a binary operation character


### PR DESCRIPTION
These obscure move is used in multiple places in the code base:
- `eox()` determines the end of an expression, but only with new lines.
- `eox().or(eod())` determines the end of an expression, more precisely, since a closing delimiter most likely also means the end of an expression.
- `not(blanks().then(eox().or(eod())))`, like `eox()` but allow intermediate new lines.

Those compositions hint that something is not handled properly.

Consider a return (https://github.com/moshell-lang/moshell/blob/master/parser/src/aspects/function_declaration.rs#L64):
If the line ends, or if the enclosing group ends, it's a void return. This intent is actually the end of an expression, which is not fully covered by simply `eox()`. This PR tackles that by merging the `eox()` move with the idea behind `eod()` together.

What is `eod()` exactly? An *end of group delimiter*? So `eod()` treats quotes as delimiters, meaning that `return 'foo'` is not parsed correctly.

`eox()` was more in fact `line_end()`, but let's dig more. There is the real *end of expressions*, `eox()` where line endings matter, and the *end of groups*, `eog()`, where lines ending aren't important (like in function parameters).

Lastly, this PR forces the lexer to emit a new line token if there is one after a comment. Since it was not the case before, the following code was invalid:
```kt
val command = 'ssh' // A comment
return $command
```