### PR TITLE
Pop unused expression values

### DIFF
--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -617,7 +617,7 @@ fn ascribe_if(
         diagnostics,
         env,
         &block.condition,
-        state.with_local_type(),
+        state,
     );
     let condition = coerce_condition(condition, exploration, state, diagnostics);
     let mut then = ascribe_types(
@@ -711,12 +711,9 @@ fn ascribe_call(
             convert_into_string(expr, exploration, diagnostics, state)
         })
         .collect::<Vec<_>>();
-
-    let ty = if state.local_type { EXIT_CODE } else { NOTHING };
-
     TypedExpr {
         kind: ExprKind::ProcessCall(args),
-        ty,
+        ty: EXIT_CODE,
         segment: call.segment(),
     }
 }
@@ -1523,7 +1520,7 @@ mod tests {
                             segment: find_in(content, "4.2"),
                         }
                     ]),
-                    ty: NOTHING,
+                    ty: EXIT_CODE,
                     segment: find_in(content, "grep $n 4.2"),
                 }
             ])

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -617,7 +617,7 @@ fn ascribe_if(
         diagnostics,
         env,
         &block.condition,
-        state,
+        state.with_local_type(),
     );
     let condition = coerce_condition(condition, exploration, state, diagnostics);
     let mut then = ascribe_types(
@@ -711,9 +711,12 @@ fn ascribe_call(
             convert_into_string(expr, exploration, diagnostics, state)
         })
         .collect::<Vec<_>>();
+
+    let ty = if state.local_type { EXIT_CODE } else { NOTHING };
+
     TypedExpr {
         kind: ExprKind::ProcessCall(args),
-        ty: EXIT_CODE,
+        ty,
         segment: call.segment(),
     }
 }
@@ -1520,7 +1523,7 @@ mod tests {
                             segment: find_in(content, "4.2"),
                         }
                     ]),
-                    ty: EXIT_CODE,
+                    ty: NOTHING,
                     segment: find_in(content, "grep $n 4.2"),
                 }
             ])

--- a/compiler/src/bytecode.rs
+++ b/compiler/src/bytecode.rs
@@ -28,6 +28,11 @@ impl Bytecode {
         self.bytes.push(identifier);
     }
 
