### PR TITLE
Analyzer refactors, encapsulate `Relations`

### DIFF
--- a/analyzer/src/diagnostic.rs
+++ b/analyzer/src/diagnostic.rs
@@ -1,4 +1,4 @@
-use crate::relations::SourceObjectId;
+use crate::relations::SourceId;
 use context::source::SourceSegment;
 use enum_assoc::Assoc;
 
@@ -85,7 +85,7 @@ impl Observation {
 #[derive(PartialEq, Debug)]
 pub struct Diagnostic {
     /// The source where this diagnostic applies
-    pub source: SourceObjectId,
+    pub source: SourceId,
     /// The diagnostic identifier
     pub identifier: DiagnosticID,
     /// The overall message of this diagnostic
@@ -97,7 +97,7 @@ pub struct Diagnostic {
 }
 
 impl Diagnostic {
-    pub fn new(id: DiagnosticID, source: SourceObjectId, msg: impl Into<String>) -> Self {
+    pub fn new(id: DiagnosticID, source: SourceId, msg: impl Into<String>) -> Self {
         Self {
             source,
             identifier: id,

--- a/analyzer/src/engine.rs
+++ b/analyzer/src/engine.rs
@@ -1,7 +1,7 @@
 use crate::environment::Environment;
 use crate::name::Name;
 
-use crate::relations::SourceObjectId;
+use crate::relations::SourceId;
 use ast::Expr;
 
 /// Owns references to the global AST and its environments.
@@ -31,25 +31,25 @@ impl<'a> Engine<'a> {
     }
 
     ///Returns an iterator over environments contained in engine
-    pub fn environments(&self) -> impl Iterator<Item = (SourceObjectId, &Environment)> {
+    pub fn environments(&self) -> impl Iterator<Item = (SourceId, &Environment)> {
         self.origins
             .iter()
             .enumerate()
-            .filter_map(|(id, (_, env))| env.as_ref().map(|env| (SourceObjectId(id), env)))
+            .filter_map(|(id, (_, env))| env.as_ref().map(|env| (SourceId(id), env)))
     }
 
     /// Adds a new origin to the engine and returns its given id.
     ///
     /// A call to this method must be followed by a call to [`Engine::attach`] with the same id
     /// after the environment has been built.
-    pub fn track(&mut self, ast: &'a Expr<'a>) -> SourceObjectId {
+    pub fn track(&mut self, ast: &'a Expr<'a>) -> SourceId {
         let id = self.origins.len();
         self.origins.push((ast, None));
-        SourceObjectId(id)
+        SourceId(id)
     }
 
     /// Attaches an environment to an origin if the origin does not already have an attached environment.
-    pub fn attach(&mut self, id: SourceObjectId, env: Environment) {
+    pub fn attach(&mut self, id: SourceId, env: Environment) {
         debug_assert!(
             self.origins[id.0].1.is_none(),
             "Could not attach environment to a source that is already attached"
@@ -58,20 +58,20 @@ impl<'a> Engine<'a> {
     }
 
     ///Finds an environment by its fully qualified name.
-    pub fn find_environment_by_name(&self, name: &Name) -> Option<(SourceObjectId, &Environment)> {
+    pub fn find_environment_by_name(&self, name: &Name) -> Option<(SourceId, &Environment)> {
         self.origins
             .iter()
             .enumerate()
             .find(|(_, (_, env))| env.as_ref().map(|env| &env.fqn == name).unwrap_or(false))
-            .and_then(|(idx, (_, env))| env.as_ref().map(|env| (SourceObjectId(idx), env)))
+            .and_then(|(idx, (_, env))| env.as_ref().map(|env| (SourceId(idx), env)))
     }
 
-    pub fn get_expression(&self, id: SourceObjectId) -> Option<&Expr<'a>> {
+    pub fn get_expression(&self, id: SourceId) -> Option<&Expr<'a>> {
         self.origins.get(id.0).map(|(expr, _)| *expr)
     }
 
     /// Gets an environment by its identifier.
-    pub fn get_environment(&self, id: SourceObjectId) -> Option<&Environment> {
+    pub fn get_environment(&self, id: SourceId) -> Option<&Environment> {
         self.origins.get(id.0).and_then(|(_, env)| env.as_ref())
     }
 

--- a/analyzer/src/environment.rs
+++ b/analyzer/src/environment.rs
@@ -1,5 +1,5 @@
 use crate::name::Name;
-use crate::relations::{SourceObjectId, Symbol};
+use crate::relations::{SourceId, Symbol};
 use context::source::{SourceSegment, SourceSegmentHolder};
 use std::collections::HashMap;
 use variables::Variables;
@@ -33,7 +33,7 @@ pub mod variables;
 #[derive(Debug, Clone)]
 pub struct Environment {
     /// The source object id of the parent environment, if the environment is nested.
-    pub parent: Option<SourceObjectId>,
+    pub parent: Option<SourceId>,
 
     ///Fully qualified name of the environment
     pub fqn: Name,
@@ -45,7 +45,7 @@ pub struct Environment {
     pub definitions: HashMap<SourceSegment, Symbol>,
 
     /// A mapping of expression segments to their declaring environment.
-    pub declarations: HashMap<SourceSegment, SourceObjectId>,
+    pub declarations: HashMap<SourceSegment, SourceId>,
 }
 
 impl Environment {
@@ -59,7 +59,7 @@ impl Environment {
         }
     }
 
-    pub fn fork(&self, source_id: SourceObjectId, name: &str) -> Environment {
+    pub fn fork(&self, source_id: SourceId, name: &str) -> Environment {
         let env_fqn = self.fqn.child(name);
 
         Self {
@@ -96,7 +96,7 @@ impl Environment {
     }
 
     /// Maps the declaring environment of a segment.
-    pub fn bind_source(&mut self, segment: &impl SourceSegmentHolder, source: SourceObjectId) {
+    pub fn bind_source(&mut self, segment: &impl SourceSegmentHolder, source: SourceId) {
         self.declarations.insert(segment.segment(), source);
     }
 
@@ -111,7 +111,7 @@ impl Environment {
     }
 
     /// Gets the declaring environment id of a segment.
-    pub fn get_raw_env(&self, segment: SourceSegment) -> Option<SourceObjectId> {
+    pub fn get_raw_env(&self, segment: SourceSegment) -> Option<SourceId> {
         self.declarations.get(&segment).copied()
     }
 

--- a/analyzer/src/environment/variables.rs
+++ b/analyzer/src/environment/variables.rs
@@ -35,7 +35,7 @@ pub struct Variables {
 }
 
 impl Variables {
-    /// Declares a new local variable.
+    /// Creates a new local variable.
     pub fn declare_local(&mut self, name: String, ty: TypeInfo) -> Symbol {
         self.locals.declare(name, ty)
     }

--- a/analyzer/src/environment/variables.rs
+++ b/analyzer/src/environment/variables.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
 use crate::name::Name;
-use crate::relations::{GlobalObjectId, ObjectId, Symbol};
+use crate::relations::{LocalId, RelationId, Symbol};
 
 /// Information over the declared type of a variable
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -31,52 +31,52 @@ pub struct Variables {
 
     /// Relations with external variables.
     /// The key is the variable Names, where value is the relation with another external environment's [Locals]
-    externals: HashMap<Name, GlobalObjectId>,
+    externals: HashMap<Name, RelationId>,
 }
 
 impl Variables {
-    /// Creates a new local variable.
+    /// Declares a new local variable.
     pub fn declare_local(&mut self, name: String, ty: TypeInfo) -> Symbol {
         self.locals.declare(name, ty)
     }
 
     /// Returns the local variable associated with the id
-    pub fn get_var(&self, id: ObjectId) -> Option<&Variable> {
-        self.locals.vars.get(id)
+    pub fn get_var(&self, id: LocalId) -> Option<&Variable> {
+        self.locals.vars.get(id.0)
     }
 
     /// Returns an entry for the given external symbol name relation
-    pub fn external(&mut self, name: Name) -> Entry<Name, GlobalObjectId> {
+    pub fn external(&mut self, name: Name) -> Entry<Name, RelationId> {
         self.externals.entry(name)
     }
 
-    /// Gets the local identifier associated with an already known name.
+    /// Finds the local identifier associated with an already known name.
     ///
     /// The lookup uses the current scope, which is frequently updated during the collection phase.
     /// That's the main reason why this method should be used in pair the variable capture
     /// resolution, immediately after the closure is observed and inertly populated.
-    pub fn get_reachable(&self, name: &str) -> Option<ObjectId> {
+    pub fn find_reachable(&self, name: &str) -> Option<LocalId> {
         self.locals.position_reachable_local(name)
     }
 
-    /// Gets the local exported symbol associated with an already known name.
+    /// Finds the local exported symbol associated with an already known name.
     ///
     /// Exported symbols are always declared in the outermost scope, and should be checked only
     /// after the whole environment is collected.
-    pub fn get_exported(&self, name: &str) -> Option<ObjectId> {
+    pub fn find_exported(&self, name: &str) -> Option<LocalId> {
         self.locals
             .vars
             .iter()
             .rev()
             .position(|var| var.name == name && var.is_exported())
-            .map(|idx| self.locals.vars.len() - 1 - idx)
+            .map(|idx| LocalId(self.locals.vars.len() - 1 - idx))
     }
 
     /// Lists all local variables, in the order they are declared.
     ///
     /// This exposes their current state, which is only interesting for debugging.
-    /// Use [`Variables::get_reachable`] to lookup any variable during the collection phase,
-    /// or [`Variables::get_exported`] to lookup an exported variable after the collection phase.
+    /// Use [`Variables::find_reachable`] to lookup any variable during the collection phase,
+    /// or [`Variables::find_exported`] to lookup an exported variable after the collection phase.
     pub fn all_vars(&self) -> &[Variable] {
         &self.locals.vars
     }
@@ -88,14 +88,14 @@ impl Variables {
     }
 
     /// Iterates over all the global variable ids, with their corresponding name.
-    pub fn external_vars(&self) -> impl Iterator<Item = (&Name, GlobalObjectId)> {
+    pub fn external_vars(&self) -> impl Iterator<Item = (&Name, RelationId)> {
         self.externals.iter().map(|(name, id)| (name, *id))
     }
 
-    /// Gets the name of an external variable.
+    /// Finds the name of an external variable.
     ///
     /// This returns the name only if the global object comes from this environment.
-    pub fn get_external_symbol_name(&self, object_id: GlobalObjectId) -> Option<&Name> {
+    pub fn find_external_symbol_name(&self, object_id: RelationId) -> Option<&Name> {
         self.externals
             .iter()
             .find_map(|(name, id)| (id == &object_id).then_some(name))
@@ -130,7 +130,7 @@ impl Locals {
             depth: self.current_depth as isize,
             ty,
         });
-        Symbol::Local(id)
+        Symbol::Local(LocalId(id))
     }
 
     /// Declares a new variable of type `TypeInfo::Variable`.
@@ -178,12 +178,12 @@ impl Locals {
     }
 
     /// Gets the variable id from the current scope.
-    fn position_reachable_local(&self, name: &str) -> Option<ObjectId> {
+    fn position_reachable_local(&self, name: &str) -> Option<LocalId> {
         self.vars
             .iter()
             .rev()
             .position(|var| var.name == name && var.depth >= 0)
-            .map(|idx| self.vars.len() - 1 - idx)
+            .map(|idx| LocalId(self.vars.len() - 1 - idx))
     }
 }
 

--- a/analyzer/src/imports.rs
+++ b/analyzer/src/imports.rs
@@ -1,5 +1,5 @@
 use crate::name::Name;
-use crate::relations::{ResolvedSymbol, SourceObjectId};
+use crate::relations::{ResolvedSymbol, SourceId};
 use context::source::SourceSegment;
 use indexmap::IndexMap;
 use std::collections::HashMap;
@@ -12,7 +12,7 @@ pub struct Imports {
     /// Imports may only be declared at the top level of a source. This lets us track the unresolved imports
     /// per [`crate::environment::Environment`]. If a source is not tracked here, it means that it has no
     /// imports.
-    imports: HashMap<SourceObjectId, SourceImports>,
+    imports: HashMap<SourceId, SourceImports>,
 }
 
 impl Imports {
@@ -21,7 +21,7 @@ impl Imports {
     /// This directive may be used later to resolve the import.
     pub fn add_unresolved_import(
         &mut self,
-        source: SourceObjectId,
+        source: SourceId,
         import: UnresolvedImport,
         import_expr: SourceSegment,
     ) -> Option<SourceSegment> {
@@ -29,11 +29,11 @@ impl Imports {
         imports.add_unresolved_import(import, import_expr)
     }
 
-    pub fn get_imports(&self, source: SourceObjectId) -> Option<&SourceImports> {
+    pub fn get_imports(&self, source: SourceId) -> Option<&SourceImports> {
         self.imports.get(&source)
     }
 
-    pub fn get_imports_mut(&mut self, source: SourceObjectId) -> Option<&mut SourceImports> {
+    pub fn get_imports_mut(&mut self, source: SourceId) -> Option<&mut SourceImports> {
         self.imports.get_mut(&source)
     }
 }
@@ -66,7 +66,7 @@ pub enum ResolvedImport {
     /// The import is a symbol
     Symbol(ResolvedSymbol),
     /// The import is an environment
-    Env(SourceObjectId),
+    Env(SourceId),
 
     /// The import wasn't found
     Dead,

--- a/analyzer/src/relations.rs
+++ b/analyzer/src/relations.rs
@@ -1,5 +1,6 @@
 use crate::dependency::Dependencies;
 use std::fmt::Debug;
+use std::ops::{Index, IndexMut};
 
 use context::source::SourceSegment;
 
@@ -7,36 +8,51 @@ use crate::engine::Engine;
 
 /// The object identifier base.
 ///
-/// Note that this type doesn't convey if it is a local or global object, i.e. in which scope it is stored.
+/// An object is anything that can be referenced by its [`ObjectId`],
+/// here's an exhaustive list of the main objects and structures in the analyzer.
 ///
-/// To further indicate the provenance of the object, use specific types:
-/// - [`GlobalObjectId`] points to a global object that needs to be resolved.
-/// - [`SourceObjectId`] points to a object whose environment may contain actual symbol sources.
-/// - [`ResolvedSymbol`] is used to point globally to a nested environment.
-/// - [`Symbol`] refers differentiate a id that is local or not.
+/// - [`RelationId`] points to a relation in [`Relation`].
+/// - [`SourceId`] points to a source in [`Engine`], sources are a root AST expression bound to an [`Environment`].
+/// - [`LocalId`] points to a local object in an environment's [`crate::environment::variables::Variables`].
+/// - [`crate::types::TypeId`] points to a type registered in [`Typing`]
+///
+/// Some main structures are based on object identifiers
+/// - [`ResolvedSymbol`] contains a [`SourceId`] and a [`LocalId`] which globally targets a symbol inside a given source environment,
+///                      this structure is emitted by the resolution phase.
+/// - [`Symbol`] refers to a symbol, which is either local (to an unbound environment) or external, where the relation is held by the [`Relations`]
 pub type ObjectId = usize;
 
-/// A global object identifier, that points to a specific object in the [`Relations`].
+/// A relation identifier, that points to a specific relation in the [`Relations`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct GlobalObjectId(pub ObjectId);
+pub struct RelationId(pub ObjectId);
+
+/// A source identifier, that can be the target of a global resolution.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct SourceId(pub ObjectId);
 
 /// A source object identifier, that can be the target of a global resolution.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct SourceObjectId(pub ObjectId);
+pub struct LocalId(pub ObjectId);
 
 /// An indication where an object is located.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Symbol {
     /// A local object, referenced by its index in the [`crate::environment::Environment`] it is defined in.
-    Local(ObjectId),
+    Local(LocalId),
 
-    /// A global object, referenced by its index in the [`Relations`] it is linked to.
-    Global(ObjectId),
+    /// An external symbol, where the relation is contained in the [`Resolver`].
+    External(RelationId),
 }
 
-impl From<GlobalObjectId> for Symbol {
-    fn from(id: GlobalObjectId) -> Self {
-        Symbol::Global(id.0)
+impl From<RelationId> for Symbol {
+    fn from(id: RelationId) -> Self {
+        Symbol::External(id)
+    }
+}
+
+impl From<LocalId> for Symbol {
+    fn from(id: LocalId) -> Self {
+        Symbol::Local(id)
     }
 }
 
@@ -46,63 +62,64 @@ pub struct ResolvedSymbol {
     /// The module where the symbol is defined.
     ///
     /// This is used to route the symbol to the correct environment.
-    pub source: SourceObjectId,
+    pub source: SourceId,
 
-    /// The object identifier of the symbol, local to the module.
-    pub object_id: ObjectId,
+    /// The object identifier of the symbol, local to the given environment.
+    pub object_id: LocalId,
 }
 
 impl ResolvedSymbol {
-    pub fn new(source: SourceObjectId, object_id: ObjectId) -> Self {
+    pub fn new(source: SourceId, object_id: LocalId) -> Self {
         Self { source, object_id }
     }
 }
 
-/// The state of an object
+/// The state of a relation
 ///
-/// The [SymbolResolver] only handles objects marked as [ObjectState::Unresolved]
-/// and will attempt to resolve it by updating his state to [ObjectState::Resolved]
-/// If the resolution fails, for any reason, the object is marked as dead ([ObjectState::Dead])
-/// which should imply a diagnostic.
-/// This state prevents the resolver to attempt to resolve again unresolvable symbols on next cycles.
+/// The [SymbolResolver] only attempts to resolve relations marked as [RelationState::Unresolved]
+/// If the resolution fails, for any reason, the object is marked as dead ([RelationState::Dead])
+/// which in most case implies a diagnostic.
+/// The dead state prevents the resolver to attempt to resolve again unresolvable symbols on next cycles.
+/// If the relation was successfully resolved, the state is then [RelationState::Resolved], containing the
+/// resolved symbol and targeted environment.
 #[derive(Debug, Clone, Copy, Hash, PartialEq)]
-pub enum ObjectState {
+pub enum RelationState {
     Resolved(ResolvedSymbol),
     Unresolved,
     Dead,
 }
 
-impl ObjectState {
+impl RelationState {
     pub fn expect_resolved(self, msg: &str) -> ResolvedSymbol {
         match self {
-            ObjectState::Resolved(resolved) => resolved,
+            RelationState::Resolved(resolved) => resolved,
             _ => panic!("{}", msg),
         }
     }
 }
 
 #[derive(Debug, Clone, Hash, PartialEq)]
-pub struct Object {
+pub struct Relation {
     /// The environment's id that requested this object resolution.
-    pub origin: SourceObjectId,
+    pub origin: SourceId,
 
-    /// This object's state.
-    /// See [ObjectState] for more details
-    pub state: ObjectState,
+    /// This relation's state.
+    /// See [RelationState] for more details
+    pub state: RelationState,
 }
 
-impl Object {
-    pub fn unresolved(origin: SourceObjectId) -> Self {
+impl Relation {
+    pub fn unresolved(origin: SourceId) -> Self {
         Self {
             origin,
-            state: ObjectState::Unresolved,
+            state: RelationState::Unresolved,
         }
     }
 
-    pub fn resolved(origin: SourceObjectId, resolved: ResolvedSymbol) -> Self {
+    pub fn resolved(origin: SourceId, resolved: ResolvedSymbol) -> Self {
         Self {
             origin,
-            state: ObjectState::Resolved(resolved),
+            state: RelationState::Resolved(resolved),
         }
     }
 }
@@ -110,21 +127,21 @@ impl Object {
 /// A collection of objects that are tracked globally and may link to each other.
 #[derive(Debug, Default)]
 pub struct Relations {
-    /// The objects that need resolution that are tracked globally.
+    /// The tracked relations.
     ///
     /// The actual [`String`] -> [`ObjectId`] mapping is left to the [`crate::environment::Environment`].
     /// The reason that the resolution information is lifted out of the environment is that identifiers
     /// binding happens across modules, and an environment cannot guarantee that it will be able to generate
     /// unique identifiers for all the symbols that do not conflicts with the ones from other modules.
-    pub objects: Vec<Object>,
+    relations: Vec<Relation>,
 }
 
 impl Relations {
     /// Tracks a new object and returns its identifier.
-    pub fn track_new_object(&mut self, origin: SourceObjectId) -> GlobalObjectId {
-        let id = self.objects.len();
-        self.objects.push(Object::unresolved(origin));
-        GlobalObjectId(id)
+    pub fn track_new_object(&mut self, origin: SourceId) -> RelationId {
+        let id = self.relations.len();
+        self.relations.push(Relation::unresolved(origin));
+        RelationId(id)
     }
 
     /// Finds segments that reference the given object.
@@ -133,42 +150,64 @@ impl Relations {
     pub fn find_references(
         &self,
         engine: &Engine,
-        tracked_object: GlobalObjectId,
+        tracked_object: RelationId,
     ) -> Option<Vec<SourceSegment>> {
-        let object = self.objects.get(tracked_object.0)?;
+        let object = self.relations.get(tracked_object.0)?;
         let environment = engine
             .get_environment(object.origin)
             .expect("object relation targets to an unknown environment");
-        Some(environment.find_references(Symbol::Global(tracked_object.0)))
+        Some(environment.find_references(Symbol::External(tracked_object)))
     }
 
     /// Returns a mutable iterator over all the objects.
-    pub fn iter_mut(&mut self) -> impl Iterator<Item = (GlobalObjectId, &mut Object)> {
-        self.objects
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (RelationId, &mut Relation)> {
+        self.relations
             .iter_mut()
             .enumerate()
-            .map(|(id, object)| (GlobalObjectId(id), object))
+            .map(|(id, relation)| (RelationId(id), relation))
+    }
+
+    /// Returns a mutable iterator over all the objects.
+    pub fn iter(&self) -> impl Iterator<Item = (RelationId, &Relation)> {
+        self.relations
+            .iter()
+            .enumerate()
+            .map(|(id, relation)| (RelationId(id), relation))
     }
 
     /// Returns the state of the given object.
     ///
-    /// If the object is not referenced, returns [`None`].
-    pub fn get_state(&self, id: GlobalObjectId) -> Option<ObjectState> {
-        Some(self.objects.get(id.0)?.state)
+    /// If the relation is not referenced, returns [`None`].
+    pub fn get_state(&self, id: RelationId) -> Option<RelationState> {
+        Some(self.relations.get(id.0)?.state)
     }
 
     /// Creates a dependency graph for the given engine.
-    pub fn as_dependencies(&self, engine: &Engine) -> Dependencies<SourceObjectId> {
+    pub fn as_dependencies(&self, engine: &Engine) -> Dependencies<SourceId> {
         let mut dependencies = Dependencies::default();
         for (id, _) in engine.environments() {
             dependencies.add_node(id);
         }
 
-        for object in self.objects.iter() {
-            if let ObjectState::Resolved(resolved) = object.state {
+        for object in self.relations.iter() {
+            if let RelationState::Resolved(resolved) = object.state {
                 dependencies.add_dependency(object.origin, resolved.source);
             }
         }
         dependencies
+    }
+}
+
+impl IndexMut<RelationId> for Relations {
+    fn index_mut(&mut self, index: RelationId) -> &mut Self::Output {
+        &mut self.relations[index.0]
+    }
+}
+
+impl Index<RelationId> for Relations {
+    type Output = Relation;
+
+    fn index(&self, index: RelationId) -> &Self::Output {
+        &self.relations[index.0]
     }
 }

--- a/analyzer/src/relations.rs
+++ b/analyzer/src/relations.rs
@@ -167,7 +167,7 @@ impl Relations {
             .map(|(id, relation)| (RelationId(id), relation))
     }
 
-    /// Returns a mutable iterator over all the objects.
+    /// Returns an immutable iterator over all the objects.
     pub fn iter(&self) -> impl Iterator<Item = (RelationId, &Relation)> {
         self.relations
             .iter()

--- a/analyzer/src/relations.rs
+++ b/analyzer/src/relations.rs
@@ -30,7 +30,7 @@ pub struct RelationId(pub ObjectId);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SourceId(pub ObjectId);
 
-/// A source object identifier, that can be the target of a global resolution.
+/// An identifier for a local variable stored in an environment
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct LocalId(pub ObjectId);
 
@@ -127,7 +127,7 @@ impl Relation {
 /// A collection of objects that are tracked globally and may link to each other.
 #[derive(Debug, Default)]
 pub struct Relations {
-    /// The tracked relations.
+    /// The tracked relations between environments.
     ///
     /// The actual [`String`] -> [`ObjectId`] mapping is left to the [`crate::environment::Environment`].
     /// The reason that the resolution information is lifted out of the environment is that identifiers

--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -18,7 +18,7 @@ use crate::environment::Environment;
 use crate::importer::ASTImporter;
 use crate::imports::{Imports, UnresolvedImport};
 use crate::name::Name;
-use crate::relations::{ObjectState, Relations, SourceObjectId, Symbol};
+use crate::relations::{RelationState, Relations, SourceId, Symbol};
 use crate::steps::resolve::SymbolResolver;
 use crate::steps::shared_diagnostics::diagnose_invalid_symbol;
 
@@ -26,14 +26,14 @@ use crate::steps::shared_diagnostics::diagnose_invalid_symbol;
 #[derive(Debug, Clone, Copy)]
 struct ResolutionState {
     /// The module id that is currently being explored.
-    module: SourceObjectId,
+    module: SourceId,
 
     /// Whether the current module accepts imports.
     accept_imports: bool,
 }
 
 impl ResolutionState {
-    fn new(module: SourceObjectId) -> Self {
+    fn new(module: SourceId) -> Self {
         Self {
             module,
             accept_imports: true,
@@ -48,7 +48,7 @@ pub struct SymbolCollector<'a, 'e> {
     diagnostics: Vec<Diagnostic>,
 
     /// During the exploration, a parent environment always leaves a reference for its children.
-    stack: Vec<(SourceObjectId, &'e Environment)>,
+    stack: Vec<(SourceId, &'e Environment)>,
 }
 
 impl<'a, 'e> SymbolCollector<'a, 'e> {
@@ -101,7 +101,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
             for (declaration_segment, symbol) in &env.definitions {
                 let id = match symbol {
                     Symbol::Local(id) => id,
-                    Symbol::Global(_) => continue, //we check declarations only, thus external symbols are ignored
+                    Symbol::External(_) => continue, //we check declarations only, thus external symbols are ignored
                 };
                 if !reported.insert(id) {
                     continue;
@@ -180,7 +180,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
 
     fn add_checked_import(
         &mut self,
-        mod_id: SourceObjectId,
+        mod_id: SourceId,
         import: UnresolvedImport,
         import_expr: &'e ImportExpr<'e>,
         import_fqn: Name,
@@ -208,7 +208,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
         &mut self,
         import: &'e ImportExpr<'e>,
         relative_path: Vec<String>,
-        mod_id: SourceObjectId,
+        mod_id: SourceId,
         to_visit: &mut Vec<Name>,
     ) {
         match import {
@@ -264,7 +264,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
     fn identify_variable(
         &mut self,
         variables: &mut Variables,
-        origin: SourceObjectId,
+        origin: SourceId,
         name: &Name,
         segment: SourceSegment,
     ) -> Symbol {
@@ -276,8 +276,8 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
             };
         }
 
-        match variables.get_reachable(name.root()) {
-            None => Symbol::Global(track_global!().0),
+        match variables.find_reachable(name.root()) {
+            None => Symbol::External(track_global!()),
             Some(id) if name.is_qualified() => {
                 let var = variables.get_var(id).unwrap();
                 self.diagnostics
@@ -286,8 +286,8 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                 // We could have returned None here to ignore the symbol but it's more appropriate to
                 // bind the variable occurrence with a dead object to signify that it's bound symbol invalid.
                 let id = track_global!();
-                self.relations.objects[id.0].state = ObjectState::Dead;
-                Symbol::Global(id.0)
+                self.relations[id].state = RelationState::Dead;
+                Symbol::External(id)
             }
             Some(id) => Symbol::Local(id),
         }
@@ -570,7 +570,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
         parent_env: &Environment,
         parent_state: &ResolutionState,
         capture_env: &Environment,
-        capture_env_id: SourceObjectId,
+        capture_env_id: SourceId,
     ) {
         self.stack.push((parent_state.module, unsafe {
             // SAFETY: the reference will immediately be popped off the stack.
@@ -655,7 +655,7 @@ mod tests {
     use parser::parse_trusted;
 
     use crate::importer::StaticImporter;
-    use crate::relations::{GlobalObjectId, Symbol};
+    use crate::relations::{LocalId, RelationId, Symbol};
 
     use super::*;
 
@@ -679,7 +679,7 @@ mod tests {
         assert_eq!(
             res,
             vec![
-                Diagnostic::new(DiagnosticID::UseBetweenExprs, SourceObjectId(0), "Unexpected use statement between expressions. use statements can only be declared on top of environment"),
+                Diagnostic::new(DiagnosticID::UseBetweenExprs, SourceId(0), "Unexpected use statement between expressions. use statements can only be declared on top of environment"),
             ]
         )
     }
@@ -697,7 +697,7 @@ mod tests {
 
         collector.tree_walk(&mut env, &mut state, &expr, &mut vec![]);
         assert_eq!(collector.diagnostics, vec![]);
-        assert_eq!(relations.objects, vec![]);
+        assert_eq!(relations.iter().collect::<Vec<_>>(), vec![]);
     }
 
     #[test]
@@ -730,7 +730,7 @@ mod tests {
             &mut importer,
         );
         assert_eq!(diagnostics, vec![
-            Diagnostic::new(DiagnosticID::SymbolConflictsWithModule, SourceObjectId(0), "Declared symbol 'multiply' in module math clashes with module math::multiply")
+            Diagnostic::new(DiagnosticID::SymbolConflictsWithModule, SourceId(0), "Declared symbol 'multiply' in module math clashes with module math::multiply")
                 .with_observation(Observation::with_help(find_in(math_source, "fun multiply(a: Int, b: Int) = a * b"), "This symbol has the same fully-qualified name as module math::multiply"))
                 .with_help("You should refactor this symbol with a name that does not conflicts with following modules: math::{divide, multiply, add}")
         ]);
@@ -759,7 +759,7 @@ mod tests {
             vec![
                 Diagnostic::new(
                     DiagnosticID::ShadowedImport,
-                    SourceObjectId(0),
+                    SourceId(0),
                     "A is imported twice."
                 )
                 .with_observation(Observation::with_help(
@@ -772,7 +772,7 @@ mod tests {
                 )),
                 Diagnostic::new(
                     DiagnosticID::ShadowedImport,
-                    SourceObjectId(0),
+                    SourceId(0),
                     "B is imported twice."
                 )
                 .with_observation(Observation::with_help(
@@ -802,18 +802,21 @@ mod tests {
         collector.tree_walk(&mut env, &mut state, &expr, &mut vec![]);
 
         assert_eq!(collector.diagnostics, vec![]);
-        assert_eq!(relations.objects, vec![]);
-        assert_eq!(env.get_raw_symbol(source.segment()), Some(Symbol::Local(0)));
+        assert_eq!(relations.iter().collect::<Vec<_>>(), vec![]);
+        assert_eq!(
+            env.get_raw_symbol(source.segment()),
+            Some(Symbol::Local(LocalId(0)))
+        );
         assert_eq!(env.get_raw_symbol(find_in(src, "a")), None);
         assert_eq!(env.get_raw_symbol(find_in(src, "$a")), None);
-        let func_env = engine.get_environment(SourceObjectId(1)).unwrap();
+        let func_env = engine.get_environment(SourceId(1)).unwrap();
         assert_eq!(
             func_env.get_raw_symbol(find_in(src, "a")),
-            Some(Symbol::Local(0))
+            Some(Symbol::Local(LocalId(0)))
         );
         assert_eq!(
             func_env.get_raw_symbol(find_in(src, "$a")),
-            Some(Symbol::Local(0))
+            Some(Symbol::Local(LocalId(0)))
         );
     }
 
@@ -832,11 +835,11 @@ mod tests {
         collector.tree_walk(&mut env, &mut state, &expr, &mut vec![]);
 
         assert_eq!(collector.diagnostics, vec![]);
-        assert_eq!(relations.objects, vec![]);
+        assert_eq!(relations.iter().collect::<Vec<_>>(), vec![]);
         assert_eq!(env.get_raw_symbol(find_in(src, "read")), None);
         assert_eq!(
             env.get_raw_symbol(find_in(src, "foo")),
-            Some(Symbol::Local(0))
+            Some(Symbol::Local(LocalId(0)))
         );
     }
 
@@ -859,7 +862,7 @@ mod tests {
         engine.attach(state.module, env);
         assert_eq!(
             relations
-                .find_references(&engine, GlobalObjectId(0))
+                .find_references(&engine, RelationId(0))
                 .map(|mut references| {
                     references.sort_by_key(|range| range.start);
                     references
@@ -867,11 +870,11 @@ mod tests {
             Some(vec![find_in(src, "$bar"), find_in_nth(src, "$bar", 1)])
         );
         assert_eq!(
-            relations.find_references(&engine, GlobalObjectId(1)),
+            relations.find_references(&engine, RelationId(1)),
             Some(vec![find_in(src, "baz($foo, $bar)")])
         );
         assert_eq!(
-            relations.find_references(&engine, GlobalObjectId(2)),
+            relations.find_references(&engine, RelationId(2)),
             Some(vec![find_in(src, "$foo")])
         );
     }

--- a/analyzer/src/steps/resolve/import.rs
+++ b/analyzer/src/steps/resolve/import.rs
@@ -3,7 +3,7 @@ use crate::engine::Engine;
 use crate::environment::Environment;
 use crate::imports::{ResolvedImport, SourceImports, UnresolvedImport};
 use crate::name::Name;
-use crate::relations::{ResolvedSymbol, SourceObjectId};
+use crate::relations::{ResolvedSymbol, SourceId};
 use crate::steps::resolve::{diagnose_unresolved_import, SymbolResolver};
 
 impl<'a, 'e> SymbolResolver<'a, 'e> {
@@ -11,7 +11,7 @@ impl<'a, 'e> SymbolResolver<'a, 'e> {
     /// imports that could get resolved.
     /// This method will append a new diagnostic for each imports that could not be resolved.
     pub fn resolve_imports(
-        env_id: SourceObjectId,
+        env_id: SourceId,
         imports: &mut SourceImports,
         engine: &Engine,
         diagnostics: &mut Vec<Diagnostic>,
@@ -52,7 +52,7 @@ impl<'a, 'e> SymbolResolver<'a, 'e> {
                                 continue;
                             }
 
-                            let symbol_id = found_env.variables.get_exported(&symbol_name);
+                            let symbol_id = found_env.variables.find_exported(&symbol_name);
 
                             if let Some(symbol_id) = symbol_id {
                                 let resolved = ResolvedSymbol::new(found_env_id, symbol_id);
@@ -92,7 +92,7 @@ impl<'a, 'e> SymbolResolver<'a, 'e> {
                         }
                         Some((env_id, env)) => {
                             for var in env.variables.exported_vars() {
-                                let var_id = env.variables.get_exported(&var.name).unwrap();
+                                let var_id = env.variables.find_exported(&var.name).unwrap();
 
                                 let import_symbol = ResolvedSymbol::new(env_id, var_id);
                                 imports.set_resolved_import(
@@ -114,7 +114,7 @@ impl<'a, 'e> SymbolResolver<'a, 'e> {
 fn get_mod_from_absolute<'a>(
     engine: &'a Engine,
     name: &Name,
-) -> Option<(SourceObjectId, &'a Environment)> {
+) -> Option<(SourceId, &'a Environment)> {
     let mut env_name = Some(name.clone());
     while let Some(name) = env_name {
         if let Some((id, env)) = engine.find_environment_by_name(&name) {

--- a/analyzer/src/steps/resolve/symbol.rs
+++ b/analyzer/src/steps/resolve/symbol.rs
@@ -2,7 +2,7 @@ use crate::engine::Engine;
 use crate::environment::Environment;
 use crate::imports::{ResolvedImport, SourceImports};
 use crate::name::Name;
-use crate::relations::{ResolvedSymbol, SourceObjectId};
+use crate::relations::{ResolvedSymbol, SourceId};
 use crate::steps::resolve::SymbolResolver;
 
 /// The result of a symbol resolution attempt
@@ -21,14 +21,14 @@ pub enum SymbolResolutionResult {
 
 impl<'a, 'e> SymbolResolver<'a, 'e> {
     pub fn resolve_symbol_from_locals(
-        env_id: SourceObjectId,
+        env_id: SourceId,
         env: &Environment,
         symbol_name: &Name,
     ) -> SymbolResolutionResult {
         if env.has_strict_declaration_order() {
             return SymbolResolutionResult::NotFound;
         }
-        if let Some(var_id) = env.variables.get_exported(symbol_name.root()) {
+        if let Some(var_id) = env.variables.find_exported(symbol_name.root()) {
             let symbol = ResolvedSymbol {
                 source: env_id,
                 object_id: var_id,
@@ -49,7 +49,7 @@ impl<'a, 'e> SymbolResolver<'a, 'e> {
         let env_result = engine.find_environment_by_name(&env_name);
 
         if let Some((env_id, env)) = env_result {
-            let resolved_pos = env.variables.get_exported(name.simple_name());
+            let resolved_pos = env.variables.find_exported(name.simple_name());
 
             if let Some(symbol_pos) = resolved_pos {
                 let symbol = ResolvedSymbol::new(env_id, symbol_pos);
@@ -81,7 +81,7 @@ impl<'a, 'e> SymbolResolver<'a, 'e> {
                     .get_environment(*resolved_module)
                     .expect("resolved import points to an unknown environment");
 
-                let resolved_pos = env.variables.get_exported(name.simple_name());
+                let resolved_pos = env.variables.find_exported(name.simple_name());
 
                 if let Some(symbol_pos) = resolved_pos {
                     return SymbolResolutionResult::Resolved(ResolvedSymbol::new(

--- a/analyzer/src/steps/shared_diagnostics.rs
+++ b/analyzer/src/steps/shared_diagnostics.rs
@@ -3,12 +3,12 @@
 use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
 use crate::environment::variables::TypeInfo;
 use crate::name::Name;
-use crate::relations::SourceObjectId;
+use crate::relations::SourceId;
 use context::source::SourceSegment;
 
 pub fn diagnose_invalid_symbol(
     base_type: TypeInfo,
-    env_id: SourceObjectId,
+    env_id: SourceId,
     name: &Name,
     segments: &[SourceSegment],
 ) -> Diagnostic {

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -2,7 +2,7 @@ use crate::dependency::topological_sort;
 use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
 use crate::engine::Engine;
 use crate::environment::Environment;
-use crate::relations::{Relations, SourceObjectId};
+use crate::relations::{Relations, SourceId};
 use crate::steps::typing::exploration::Exploration;
 use crate::steps::typing::function::{infer_return, type_call, type_parameter, Return};
 use crate::types::ctx::TypeContext;
@@ -46,13 +46,13 @@ pub fn apply_types(
 /// checked.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(self) struct TypingState {
-    source: SourceObjectId,
+    source: SourceId,
     local_type: bool,
 }
 
 impl TypingState {
     /// Creates a new initial state, for a script.
-    fn new(source: SourceObjectId) -> Self {
+    fn new(source: SourceId) -> Self {
         Self {
             source,
             local_type: false,
@@ -466,7 +466,7 @@ mod tests {
         let mut diagnostics = result.diagnostics;
         assert_eq!(diagnostics, vec![]);
         let typed = apply_types(&result.engine, &result.relations, &mut diagnostics);
-        let expr = typed.get(SourceObjectId(0)).unwrap();
+        let expr = typed.get(SourceId(0)).unwrap();
         if !diagnostics.is_empty() {
             return Err(diagnostics);
         }
@@ -499,7 +499,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceObjectId(0),
+                SourceId(0),
                 "Type mismatch",
             )
             .with_observation(Observation::with_help(
@@ -521,7 +521,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::UnknownType,
-                SourceObjectId(0),
+                SourceId(0),
                 "Unknown type annotation",
             )
             .with_observation(Observation::with_help(
@@ -551,7 +551,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceObjectId(0),
+                SourceId(0),
                 "`if` and `else` have incompatible types",
             )
             .with_observation(Observation::with_help(
@@ -586,7 +586,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceObjectId(0),
+                SourceId(0),
                 "This function takes 1 argument but 2 were supplied",
             )
             .with_observation(Observation::with_help(
@@ -604,7 +604,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceObjectId(0),
+                SourceId(0),
                 "Type mismatch",
             )
             .with_observation(Observation::with_help(
@@ -626,7 +626,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceObjectId(0),
+                SourceId(0),
                 "Cannot invoke non function type",
             )
             .with_observation(Observation::with_help(
@@ -644,7 +644,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceObjectId(1),
+                SourceId(1),
                 "Type mismatch",
             )
             .with_observation(Observation::with_help(
@@ -682,7 +682,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceObjectId(1),
+                SourceId(1),
                 "Type mismatch",
             )
             .with_observation(Observation::with_help(find_in(content, "0"), "Found `Int`"))
@@ -718,23 +718,15 @@ mod tests {
         assert_eq!(
             res,
             Err(vec![
-                Diagnostic::new(
-                    DiagnosticID::TypeMismatch,
-                    SourceObjectId(1),
-                    "Type mismatch",
-                )
-                .with_observation(Observation::with_help(
-                    find_in(content, "return {}"),
-                    "Found `Nothing`"
-                ))
-                .with_observation(return_observation.clone()),
-                Diagnostic::new(
-                    DiagnosticID::TypeMismatch,
-                    SourceObjectId(1),
-                    "Type mismatch",
-                )
-                .with_observation(Observation::with_help(find_in(content, "9"), "Found `Int`"))
-                .with_observation(return_observation)
+                Diagnostic::new(DiagnosticID::TypeMismatch, SourceId(1), "Type mismatch",)
+                    .with_observation(Observation::with_help(
+                        find_in(content, "return {}"),
+                        "Found `Nothing`"
+                    ))
+                    .with_observation(return_observation.clone()),
+                Diagnostic::new(DiagnosticID::TypeMismatch, SourceId(1), "Type mismatch",)
+                    .with_observation(Observation::with_help(find_in(content, "9"), "Found `Int`"))
+                    .with_observation(return_observation)
             ])
         );
     }
@@ -747,7 +739,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::CannotInfer,
-                SourceObjectId(1),
+                SourceId(1),
                 "Return type inference is not supported yet",
             )
             .with_observation(Observation::with_help(
@@ -766,7 +758,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::CannotInfer,
-                SourceObjectId(1),
+                SourceId(1),
                 "Return type is not inferred for block functions",
             )
             .with_observation(Observation::with_help(
@@ -791,7 +783,7 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::CannotInfer,
-                SourceObjectId(1),
+                SourceId(1),
                 "Failed to infer return type",
             )
             .with_observation(Observation::with_help(

--- a/analyzer/src/types/ctx.rs
+++ b/analyzer/src/types/ctx.rs
@@ -1,4 +1,4 @@
-use crate::relations::{ObjectId, Relations, SourceId, Symbol};
+use crate::relations::{LocalId, Relations, SourceId, Symbol};
 use crate::types::hir::TypeId;
 use crate::types::{BOOL, FLOAT, INT, NOTHING, STRING};
 use std::collections::HashMap;
@@ -49,11 +49,11 @@ impl TypeContext {
     /// Defines the type of a currently explored symbol.
     ///
     /// This must be in sync with the symbol in the environment.
-    pub(crate) fn push_local_type(&mut self, source: SourceId, type_id: TypeId) -> ObjectId {
+    pub(crate) fn push_local_type(&mut self, source: SourceId, type_id: TypeId) -> LocalId {
         let locals = self.locals.entry(source).or_default();
         let index = locals.len();
         locals.push(type_id);
-        index
+        LocalId(index)
     }
 
     /// Finds the type from an annotation.

--- a/analyzer/src/types/ctx.rs
+++ b/analyzer/src/types/ctx.rs
@@ -1,4 +1,4 @@
-use crate::relations::{ObjectId, Relations, SourceObjectId, Symbol};
+use crate::relations::{ObjectId, Relations, SourceId, Symbol};
 use crate::types::hir::TypeId;
 use crate::types::{BOOL, FLOAT, INT, NOTHING, STRING};
 use std::collections::HashMap;
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 /// The actual type definition is in the [`crate::types::Typing`] struct.
 pub struct TypeContext {
     names: HashMap<String, TypeId>,
-    locals: HashMap<SourceObjectId, Vec<TypeId>>,
+    locals: HashMap<SourceId, Vec<TypeId>>,
 }
 
 impl TypeContext {
@@ -30,19 +30,17 @@ impl TypeContext {
     pub(crate) fn get(
         &self,
         relations: &Relations,
-        source: SourceObjectId,
+        source: SourceId,
         symbol: Symbol,
     ) -> Option<TypeId> {
         match symbol {
-            Symbol::Local(index) => self.locals.get(&source).unwrap().get(index).copied(),
-            Symbol::Global(index) => {
-                let resolved = relations.objects[index]
-                    .state
-                    .expect_resolved("Unresolved symbol");
+            Symbol::Local(index) => self.locals.get(&source).unwrap().get(index.0).copied(),
+            Symbol::External(index) => {
+                let resolved = relations[index].state.expect_resolved("Unresolved symbol");
                 self.locals
                     .get(&resolved.source)
                     .unwrap()
-                    .get(resolved.object_id)
+                    .get(resolved.object_id.0)
                     .copied()
             }
         }
@@ -51,7 +49,7 @@ impl TypeContext {
     /// Defines the type of a currently explored symbol.
     ///
     /// This must be in sync with the symbol in the environment.
-    pub(crate) fn push_local_type(&mut self, source: SourceObjectId, type_id: TypeId) -> ObjectId {
+    pub(crate) fn push_local_type(&mut self, source: SourceId, type_id: TypeId) -> ObjectId {
         let locals = self.locals.entry(source).or_default();
         let index = locals.len();
         locals.push(type_id);

--- a/analyzer/src/types/engine.rs
+++ b/analyzer/src/types/engine.rs
@@ -1,4 +1,4 @@
-use crate::relations::SourceObjectId;
+use crate::relations::SourceId;
 use crate::types::hir::{TypeId, TypedExpr};
 use crate::types::ty::Parameter;
 use crate::types::NOTHING;
@@ -65,19 +65,19 @@ impl TypedEngine {
     }
 
     /// Returns the chunk with the given id.
-    pub fn get(&self, id: SourceObjectId) -> Option<&Chunk> {
+    pub fn get(&self, id: SourceId) -> Option<&Chunk> {
         self.entries.get(id.0).and_then(|entry| entry.as_ref())
     }
 
     /// Inserts a chunk into the engine.
-    pub fn insert(&mut self, id: SourceObjectId, entry: Chunk) {
+    pub fn insert(&mut self, id: SourceId, entry: Chunk) {
         self.entries[id.0] = Some(entry);
     }
 
     /// Inserts a chunk into the engine if it is not already present.
     ///
     /// This may be used to insert semi-accurate chunks into the engine.
-    pub fn insert_if_absent(&mut self, id: SourceObjectId, entry: Chunk) {
+    pub fn insert_if_absent(&mut self, id: SourceId, entry: Chunk) {
         if self.entries[id.0].is_none() {
             self.entries[id.0] = Some(entry);
         }

--- a/analyzer/src/types/hir.rs
+++ b/analyzer/src/types/hir.rs
@@ -1,4 +1,4 @@
-use crate::relations::{ObjectId, Symbol};
+use crate::relations::{LocalId, ObjectId, Symbol};
 use crate::types::{ERROR, NOTHING};
 use ast::operation::BinaryOperator;
 use ast::value::LiteralValue;
@@ -49,7 +49,7 @@ pub enum ExprKind {
         rhs: Box<TypedExpr>,
     },
     Declare {
-        identifier: ObjectId,
+        identifier: LocalId,
         value: Option<Box<TypedExpr>>,
     },
     Reference(Symbol),

--- a/analyzer/src/types/ty.rs
+++ b/analyzer/src/types/ty.rs
@@ -1,4 +1,4 @@
-use crate::relations::SourceObjectId;
+use crate::relations::SourceId;
 use crate::types::hir::TypeId;
 use context::source::SourceSegment;
 use std::fmt::Display;
@@ -29,7 +29,7 @@ pub enum Type {
     String,
 
     /// A callable type, that have a separate environment.
-    Function(SourceObjectId),
+    Function(SourceId),
 }
 
 /// A function parameter.


### PR DESCRIPTION
This simple pull request refactors some structure names in order to be less misleading and more straightforward 

- `GlobalObjectId` => `RelationId` as they ARE relations identifier
- `SourceObjectId` => `SourceId`
- Created `LocalId` in order to pair with `RelationId`

- `Symbol::Global` => `Symbol::External` as "global" symbols are more of global variables, functions, defined in script's roots. This refactor better matches with the fact that a symbol can either be local to environment (thus `Symbol::Local`) or external (thus `Symbol::External`).

- `Object` => `Relation` as its identifier is `RelationId` that could be flustered with `ObjectId`.

- `Relations::objects` => `Relations::relations` to match `Object` => `Relation` refactor
  The relations' map were unexposed, and `Relations` now implements `Index<RelationId>` and `Index<RelationId>`

also refactored some `get_` methods to `find_` in `Variables` that weren't 0(1)