+    pub fn emit_set_local(&mut self, identifier: u8) {
+        self.emit_code(Opcode::SetLocal);
+        self.bytes.push(identifier);
+    }
+
     pub fn emit_int(&mut self, constant: i64) {
         self.emit_code(Opcode::PushInt);
         self.bytes.extend(constant.to_be_bytes());

--- a/compiler/src/emit.rs
+++ b/compiler/src/emit.rs
@@ -80,9 +80,10 @@ fn emit_declaration(
     state: &mut EmissionState,
 ) {
     if let Some(value) = &declaration.value {
-        state.use_values = true;
+        let last = state.use_values(true);
         emit(value, emitter, cp, state);
-        state.use_values = false;
+        state.use_values(last);
+
         emitter.emit_code(Opcode::SetLocal);
         emitter.bytes.push(declaration.identifier.0 as u8);
     }
@@ -99,7 +100,7 @@ fn emit_block(
         for expr in exprs {
             emit(expr, emitter, cp, state);
         }
-        state.use_values = used;
+        state.use_values(used);
         emit(last_expr, emitter, cp, state);
     }
 }
@@ -110,7 +111,10 @@ fn emit_assignment(
     cp: &mut ConstantPool,
     state: &mut EmissionState,
 ) {
+    let last = state.use_values(true);
     emit(&assignment.rhs, emitter, cp, state);
+    state.use_values(last);
+
     match assignment.identifier {
         Symbol::Local(id) => emitter.emit_set_local(id.0 as u8),
         Symbol::External(_) => {

--- a/compiler/src/emit.rs
+++ b/compiler/src/emit.rs
@@ -25,7 +25,7 @@ pub struct EmissionState {
     // if set to false, the compiler will avoid emitting literals, var references or will
     // instantly pop values returned from functions, methods and process calls
     // we don't use values by default
-    pub use_values: bool
+    pub use_values: bool,
 }
 
 impl EmissionState {
@@ -39,7 +39,7 @@ impl EmissionState {
         Self {
             enclosing_loop_start: loop_start,
             enclosing_loop_end_placeholders: Vec::new(),
-            use_values: false
+            use_values: false,
         }
     }
 

--- a/compiler/src/emit.rs
+++ b/compiler/src/emit.rs
@@ -1,9 +1,8 @@
 use analyzer::relations::{Definition, Symbol};
 use analyzer::types::hir::{Assignment, Declaration, ExprKind, TypedExpr};
-use analyzer::types::*;
 use ast::value::LiteralValue;
 
-use crate::bytecode::Bytecode;
+use crate::bytecode::{Bytecode, Opcode};
 use crate::constant_pool::ConstantPool;
 use crate::emit::invoke::emit_process_call;
 use crate::emit::jump::{emit_break, emit_conditional, emit_continue, emit_loop};
@@ -22,6 +21,11 @@ pub struct EmissionState {
     // When the loop compilation ends, all those placeholder are filled with the
     // first instruction pointer after the loop.
     pub enclosing_loop_end_placeholders: Vec<usize>,
+
+    // if set to false, the compiler will avoid emitting literals, var references or will
+    // instantly pop values returned from functions, methods and process calls
+    // we don't use values by default
+    pub use_values: bool
 }
 
 impl EmissionState {
@@ -35,7 +39,15 @@ impl EmissionState {
         Self {
             enclosing_loop_start: loop_start,
             enclosing_loop_end_placeholders: Vec::new(),
+            use_values: false
         }
+    }
+
+    /// sets use_values to given value, and return last value
+    pub fn use_values(&mut self, used: bool) -> bool {
+        let last_state = self.use_values;
+        self.use_values = used;
+        last_state
     }
 }
 
@@ -68,19 +80,27 @@ fn emit_declaration(
     state: &mut EmissionState,
 ) {
     if let Some(value) = &declaration.value {
+        state.use_values = true;
         emit(value, emitter, cp, state);
-        emitter.emit_set_local(declaration.identifier.0 as u8)
+        state.use_values = false;
+        emitter.emit_code(Opcode::SetLocal);
+        emitter.bytes.push(declaration.identifier.0 as u8);
     }
 }
 
 fn emit_block(
-    exprs: &Vec<TypedExpr>,
+    exprs: &[TypedExpr],
     emitter: &mut Bytecode,
     cp: &mut ConstantPool,
     state: &mut EmissionState,
 ) {
-    for expr in exprs {
-        emit(expr, emitter, cp, state);
+    if let Some((last_expr, exprs)) = exprs.split_last() {
+        let used = state.use_values(false);
+        for expr in exprs {
+            emit(expr, emitter, cp, state);
+        }
+        state.use_values = used;
+        emit(last_expr, emitter, cp, state);
     }
 }
 
@@ -105,7 +125,6 @@ pub fn emit(
     cp: &mut ConstantPool,
     state: &mut EmissionState,
 ) {
-    let use_return = expr.ty != NOTHING;
     match &expr.kind {
         ExprKind::Declare(d) => emit_declaration(d, emitter, cp, state),
         ExprKind::Block(exprs) => emit_block(exprs, emitter, cp, state),
@@ -115,16 +134,18 @@ pub fn emit(
         ExprKind::Break => emit_break(emitter, state),
         ExprKind::Assign(ass) => emit_assignment(ass, emitter, cp, state),
         ExprKind::Reference(r) => {
-            if use_return {
+            // if the reference's value is not used, then simply do not emit it
+            if state.use_values {
                 emit_ref(r, emitter)
             }
         }
         ExprKind::Literal(literal) => {
-            if use_return {
+            // if the literal's value is not used, then simply do not emit it
+            if state.use_values {
                 emit_literal(literal, emitter, cp)
             }
         }
-        ExprKind::ProcessCall(args) => emit_process_call(args, use_return, emitter, cp, state),
+        ExprKind::ProcessCall(args) => emit_process_call(args, emitter, cp, state),
         ExprKind::MethodCall(method) => match method.definition {
             Definition::Native(id) => {
                 emit_primitive_op(id, &method.callee, &method.arguments, emitter, cp, state);

--- a/compiler/src/emit.rs
+++ b/compiler/src/emit.rs
@@ -91,11 +91,12 @@ fn emit_assignment(
     state: &mut EmissionState,
 ) {
     emit(&assignment.rhs, emitter, cp, state);
-    if let Symbol::Local(id) = assignment.identifier {
-        emitter.emit_set_local(id.0 as u8);
-        return;
+    match assignment.identifier {
+        Symbol::Local(id) => emitter.emit_set_local(id.0 as u8),
+        Symbol::External(_) => {
+            unimplemented!("External variable assignations are not implemented yet")
+        }
     }
-    unimplemented!("cannot support external variables assignations")
 }
 
 pub fn emit(

--- a/compiler/src/emit/invoke.rs
+++ b/compiler/src/emit/invoke.rs
@@ -12,6 +12,7 @@ pub fn emit_process_call(
     cp: &mut ConstantPool,
     state: &mut EmissionState,
 ) {
+    let last = state.use_values(true);
     for arg in arguments {
         emit(arg, emitter, cp, state);
 
@@ -23,6 +24,7 @@ pub fn emit_process_call(
             _ => todo!("Convert to other types"),
         }
     }
+    state.use_values(last);
 
     emitter.emit_code(Opcode::Spawn);
     emitter.bytes.push(arguments.len() as u8);

--- a/compiler/src/emit/invoke.rs
+++ b/compiler/src/emit/invoke.rs
@@ -8,7 +8,6 @@ use crate::emit::EmissionState;
 
 pub fn emit_process_call(
     arguments: &Vec<TypedExpr>,
-    use_return: bool,
     emitter: &mut Bytecode,
     cp: &mut ConstantPool,
     state: &mut EmissionState,
@@ -28,7 +27,7 @@ pub fn emit_process_call(
     emitter.emit_code(Opcode::Spawn);
     emitter.bytes.push(arguments.len() as u8);
 
-    if !use_return {
+    if !state.use_values {
         // The Spawn operation will push the process's exitcode onto the stack
         // in order to maintain the stack's size, we instantly pop
         // the stack if the value isn't used later in the code

--- a/compiler/src/emit/jump.rs
+++ b/compiler/src/emit/jump.rs
@@ -53,7 +53,7 @@ pub fn emit_loop(
         let jump_to_end = emitter.emit_jump(Opcode::IfNotJump);
         loop_state.enclosing_loop_end_placeholders.push(jump_to_end);
     }
-    
+
     loop_state.enclosing_loop_start = loop_start;
 
     // Evaluate the loop body.

--- a/compiler/src/emit/jump.rs
+++ b/compiler/src/emit/jump.rs
@@ -13,7 +13,7 @@ pub fn emit_conditional(
     // emit condition
     let last = state.use_values(true);
     emit(&conditional.condition, emitter, cp, state);
-    state.use_values = last;
+    state.use_values(last);
 
     // If the condition is false, go to ELSE.
     let jump_to_else = emitter.emit_jump(Opcode::IfNotJump);
@@ -47,7 +47,7 @@ pub fn emit_loop(
         let last = state.use_values(true);
         // Evaluate the condition.
         emit(condition, emitter, cp, state);
-        state.use_values = last;
+        state.use_values(last);
         
         // If the condition is false, go to END.
         let jump_to_end = emitter.emit_jump(Opcode::IfNotJump);

--- a/compiler/src/emit/jump.rs
+++ b/compiler/src/emit/jump.rs
@@ -10,7 +10,10 @@ pub fn emit_conditional(
     cp: &mut ConstantPool,
     state: &mut EmissionState,
 ) {
+    // emit condition
+    let last = state.use_values(true);
     emit(&conditional.condition, emitter, cp, state);
+    state.use_values = last;
 
     // If the condition is false, go to ELSE.
     let jump_to_else = emitter.emit_jump(Opcode::IfNotJump);
@@ -41,13 +44,16 @@ pub fn emit_loop(
     let mut loop_state = EmissionState::in_loop(loop_start);
 
     if let Some(condition) = &lp.condition {
+        let last = state.use_values(true);
         // Evaluate the condition.
         emit(condition, emitter, cp, state);
+        state.use_values = last;
+        
         // If the condition is false, go to END.
         let jump_to_end = emitter.emit_jump(Opcode::IfNotJump);
         loop_state.enclosing_loop_end_placeholders.push(jump_to_end);
     }
-
+    
     loop_state.enclosing_loop_start = loop_start;
 
     // Evaluate the loop body.

--- a/compiler/src/emit/native.rs
+++ b/compiler/src/emit/native.rs
@@ -67,7 +67,7 @@ pub(crate) fn emit_primitive_op(
         id => todo!("Native function with id {id}"),
     };
 
-    if state.use_values {
+    if !state.use_values {
         emitter.emit_code(pop_opcode)
     }
 }

--- a/compiler/src/emit/native.rs
+++ b/compiler/src/emit/native.rs
@@ -17,7 +17,7 @@ pub(crate) fn emit_primitive_op(
     emit(callee, emitter, cp, state);
     state.use_values(last);
 
-    let pop_opcode= match native.0 {
+    let pop_opcode = match native.0 {
         0 => {
             // ExitCode -> Bool
             emitter.emit_byte(1);


### PR DESCRIPTION
This pull request, as discussed in #112, adds a new state during compilation phase (`EmissionState::use_values`) which helps the compiler tracking unused values pushed from expressions.
Those check are needed to keep an operand stack as small as possible and with a deterministic size