### PR TITLE
Import multiple files

### DIFF
--- a/analyzer/src/diagnostic.rs
+++ b/analyzer/src/diagnostic.rs
@@ -89,37 +89,33 @@ pub struct Observation {
     /// The location where this observation applies
     pub location: SourceLocation,
     /// An optional help string to complete the observation
-    pub label: Option<String>,
+    pub message: Option<String>,
 }
 
 impl Observation {
-    pub fn new(location: SourceLocation) -> Self {
-        Self {
-            location,
-            label: None,
-        }
-    }
-
     /// Creates an observation that underlines an erroneous location.
     ///
     /// Prefer adding a label to explain the observation.
-    pub fn underline(source: SourceId, segment: SourceSegment) -> Self {
-        Self::new(SourceLocation::new(source, segment))
+    pub fn new(location: SourceLocation) -> Self {
+        Self {
+            location,
+            message: None,
+        }
     }
 
     /// Creates an observation on an erroneous location.
-    pub fn here(source: SourceId, segment: SourceSegment, help: impl Into<String>) -> Self {
+    pub fn here(source: SourceId, segment: SourceSegment, message: impl Into<String>) -> Self {
         Self {
             location: SourceLocation::new(source, segment),
-            label: Some(help.into()),
+            message: Some(message.into()),
         }
     }
 
     /// Creates a contextual observation.
-    pub fn context(source: SourceId, segment: SourceSegment, help: impl Into<String>) -> Self {
+    pub fn context(source: SourceId, segment: SourceSegment, message: impl Into<String>) -> Self {
         Self {
             location: SourceLocation::new(source, segment),
-            label: Some(help.into()),
+            message: Some(message.into()),
         }
     }
 }
@@ -177,5 +173,11 @@ impl Diagnostic {
     pub fn with_help(mut self, help: impl Into<String>) -> Self {
         self.helps.push(help.into());
         self
+    }
+}
+
+impl From<(SourceId, SourceSegment)> for Observation {
+    fn from((source, segment): (SourceId, SourceSegment)) -> Self {
+        Self::new(SourceLocation::new(source, segment))
     }
 }

--- a/analyzer/src/engine.rs
+++ b/analyzer/src/engine.rs
@@ -22,14 +22,13 @@ pub struct Engine<'a> {
 
 impl<'a> Engine<'a> {
     /// Takes ownership of an expression and returns a reference to it.
-    pub fn take(&mut self, ast: Expr<'a>) -> (ContentId, &'a Expr<'a>) {
-        let id = ContentId(self.asts.len());
+    pub fn take(&mut self, ast: Expr<'a>) -> &'a Expr<'a> {
         self.asts.push(Box::new(ast));
-        (id, unsafe {
+        unsafe {
             // SAFETY: Assume for now that expressions are never removed from the engine.
             // The reference behind Box does not change and is valid for the lifetime of the engine.
             std::mem::transmute::<&Expr<'a>, &'a Expr<'a>>(self.asts.last().unwrap())
-        })
+        }
     }
 
     ///Returns an iterator over environments contained in engine

--- a/analyzer/src/engine.rs
+++ b/analyzer/src/engine.rs
@@ -1,4 +1,5 @@
 use ast::Expr;
+use context::source::ContentId;
 
 use crate::environment::Environment;
 use crate::name::Name;
@@ -16,18 +17,19 @@ pub struct Engine<'a> {
     ///
     /// Those are origins of symbols that are available locally in the environment,
     /// which may also be the source of unresolved symbols, tracked in the Relations.
-    origins: Vec<(&'a Expr<'a>, Option<Environment>)>,
+    origins: Vec<(ContentId, &'a Expr<'a>, Option<Environment>)>,
 }
 
 impl<'a> Engine<'a> {
     /// Takes ownership of an expression and returns a reference to it.
-    pub fn take(&mut self, ast: Expr<'a>) -> &'a Expr<'a> {
+    pub fn take(&mut self, ast: Expr<'a>) -> (ContentId, &'a Expr<'a>) {
+        let id = ContentId(self.asts.len());
         self.asts.push(Box::new(ast));
-        unsafe {
+        (id, unsafe {
             // SAFETY: Assume for now that expressions are never removed from the engine.
             // The reference behind Box does not change and is valid for the lifetime of the engine.
             std::mem::transmute::<&Expr<'a>, &'a Expr<'a>>(self.asts.last().unwrap())
-        }
+        })
     }
 
     ///Returns an iterator over environments contained in engine
@@ -35,26 +37,26 @@ impl<'a> Engine<'a> {
         self.origins
             .iter()
             .enumerate()
-            .filter_map(|(id, (_, env))| env.as_ref().map(|env| (SourceId(id), env)))
+            .filter_map(|(id, (_, _, env))| env.as_ref().map(|env| (SourceId(id), env)))
     }
 
     /// Adds a new origin to the engine and returns its given id.
     ///
     /// A call to this method must be followed by a call to [`Engine::attach`] with the same id
     /// after the environment has been built.
-    pub fn track(&mut self, ast: &'a Expr<'a>) -> SourceId {
+    pub fn track(&mut self, content_id: ContentId, ast: &'a Expr<'a>) -> SourceId {
         let id = self.origins.len();
-        self.origins.push((ast, None));
+        self.origins.push((content_id, ast, None));
         SourceId(id)
     }
 
     /// Attaches an environment to an origin if the origin does not already have an attached environment.
     pub fn attach(&mut self, id: SourceId, env: Environment) {
         debug_assert!(
-            self.origins[id.0].1.is_none(),
+            self.origins[id.0].2.is_none(),
             "Could not attach environment to a source that is already attached"
         );
-        self.origins[id.0].1.replace(env);
+        self.origins[id.0].2.replace(env);
     }
 
     ///Finds an environment by its fully qualified name.
@@ -62,17 +64,17 @@ impl<'a> Engine<'a> {
         self.origins
             .iter()
             .enumerate()
-            .find(|(_, (_, env))| env.as_ref().map(|env| &env.fqn == name).unwrap_or(false))
-            .and_then(|(idx, (_, env))| env.as_ref().map(|env| (SourceId(idx), env)))
+            .find(|(_, (_, _, env))| env.as_ref().map(|env| &env.fqn == name).unwrap_or(false))
+            .and_then(|(idx, (_, _, env))| env.as_ref().map(|env| (SourceId(idx), env)))
     }
 
     pub fn get_expression(&self, id: SourceId) -> Option<&Expr<'a>> {
-        self.origins.get(id.0).map(|(expr, _)| *expr)
+        self.origins.get(id.0).map(|(_, expr, _)| *expr)
     }
 
     /// Gets an environment by its identifier.
     pub fn get_environment(&self, id: SourceId) -> Option<&Environment> {
-        self.origins.get(id.0).and_then(|(_, env)| env.as_ref())
+        self.origins.get(id.0).and_then(|(_, _, env)| env.as_ref())
     }
 
     /// Gets the number of origins in the engine.
@@ -83,5 +85,10 @@ impl<'a> Engine<'a> {
     /// Returns `true` does not contain any origin.
     pub fn is_empty(&self) -> bool {
         self.origins.is_empty()
+    }
+
+    /// Gets the id of the AST tree that was used to create the given origin.
+    pub fn get_original_content(&self, id: SourceId) -> Option<ContentId> {
+        self.origins.get(id.0).map(|(content_id, _, _)| *content_id)
     }
 }

--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -15,7 +15,7 @@ use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
 use crate::engine::Engine;
 use crate::environment::variables::{TypeInfo, Variables};
 use crate::environment::Environment;
-use crate::importer::{ASTImporter, Imported};
+use crate::importer::{ASTImporter, ImportResult, Imported};
 use crate::imports::{Imports, UnresolvedImport};
 use crate::name::Name;
 use crate::relations::{RelationState, Relations, SourceId, Symbol};
@@ -648,13 +648,13 @@ fn import_ast<'a, 'b>(
     while !parts.is_empty() {
         let name = Name::from(parts.clone());
         match importer.import(&name) {
-            Ok(Some(imported)) => return Some((imported, name)),
-            Ok(None) => {
+            ImportResult::Success(imported) => return Some((imported, name)),
+            ImportResult::NotFound => {
                 // Nothing has been found, but we might have a chance by
                 // importing the parent module.
                 parts.pop();
             }
-            Err(_) => {
+            ImportResult::Failure => {
                 // Something has been found, but cannot be fully imported,
                 // so don't try to import anything else.
                 return None;

--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -630,9 +630,16 @@ fn import_ast<'a, 'b>(
     while !parts.is_empty() {
         let name = Name::from(parts.clone());
         match importer.import(&name) {
-            Some(expr) => return Some((expr, name)),
-            None => {
+            Ok(Some(expr)) => return Some((expr, name)),
+            Ok(None) => {
+                // Nothing has been found, but we might have a chance by
+                // importing the parent module.
                 parts.pop();
+            }
+            Err(_) => {
+                // Something has been found, but cannot be fully imported,
+                // so don't try to import anything else.
+                return None;
             }
         }
     }

--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -262,7 +262,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                     DiagnosticID::UnsupportedFeature,
                     "import of environment variables and commands are not yet supported.",
                 )
-                .with_observation(Observation::underline(mod_id, import.segment()));
+                .with_observation((mod_id, import.segment()).into());
 
                 self.diagnostics.push(diagnostic);
             }
@@ -325,7 +325,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                     let diagnostic = Diagnostic::new(
                         DiagnosticID::UseBetweenExprs,
                         "Unexpected use statement between expressions. Use statements must be at the top of the environment.",
-                    ).with_observation(Observation::underline(state.module, import.segment()));
+                    ).with_observation((state.module, import.segment()).into());
                     self.diagnostics.push(diagnostic);
                     return;
                 }
@@ -726,10 +726,10 @@ mod tests {
             res,
             vec![
                 Diagnostic::new(DiagnosticID::UseBetweenExprs, "Unexpected use statement between expressions. Use statements must be at the top of the environment.")
-                    .with_observation(Observation::underline(
+                    .with_observation((
                         SourceId(0),
                         find_in(content, "use c"),
-                    )),
+                    ).into()),
             ]
         )
     }

--- a/analyzer/src/steps/resolve.rs
+++ b/analyzer/src/steps/resolve.rs
@@ -394,10 +394,12 @@ mod tests {
             diagnostics,
             vec![Diagnostic::new(
                 DiagnosticID::ImportResolution,
-                SourceId(0),
                 "unable to find imported symbol `foo` in module `std`.",
             )
-            .with_observation(Observation::new(find_in(test_src, "foo")))]
+            .with_observation(Observation::underline(
+                SourceId(0),
+                find_in(test_src, "foo")
+            ))]
         );
 
         assert_eq!(
@@ -657,47 +659,65 @@ mod tests {
             vec![
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
-                    SourceId(0),
                     "`foo` is a function which cannot export any inner symbols"
                 )
-                .with_observation(Observation::new(find_in(test_src, "foo::x()")))
+                .with_observation(Observation::underline(
+                    SourceId(0),
+                    find_in(test_src, "foo::x()")
+                ))
                 .with_help("`x` is an invalid symbol in function `foo`"),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
-                    SourceId(0),
                     "`foo` is a function which cannot export any inner symbols"
                 )
-                .with_observation(Observation::new(find_in(test_src, "foo::y::z()")))
+                .with_observation(Observation::underline(
+                    SourceId(0),
+                    find_in(test_src, "foo::y::z()")
+                ))
                 .with_help("`y::z` is an invalid symbol in function `foo`"),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
-                    SourceId(0),
                     "`foo` is a function which cannot export any inner symbols"
                 )
-                .with_observation(Observation::new(find_in_nth(test_src, "foo::y::z()", 1)))
+                .with_observation(Observation::underline(
+                    SourceId(0),
+                    find_in_nth(test_src, "foo::y::z()", 1)
+                ))
                 .with_help("`y::z` is an invalid symbol in function `foo`"),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
-                    SourceId(2),
                     "`foz` is a function which cannot export any inner symbols"
                 )
-                .with_observation(Observation::new(find_in_nth(test_src, "foz::x()", 1)))
+                .with_observation(Observation::underline(
+                    SourceId(2),
+                    find_in_nth(test_src, "foz::x()", 1)
+                ))
                 .with_help("`x` is an invalid symbol in function `foz`"),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
-                    SourceId(2),
                     "`foo` is a function which cannot export any inner symbols",
                 )
-                .with_observation(Observation::new(find_in_nth(test_src, "foo::y::z()", 2)))
-                .with_observation(Observation::new(find_in_nth(test_src, "foo::y::z()", 3)))
-                .with_observation(Observation::new(find_in_nth(test_src, "foo::y::z()", 4)))
+                .with_observation(Observation::underline(
+                    SourceId(2),
+                    find_in_nth(test_src, "foo::y::z()", 2)
+                ))
+                .with_observation(Observation::underline(
+                    SourceId(2),
+                    find_in_nth(test_src, "foo::y::z()", 3)
+                ))
+                .with_observation(Observation::underline(
+                    SourceId(2),
+                    find_in_nth(test_src, "foo::y::z()", 4)
+                ))
                 .with_help("`y::z` is an invalid symbol in function `foo`"),
                 Diagnostic::new(
                     DiagnosticID::UnknownSymbol,
-                    SourceId(3),
                     "Could not resolve symbol `a::foo::in_local`."
                 )
-                .with_observation(Observation::new(find_in(test_src, "a::foo::in_local()"))),
+                .with_observation(Observation::underline(
+                    SourceId(3),
+                    find_in(test_src, "a::foo::in_local()")
+                )),
             ]
         );
 
@@ -754,44 +774,38 @@ mod tests {
             vec![
                 Diagnostic::new(
                     DiagnosticID::ImportResolution,
-                    SourceId(0),
                     "unable to find imported symbol `B` in module `A`.",
                 )
-                .with_observation(Observation::new(find_in(source, "A::B"))),
+                .with_observation(Observation::underline(SourceId(0), find_in(source, "A::B"))),
                 Diagnostic::new(
                     DiagnosticID::ImportResolution,
-                    SourceId(0),
                     "unable to find imported symbol `B::C`."
                 )
-                .with_observation(Observation::new(find_in(source, "B::C"))),
+                .with_observation(Observation::underline(SourceId(0), find_in(source, "B::C"))),
                 Diagnostic::new(
                     DiagnosticID::ImportResolution,
-                    SourceId(0),
                     "unable to find imported symbol `C`."
                 )
-                .with_observation(Observation::new(find_in(source, "C::*"))),
+                .with_observation(Observation::underline(SourceId(0), find_in(source, "C::*"))),
                 Diagnostic::new(
                     DiagnosticID::UnknownSymbol,
-                    SourceId(0),
                     "Could not resolve symbol `a`."
                 )
-                .with_observation(Observation::new(find_in_nth(source, "$a", 0)))
-                .with_observation(Observation::new(find_in_nth(source, "$a", 1)))
-                .with_observation(Observation::new(find_in_nth(source, "$a", 2))),
+                .with_observation(Observation::underline(SourceId(0), find_in_nth(source, "$a", 0)))
+                .with_observation(Observation::underline(SourceId(0), find_in_nth(source, "$a", 1)))
+                .with_observation(Observation::underline(SourceId(0), find_in_nth(source, "$a", 2))),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
-                    SourceId(0),
                     "unresolvable symbol `C` has no choice but to be ignored due to invalid import of `C`."
                 )
-                .with_observation(Observation::with_help(find_in_nth(source, "B::C", 0), "invalid import introduced here"))
-                    .with_observation(Observation::new(find_in(source, "$C"))),
+                .with_observation(Observation::context(SourceId(0), find_in_nth(source, "B::C", 0), "invalid import introduced here"))
+                    .with_observation(Observation::underline(SourceId(0), find_in(source, "$C"))),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
-                    SourceId(0),
                     "unresolvable symbol `B` has no choice but to be ignored due to invalid import of `B`."
                 )
-                    .with_observation(Observation::with_help(find_in_nth(source, "A::B", 0), "invalid import introduced here"))
-                    .with_observation(Observation::new(find_in(source, "$B"))),
+                    .with_observation(Observation::context(SourceId(0), find_in_nth(source, "A::B", 0), "invalid import introduced here"))
+                    .with_observation(Observation::underline(SourceId(0), find_in(source, "$B"))),
             ]
         )
     }
@@ -834,21 +848,28 @@ mod tests {
         assert_eq!(
             diagnostic,
             vec![
-                Diagnostic::new(
-                    DiagnosticID::UnknownSymbol,
-                    SourceId(0),
-                    "Could not resolve symbol `C`."
-                )
-                .with_observation(Observation::new(find_in_nth(source, "$C", 0)))
-                .with_observation(Observation::new(find_in_nth(source, "$C", 1))),
-                Diagnostic::new(
-                    DiagnosticID::UnknownSymbol,
-                    SourceId(0),
-                    "Could not resolve symbol `a`."
-                )
-                .with_observation(Observation::new(find_in_nth(source, "$a", 0)))
-                .with_observation(Observation::new(find_in_nth(source, "$a", 1)))
-                .with_observation(Observation::new(find_in_nth(source, "$a", 2))),
+                Diagnostic::new(DiagnosticID::UnknownSymbol, "Could not resolve symbol `C`.")
+                    .with_observation(Observation::underline(
+                        SourceId(0),
+                        find_in_nth(source, "$C", 0)
+                    ))
+                    .with_observation(Observation::underline(
+                        SourceId(0),
+                        find_in_nth(source, "$C", 1)
+                    )),
+                Diagnostic::new(DiagnosticID::UnknownSymbol, "Could not resolve symbol `a`.")
+                    .with_observation(Observation::underline(
+                        SourceId(0),
+                        find_in_nth(source, "$a", 0)
+                    ))
+                    .with_observation(Observation::underline(
+                        SourceId(0),
+                        find_in_nth(source, "$a", 1)
+                    ))
+                    .with_observation(Observation::underline(
+                        SourceId(0),
+                        find_in_nth(source, "$a", 2)
+                    )),
             ]
         )
     }
@@ -893,21 +914,25 @@ mod tests {
         assert_eq!(
             diagnostic,
             vec![
-                Diagnostic::new(
-                    DiagnosticID::UnknownSymbol,
-                    SourceId(1),
-                    "Could not resolve symbol `C`.",
-                )
-                .with_observation(Observation::new(find_in(source, "$C")))
-                .with_observation(Observation::new(find_in_nth(source, "$C", 1))),
-                Diagnostic::new(
-                    DiagnosticID::UnknownSymbol,
-                    SourceId(1),
-                    "Could not resolve symbol `a`.",
-                )
-                .with_observation(Observation::new(find_in_nth(source, "$a", 0)))
-                .with_observation(Observation::new(find_in_nth(source, "$a", 1)))
-                .with_observation(Observation::new(find_in_nth(source, "$a", 2))),
+                Diagnostic::new(DiagnosticID::UnknownSymbol, "Could not resolve symbol `C`.",)
+                    .with_observation(Observation::underline(SourceId(1), find_in(source, "$C")))
+                    .with_observation(Observation::underline(
+                        SourceId(1),
+                        find_in_nth(source, "$C", 1)
+                    )),
+                Diagnostic::new(DiagnosticID::UnknownSymbol, "Could not resolve symbol `a`.",)
+                    .with_observation(Observation::underline(
+                        SourceId(1),
+                        find_in_nth(source, "$a", 0)
+                    ))
+                    .with_observation(Observation::underline(
+                        SourceId(1),
+                        find_in_nth(source, "$a", 1)
+                    ))
+                    .with_observation(Observation::underline(
+                        SourceId(1),
+                        find_in_nth(source, "$a", 2)
+                    )),
             ]
         )
     }

--- a/analyzer/src/steps/resolve.rs
+++ b/analyzer/src/steps/resolve.rs
@@ -396,10 +396,7 @@ mod tests {
                 DiagnosticID::ImportResolution,
                 "unable to find imported symbol `foo` in module `std`.",
             )
-            .with_observation(Observation::underline(
-                SourceId(0),
-                find_in(test_src, "foo")
-            ))]
+            .with_observation((SourceId(0), find_in(test_src, "foo")).into())]
         );
 
         assert_eq!(
@@ -661,63 +658,39 @@ mod tests {
                     DiagnosticID::InvalidSymbol,
                     "`foo` is a function which cannot export any inner symbols"
                 )
-                .with_observation(Observation::underline(
-                    SourceId(0),
-                    find_in(test_src, "foo::x()")
-                ))
+                .with_observation((SourceId(0), find_in(test_src, "foo::x()")).into())
                 .with_help("`x` is an invalid symbol in function `foo`"),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
                     "`foo` is a function which cannot export any inner symbols"
                 )
-                .with_observation(Observation::underline(
-                    SourceId(0),
-                    find_in(test_src, "foo::y::z()")
-                ))
+                .with_observation((SourceId(0), find_in(test_src, "foo::y::z()")).into())
                 .with_help("`y::z` is an invalid symbol in function `foo`"),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
                     "`foo` is a function which cannot export any inner symbols"
                 )
-                .with_observation(Observation::underline(
-                    SourceId(0),
-                    find_in_nth(test_src, "foo::y::z()", 1)
-                ))
+                .with_observation((SourceId(0), find_in_nth(test_src, "foo::y::z()", 1)).into())
                 .with_help("`y::z` is an invalid symbol in function `foo`"),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
                     "`foz` is a function which cannot export any inner symbols"
                 )
-                .with_observation(Observation::underline(
-                    SourceId(2),
-                    find_in_nth(test_src, "foz::x()", 1)
-                ))
+                .with_observation((SourceId(2), find_in_nth(test_src, "foz::x()", 1)).into())
                 .with_help("`x` is an invalid symbol in function `foz`"),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
                     "`foo` is a function which cannot export any inner symbols",
                 )
-                .with_observation(Observation::underline(
-                    SourceId(2),
-                    find_in_nth(test_src, "foo::y::z()", 2)
-                ))
-                .with_observation(Observation::underline(
-                    SourceId(2),
-                    find_in_nth(test_src, "foo::y::z()", 3)
-                ))
-                .with_observation(Observation::underline(
-                    SourceId(2),
-                    find_in_nth(test_src, "foo::y::z()", 4)
-                ))
+                .with_observation((SourceId(2), find_in_nth(test_src, "foo::y::z()", 2)).into())
+                .with_observation((SourceId(2), find_in_nth(test_src, "foo::y::z()", 3)).into())
+                .with_observation((SourceId(2), find_in_nth(test_src, "foo::y::z()", 4)).into())
                 .with_help("`y::z` is an invalid symbol in function `foo`"),
                 Diagnostic::new(
                     DiagnosticID::UnknownSymbol,
                     "Could not resolve symbol `a::foo::in_local`."
                 )
-                .with_observation(Observation::underline(
-                    SourceId(3),
-                    find_in(test_src, "a::foo::in_local()")
-                )),
+                .with_observation((SourceId(3), find_in(test_src, "a::foo::in_local()")).into()),
             ]
         );
 
@@ -776,36 +749,36 @@ mod tests {
                     DiagnosticID::ImportResolution,
                     "unable to find imported symbol `B` in module `A`.",
                 )
-                .with_observation(Observation::underline(SourceId(0), find_in(source, "A::B"))),
+                .with_observation((SourceId(0), find_in(source, "A::B")).into()),
                 Diagnostic::new(
                     DiagnosticID::ImportResolution,
                     "unable to find imported symbol `B::C`."
                 )
-                .with_observation(Observation::underline(SourceId(0), find_in(source, "B::C"))),
+                .with_observation((SourceId(0), find_in(source, "B::C")).into()),
                 Diagnostic::new(
                     DiagnosticID::ImportResolution,
                     "unable to find imported symbol `C`."
                 )
-                .with_observation(Observation::underline(SourceId(0), find_in(source, "C::*"))),
+                .with_observation((SourceId(0), find_in(source, "C::*")).into()),
                 Diagnostic::new(
                     DiagnosticID::UnknownSymbol,
                     "Could not resolve symbol `a`."
                 )
-                .with_observation(Observation::underline(SourceId(0), find_in_nth(source, "$a", 0)))
-                .with_observation(Observation::underline(SourceId(0), find_in_nth(source, "$a", 1)))
-                .with_observation(Observation::underline(SourceId(0), find_in_nth(source, "$a", 2))),
+                .with_observation((SourceId(0), find_in_nth(source, "$a", 0)).into())
+                .with_observation((SourceId(0), find_in_nth(source, "$a", 1)).into())
+                .with_observation((SourceId(0), find_in_nth(source, "$a", 2)).into()),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
                     "unresolvable symbol `C` has no choice but to be ignored due to invalid import of `C`."
                 )
                 .with_observation(Observation::context(SourceId(0), find_in_nth(source, "B::C", 0), "invalid import introduced here"))
-                    .with_observation(Observation::underline(SourceId(0), find_in(source, "$C"))),
+                    .with_observation((SourceId(0), find_in(source, "$C")).into()),
                 Diagnostic::new(
                     DiagnosticID::InvalidSymbol,
                     "unresolvable symbol `B` has no choice but to be ignored due to invalid import of `B`."
                 )
                     .with_observation(Observation::context(SourceId(0), find_in_nth(source, "A::B", 0), "invalid import introduced here"))
-                    .with_observation(Observation::underline(SourceId(0), find_in(source, "$B"))),
+                    .with_observation((SourceId(0), find_in(source, "$B")).into()),
             ]
         )
     }
@@ -849,27 +822,12 @@ mod tests {
             diagnostic,
             vec![
                 Diagnostic::new(DiagnosticID::UnknownSymbol, "Could not resolve symbol `C`.")
-                    .with_observation(Observation::underline(
-                        SourceId(0),
-                        find_in_nth(source, "$C", 0)
-                    ))
-                    .with_observation(Observation::underline(
-                        SourceId(0),
-                        find_in_nth(source, "$C", 1)
-                    )),
+                    .with_observation((SourceId(0), find_in_nth(source, "$C", 0)).into())
+                    .with_observation((SourceId(0), find_in_nth(source, "$C", 1)).into()),
                 Diagnostic::new(DiagnosticID::UnknownSymbol, "Could not resolve symbol `a`.")
-                    .with_observation(Observation::underline(
-                        SourceId(0),
-                        find_in_nth(source, "$a", 0)
-                    ))
-                    .with_observation(Observation::underline(
-                        SourceId(0),
-                        find_in_nth(source, "$a", 1)
-                    ))
-                    .with_observation(Observation::underline(
-                        SourceId(0),
-                        find_in_nth(source, "$a", 2)
-                    )),
+                    .with_observation((SourceId(0), find_in_nth(source, "$a", 0)).into())
+                    .with_observation((SourceId(0), find_in_nth(source, "$a", 1)).into())
+                    .with_observation((SourceId(0), find_in_nth(source, "$a", 2)).into()),
             ]
         )
     }
@@ -915,24 +873,12 @@ mod tests {
             diagnostic,
             vec![
                 Diagnostic::new(DiagnosticID::UnknownSymbol, "Could not resolve symbol `C`.",)
-                    .with_observation(Observation::underline(SourceId(1), find_in(source, "$C")))
-                    .with_observation(Observation::underline(
-                        SourceId(1),
-                        find_in_nth(source, "$C", 1)
-                    )),
+                    .with_observation((SourceId(1), find_in(source, "$C")).into())
+                    .with_observation((SourceId(1), find_in_nth(source, "$C", 1)).into()),
                 Diagnostic::new(DiagnosticID::UnknownSymbol, "Could not resolve symbol `a`.",)
-                    .with_observation(Observation::underline(
-                        SourceId(1),
-                        find_in_nth(source, "$a", 0)
-                    ))
-                    .with_observation(Observation::underline(
-                        SourceId(1),
-                        find_in_nth(source, "$a", 1)
-                    ))
-                    .with_observation(Observation::underline(
-                        SourceId(1),
-                        find_in_nth(source, "$a", 2)
-                    )),
+                    .with_observation((SourceId(1), find_in_nth(source, "$a", 0)).into())
+                    .with_observation((SourceId(1), find_in_nth(source, "$a", 1)).into())
+                    .with_observation((SourceId(1), find_in_nth(source, "$a", 2)).into()),
             ]
         )
     }

--- a/analyzer/src/steps/resolve/diagnostics.rs
+++ b/analyzer/src/steps/resolve/diagnostics.rs
@@ -30,13 +30,14 @@ pub fn diagnose_invalid_symbol_from_dead_import(
 
     let mut segments: Vec<_> = segments
         .iter()
-        .map(|seg| Observation::new(seg.clone()))
+        .map(|seg| Observation::underline(env_id, seg.clone()))
         .collect();
 
-    segments.sort_by_key(|s| s.segment.start);
+    segments.sort_by_key(|s| s.location.segment.start);
 
-    Diagnostic::new(DiagnosticID::InvalidSymbol, env_id, msg)
-        .with_observation(Observation::with_help(
+    Diagnostic::new(DiagnosticID::InvalidSymbol, msg)
+        .with_observation(Observation::here(
+            env_id,
             invalid_import_seg,
             "invalid import introduced here",
         ))
@@ -54,7 +55,6 @@ pub fn diagnose_unresolved_external_symbols(
 ) -> Diagnostic {
     let diagnostic = Diagnostic::new(
         DiagnosticID::UnknownSymbol,
-        env_id,
         format!("Could not resolve symbol `{name}`."),
     );
 
@@ -64,10 +64,10 @@ pub fn diagnose_unresolved_external_symbols(
             Symbol::Local(_) => false,
             Symbol::External(g) => *g == relation,
         })
-        .map(|(seg, _)| Observation::new(seg.clone()))
+        .map(|(seg, _)| Observation::underline(env_id, seg.clone()))
         .collect();
 
-    observations.sort_by_key(|s| s.segment.start);
+    observations.sort_by_key(|s| s.location.segment.start);
     diagnostic.with_observations(observations)
 }
 
@@ -90,6 +90,6 @@ pub fn diagnose_unresolved_import(
             .unwrap_or_default()
     );
 
-    Diagnostic::new(DiagnosticID::ImportResolution, env_id, msg)
-        .with_observation(Observation::new(dependent_segment))
+    Diagnostic::new(DiagnosticID::ImportResolution, msg)
+        .with_observation(Observation::underline(env_id, dependent_segment))
 }

--- a/analyzer/src/steps/resolve/diagnostics.rs
+++ b/analyzer/src/steps/resolve/diagnostics.rs
@@ -28,9 +28,9 @@ pub fn diagnose_invalid_symbol_from_dead_import(
         .get_import_segment(name_root)
         .expect("unknown import");
 
-    let mut segments: Vec<_> = segments
+    let mut segments: Vec<Observation> = segments
         .iter()
-        .map(|seg| Observation::underline(env_id, seg.clone()))
+        .map(|seg| (env_id, seg.clone()).into())
         .collect();
 
     segments.sort_by_key(|s| s.location.segment.start);
@@ -58,13 +58,13 @@ pub fn diagnose_unresolved_external_symbols(
         format!("Could not resolve symbol `{name}`."),
     );
 
-    let mut observations: Vec<_> = env
+    let mut observations: Vec<Observation> = env
         .list_definitions()
         .filter(|(_, sym)| match sym {
             Symbol::Local(_) => false,
             Symbol::External(g) => *g == relation,
         })
-        .map(|(seg, _)| Observation::underline(env_id, seg.clone()))
+        .map(|(seg, _)| (env_id, seg.clone()).into())
         .collect();
 
     observations.sort_by_key(|s| s.location.segment.start);
@@ -91,5 +91,5 @@ pub fn diagnose_unresolved_import(
     );
 
     Diagnostic::new(DiagnosticID::ImportResolution, msg)
-        .with_observation(Observation::underline(env_id, dependent_segment))
+        .with_observation((env_id, dependent_segment).into())
 }

--- a/analyzer/src/steps/shared_diagnostics.rs
+++ b/analyzer/src/steps/shared_diagnostics.rs
@@ -2,7 +2,7 @@
 
 use context::source::SourceSegment;
 
-use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
+use crate::diagnostic::{Diagnostic, DiagnosticID, Observation, SourceLocation};
 use crate::environment::variables::TypeInfo;
 use crate::name::Name;
 use crate::relations::SourceId;
@@ -20,11 +20,11 @@ pub fn diagnose_invalid_symbol(
 
     let mut observations: Vec<_> = segments
         .iter()
-        .map(|seg| Observation::new(seg.clone()))
+        .map(|seg| Observation::new(SourceLocation::new(env_id, seg.clone())))
         .collect();
-    observations.sort_by_key(|s| s.segment.start);
+    observations.sort_by_key(|s| s.location.segment.start);
 
-    Diagnostic::new(DiagnosticID::InvalidSymbol, env_id, msg)
+    Diagnostic::new(DiagnosticID::InvalidSymbol, msg)
         .with_observations(observations)
         .with_help(format!(
             "`{}` is an invalid symbol in {base_type_name} `{name_root}`",

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -405,24 +405,23 @@ fn ascribe_block(
     state: TypingState,
 ) -> TypedExpr {
     let mut expressions = Vec::with_capacity(block.expressions.len());
-    if let Some((last, exprs)) = block.expressions.split_last() {
-        for expr in exprs {
-            expressions.push(ascribe_types(
-                exploration,
-                relations,
-                diagnostics,
-                env,
-                expr,
-                state.without_local_type(),
-            ));
-        }
+    let mut it = block
+        .expressions
+        .iter()
+        .filter(|expr| !matches!(expr, Expr::Use(_)))
+        .peekable();
+    while let Some(expr) = it.next() {
         expressions.push(ascribe_types(
             exploration,
             relations,
             diagnostics,
             env,
-            last,
-            state,
+            expr,
+            if it.peek().is_some() {
+                state.without_local_type()
+            } else {
+                state
+            },
         ));
     }
     let ty = expressions.last().map_or(UNIT, |expr| expr.ty);

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -120,8 +120,9 @@ fn apply_types_to_source(
     exploration.prepare();
     match expr {
         Expr::FunctionDeclaration(func) => {
+            let attached_env = env.parent.unwrap_or(source_id);
             for param in &func.parameters {
-                let param = type_parameter(&exploration.ctx, param);
+                let param = type_parameter(&exploration.ctx, param, attached_env);
                 exploration.ctx.push_local_type(state.source, param.ty);
             }
             let typed_expr = ascribe_types(
@@ -137,7 +138,7 @@ fn apply_types_to_source(
                 typed_expr,
                 func.parameters
                     .iter()
-                    .map(|param| type_parameter(&exploration.ctx, param))
+                    .map(|param| type_parameter(&exploration.ctx, param, attached_env))
                     .collect(),
                 return_type,
             )
@@ -248,13 +249,13 @@ fn ascribe_assign(
         diagnostics.push(
             Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                state.source,
                 format!(
                     "Named object `{}` cannot be assigned like a variable",
                     assign.name
                 ),
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                state.source,
                 assign.segment(),
                 "Assignment happens here",
             )),
@@ -280,14 +281,14 @@ fn ascribe_assign(
             diagnostics.push(
                 Diagnostic::new(
                     DiagnosticID::TypeMismatch,
-                    state.source,
                     format!(
                         "Cannot assign a value of type `{}` to something of type `{}`",
                         exploration.get_type(rhs_type).unwrap(),
                         exploration.get_type(var_ty).unwrap()
                     ),
                 )
-                .with_observation(Observation::with_help(
+                .with_observation(Observation::here(
+                    state.source,
                     assign.segment(),
                     "Assignment happens here",
                 )),
@@ -304,13 +305,13 @@ fn ascribe_assign(
         diagnostics.push(
             Diagnostic::new(
                 DiagnosticID::CannotReassign,
-                state.source,
                 format!(
                     "Cannot assign twice to immutable variable `{}`",
                     assign.name
                 ),
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                state.source,
                 assign.segment(),
                 "Assignment happens here",
             )),
@@ -477,7 +478,7 @@ fn ascribe_function_declaration(
     let parameters = fun
         .parameters
         .iter()
-        .map(|param| type_parameter(&exploration.ctx, param))
+        .map(|param| type_parameter(&exploration.ctx, param, source))
         .collect::<Vec<_>>();
     let return_type = fun
         .return_type
@@ -525,20 +526,17 @@ fn ascribe_binary(
         Some(method) => method.return_type,
         _ => {
             diagnostics.push(
-                Diagnostic::new(
-                    DiagnosticID::UnknownMethod,
-                    state.source,
-                    "Undefined operator",
-                )
-                .with_observation(Observation::with_help(
-                    bin.segment(),
-                    format!(
-                        "No operator `{}` between type `{}` and `{}`",
-                        name,
-                        exploration.get_type(left_expr.ty).unwrap(),
-                        exploration.get_type(right_expr.ty).unwrap()
-                    ),
-                )),
+                Diagnostic::new(DiagnosticID::UnknownMethod, "Undefined operator")
+                    .with_observation(Observation::here(
+                        state.source,
+                        bin.segment(),
+                        format!(
+                            "No operator `{}` between type `{}` and `{}`",
+                            name,
+                            exploration.get_type(left_expr.ty).unwrap(),
+                            exploration.get_type(right_expr.ty).unwrap()
+                        ),
+                    )),
             );
             ERROR
         }
@@ -583,14 +581,14 @@ fn ascribe_casted(
         diagnostics.push(
             Diagnostic::new(
                 DiagnosticID::IncompatibleCast,
-                state.source,
                 format!(
                     "Casting `{}` as `{}` is invalid",
                     exploration.get_type(expr.ty).unwrap(),
                     exploration.get_type(ty).unwrap()
                 ),
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                state.source,
                 casted.segment(),
                 "Incompatible cast",
             )),
@@ -645,18 +643,16 @@ fn ascribe_not(
         },
         Err(expr) => {
             diagnostics.push(
-                Diagnostic::new(
-                    DiagnosticID::TypeMismatch,
-                    state.source,
-                    "Cannot invert type",
-                )
-                .with_observation(Observation::with_help(
-                    not.segment(),
-                    format!(
-                        "Cannot invert non-boolean type `{}`",
-                        exploration.get_type(expr.ty).unwrap()
+                Diagnostic::new(DiagnosticID::TypeMismatch, "Cannot invert type").with_observation(
+                    Observation::here(
+                        state.source,
+                        not.segment(),
+                        format!(
+                            "Cannot invert non-boolean type `{}`",
+                            exploration.get_type(expr.ty).unwrap()
+                        ),
                     ),
-                )),
+                ),
             );
             expr
         }
@@ -724,15 +720,16 @@ fn ascribe_if(
             Err(_) => {
                 let mut diagnostic = Diagnostic::new(
                     DiagnosticID::TypeMismatch,
-                    state.source,
                     "`if` and `else` have incompatible types",
                 )
-                .with_observation(Observation::with_help(
+                .with_observation(Observation::here(
+                    state.source,
                     block.success_branch.segment(),
                     format!("Found `{}`", exploration.get_type(then.ty).unwrap()),
                 ));
                 if let Some(otherwise) = &otherwise {
-                    diagnostic = diagnostic.with_observation(Observation::with_help(
+                    diagnostic = diagnostic.with_observation(Observation::here(
+                        state.source,
                         otherwise.segment(),
                         format!("Found `{}`", exploration.get_type(otherwise.ty).unwrap()),
                     ));
@@ -907,10 +904,9 @@ fn ascribe_continue_or_break(
         diagnostics.push(
             Diagnostic::new(
                 DiagnosticID::InvalidBreakOrContinue,
-                source,
                 format!("`{kind_name}` must be declared inside a loop"),
             )
-            .with_observation(Observation::new(expr.segment())),
+            .with_observation(Observation::underline(source, expr.segment())),
         );
     }
     TypedExpr {
@@ -1065,14 +1061,15 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Type mismatch",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::context(
+                SourceId(0),
                 find_in(content, "Int"),
                 "Expected `Int`",
             ))
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "1.6"),
                 "Found `Float`",
             ))])
@@ -1087,10 +1084,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::UnknownType,
-                SourceId(0),
                 "Unknown type annotation",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "ABC"),
                 "Not found in scope",
             ))])
@@ -1111,10 +1108,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::CannotReassign,
-                SourceId(0),
                 "Cannot assign twice to immutable variable `l`",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "l = 2"),
                 "Assignment happens here",
             ))])
@@ -1129,10 +1126,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Cannot assign a value of type `String` to something of type `Int`",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "p = 'a'"),
                 "Assignment happens here",
             ))])
@@ -1147,10 +1144,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Cannot assign a value of type `Int` to something of type `String`",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "str = 4"),
                 "Assignment happens here",
             ))])
@@ -1165,10 +1162,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Named object `a` cannot be assigned like a variable",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "a = 'a'"),
                 "Assignment happens here",
             ))])
@@ -1195,14 +1192,15 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "`if` and `else` have incompatible types",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "4.7"),
                 "Found `Float`",
             ))
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "{}"),
                 "Found `Unit`",
             ))])
@@ -1217,10 +1215,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::UnknownType,
-                SourceId(0),
                 "Unknown type annotation",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "Imaginary"),
                 "Not found in scope",
             ))])
@@ -1235,10 +1233,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::IncompatibleCast,
-                SourceId(0),
                 "Casting `String` as `Int` is invalid",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "'a' as Int"),
                 "Incompatible cast",
             ))])
@@ -1272,10 +1270,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "This function takes 1 argument but 2 were supplied",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "square(9, 9)"),
                 "Function is called here",
             ))])
@@ -1290,14 +1288,15 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Type mismatch",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "4"),
                 "Expected `String`, found `Int`",
             ))
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::context(
+                SourceId(0),
                 find_in(content, "str: String"),
                 "Parameter is declared here",
             ))]),
@@ -1312,10 +1311,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Cannot invoke non function type",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "test()"),
                 "Call expression requires function, found `Int`",
             ))])
@@ -1330,14 +1329,15 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(1),
                 "Type mismatch",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::context(
+                SourceId(1),
                 find_in(content, "Int"),
                 "Expected `Int`",
             ))
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(1),
                 find_in(content, "$a"),
                 "Found `String`",
             ))])
@@ -1368,11 +1368,15 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(1),
                 "Type mismatch",
             )
-            .with_observation(Observation::with_help(find_in(content, "0"), "Found `Int`"))
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(1),
+                find_in(content, "0"),
+                "Found `Int`"
+            ))
+            .with_observation(Observation::context(
+                SourceId(1),
                 find_in(content, "String"),
                 "Expected `String` because of return type",
             ))])
@@ -1402,16 +1406,20 @@ mod tests {
             Err(vec![
                 Diagnostic::new(
                     DiagnosticID::InvalidBreakOrContinue,
-                    SourceId(0),
                     "`continue` must be declared inside a loop"
                 )
-                .with_observation(Observation::new(find_in(content, "continue"))),
+                .with_observation(Observation::underline(
+                    SourceId(0),
+                    find_in(content, "continue")
+                )),
                 Diagnostic::new(
                     DiagnosticID::InvalidBreakOrContinue,
-                    SourceId(0),
                     "`break` must be declared inside a loop"
                 )
-                .with_observation(Observation::new(find_in(content, "break")))
+                .with_observation(Observation::underline(
+                    SourceId(0),
+                    find_in(content, "break")
+                ))
             ])
         );
     }
@@ -1427,21 +1435,27 @@ mod tests {
     fn explicit_invalid_return() {
         let content = "fun some() -> String = {if true; return {}; 9}";
         let res = extract_type(Source::unknown(content));
-        let return_observation = Observation::with_help(
+        let return_observation = Observation::context(
+            SourceId(1),
             find_in(content, "String"),
             "Expected `String` because of return type",
         );
         assert_eq!(
             res,
             Err(vec![
-                Diagnostic::new(DiagnosticID::TypeMismatch, SourceId(1), "Type mismatch")
-                    .with_observation(Observation::with_help(
+                Diagnostic::new(DiagnosticID::TypeMismatch, "Type mismatch")
+                    .with_observation(Observation::here(
+                        SourceId(1),
                         find_in(content, "return {}"),
                         "Found `Unit`",
                     ))
                     .with_observation(return_observation.clone()),
-                Diagnostic::new(DiagnosticID::TypeMismatch, SourceId(1), "Type mismatch")
-                    .with_observation(Observation::with_help(find_in(content, "9"), "Found `Int`"))
+                Diagnostic::new(DiagnosticID::TypeMismatch, "Type mismatch")
+                    .with_observation(Observation::here(
+                        SourceId(1),
+                        find_in(content, "9"),
+                        "Found `Int`"
+                    ))
                     .with_observation(return_observation),
             ])
         );
@@ -1455,13 +1469,13 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::CannotInfer,
-                SourceId(1),
                 "Return type inference is not supported yet",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(1),
                 find_in(content, "fun test(n: Float) = "),
                 "No return type is specified",
-            ),)
+            ))
             .with_help("Add -> Float to the function declaration")])
         );
     }
@@ -1474,14 +1488,15 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::CannotInfer,
-                SourceId(1),
                 "Return type is not inferred for block functions",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(1),
                 find_in(content, "return 0"),
                 "Returning `Int`",
             ))
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(1),
                 find_in(content, "$n"),
                 "Returning `Float`",
             ))
@@ -1499,10 +1514,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::CannotInfer,
-                SourceId(1),
                 "Failed to infer return type",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(1),
                 find_in(content, "fun test() = if false; return 5; else {}"),
                 "This function returns multiple types",
             ))
@@ -1611,10 +1626,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::UnknownMethod,
-                SourceId(0),
                 "Undefined operator",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "4 / 'a'"),
                 "No operator `div` between type `Int` and `String`"
             ))]),
@@ -1629,10 +1644,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::UnknownMethod,
-                SourceId(0),
                 "Undefined operator",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "'operator' - 2.4"),
                 "No operator `sub` between type `String` and `Float`"
             ))]),
@@ -1661,10 +1676,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "This method takes 0 arguments but 1 was supplied",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, ".len(5)"),
                 "Method is called here"
             ))
@@ -1680,14 +1695,15 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Type mismatch",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "'a'"),
                 "Expected `Float`, found `String`"
             ))
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::context(
+                SourceId(0),
                 find_in(content, ".sub('a')"),
                 "Arguments to this method are incorrect"
             ))])
@@ -1702,10 +1718,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Cannot stringify type `Unit`",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "$v"),
                 "No method `to_string` on type `Unit`"
             ))])
@@ -1720,10 +1736,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Condition must be a boolean",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "9.9"),
                 "Type `Float` cannot be used as a condition"
             ))])
@@ -1738,10 +1754,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::UnknownMethod,
-                SourceId(0),
                 "Undefined operator",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "9.9 % 3.3"),
                 "No operator `mod` between type `Float` and `Float`"
             ))])
@@ -1775,10 +1791,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::TypeMismatch,
-                SourceId(0),
                 "Cannot invert type",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "!$s"),
                 "Cannot invert non-boolean type `String`"
             ))])
@@ -1793,10 +1809,10 @@ mod tests {
             res,
             Err(vec![Diagnostic::new(
                 DiagnosticID::UnknownMethod,
-                SourceId(0),
                 "Undefined operator",
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                SourceId(0),
                 find_in(content, "'text' % 9"),
                 "No operator `mod` between type `String` and `Int`"
             ))])

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -906,7 +906,7 @@ fn ascribe_continue_or_break(
                 DiagnosticID::InvalidBreakOrContinue,
                 format!("`{kind_name}` must be declared inside a loop"),
             )
-            .with_observation(Observation::underline(source, expr.segment())),
+            .with_observation((source, expr.segment()).into()),
         );
     }
     TypedExpr {
@@ -1408,18 +1408,12 @@ mod tests {
                     DiagnosticID::InvalidBreakOrContinue,
                     "`continue` must be declared inside a loop"
                 )
-                .with_observation(Observation::underline(
-                    SourceId(0),
-                    find_in(content, "continue")
-                )),
+                .with_observation((SourceId(0), find_in(content, "continue")).into()),
                 Diagnostic::new(
                     DiagnosticID::InvalidBreakOrContinue,
                     "`break` must be declared inside a loop"
                 )
-                .with_observation(Observation::underline(
-                    SourceId(0),
-                    find_in(content, "break")
-                ))
+                .with_observation((SourceId(0), find_in(content, "break")).into())
             ])
         );
     }

--- a/analyzer/src/steps/typing/coercion.rs
+++ b/analyzer/src/steps/typing/coercion.rs
@@ -40,15 +40,17 @@ pub(super) fn check_type_annotation(
     )
     .unwrap_or_else(|value| {
         diagnostics.push(
-            Diagnostic::new(DiagnosticID::TypeMismatch, state.source, "Type mismatch")
-                .with_observation(Observation::with_help(
+            Diagnostic::new(DiagnosticID::TypeMismatch, "Type mismatch")
+                .with_observation(Observation::here(
+                    state.source,
                     type_annotation.segment(),
                     format!(
                         "Expected `{}`",
                         exploration.get_type(expected_type).unwrap()
                     ),
                 ))
-                .with_observation(Observation::with_help(
+                .with_observation(Observation::here(
+                    state.source,
                     value.segment(),
                     format!("Found `{}`", exploration.get_type(value.ty).unwrap()),
                 )),
@@ -109,18 +111,15 @@ pub(super) fn coerce_condition(
         Ok(condition) => condition,
         Err(condition) => {
             diagnostics.push(
-                Diagnostic::new(
-                    DiagnosticID::TypeMismatch,
-                    state.source,
-                    "Condition must be a boolean",
-                )
-                .with_observation(Observation::with_help(
-                    condition.segment(),
-                    format!(
-                        "Type `{}` cannot be used as a condition",
-                        exploration.get_type(condition.ty).unwrap()
-                    ),
-                )),
+                Diagnostic::new(DiagnosticID::TypeMismatch, "Condition must be a boolean")
+                    .with_observation(Observation::here(
+                        state.source,
+                        condition.segment(),
+                        format!(
+                            "Type `{}` cannot be used as a condition",
+                            exploration.get_type(condition.ty).unwrap()
+                        ),
+                    )),
             );
             condition
         }

--- a/analyzer/src/steps/typing/exploration.rs
+++ b/analyzer/src/steps/typing/exploration.rs
@@ -29,6 +29,6 @@ impl Exploration {
 
 /// Generates a diagnostic for an unknown type annotation.
 pub(super) fn diagnose_unknown_type(source: SourceId, segment: SourceSegment) -> Diagnostic {
-    Diagnostic::new(DiagnosticID::UnknownType, source, "Unknown type annotation")
-        .with_observation(Observation::with_help(segment, "Not found in scope"))
+    Diagnostic::new(DiagnosticID::UnknownType, "Unknown type annotation")
+        .with_observation(Observation::here(source, segment, "Not found in scope"))
 }

--- a/analyzer/src/steps/typing/function.rs
+++ b/analyzer/src/steps/typing/function.rs
@@ -317,10 +317,7 @@ pub(super) fn type_method<'a>(
                     )
                 },
             )
-            .with_observation(Observation::underline(
-                state.source,
-                method_call.segment.clone(),
-            )),
+            .with_observation((state.source, method_call.segment.clone()).into()),
         );
         return None;
     }

--- a/analyzer/src/steps/typing/function.rs
+++ b/analyzer/src/steps/typing/function.rs
@@ -1,12 +1,11 @@
-use std::fmt;
-use std::fmt::Display;
+use std::fmt::{self, Display};
 
 use ast::call::{MethodCall, ProgrammaticCall};
 use ast::function::{FunctionDeclaration, FunctionParameter};
 use ast::Expr;
 use context::source::{SourceSegment, SourceSegmentHolder};
 
-use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
+use crate::diagnostic::{Diagnostic, DiagnosticID, Observation, SourceLocation};
 use crate::relations::{Definition, Relations, SourceId, Symbol};
 use crate::steps::typing::coercion::convert_expression;
 use crate::steps::typing::exploration::Exploration;
@@ -74,15 +73,12 @@ pub(super) fn infer_return(
             .unwrap_or(ERROR);
         if type_annotation == ERROR {
             diagnostics.push(
-                Diagnostic::new(
-                    DiagnosticID::UnknownType,
-                    state.source,
-                    "Unknown type annotation",
-                )
-                .with_observation(Observation::with_help(
-                    return_type_annotation.segment(),
-                    "Not found in scope",
-                )),
+                Diagnostic::new(DiagnosticID::UnknownType, "Unknown type annotation")
+                    .with_observation(Observation::here(
+                        state.source,
+                        return_type_annotation.segment(),
+                        "Not found in scope",
+                    )),
             );
         } else {
             for ret in &exploration.returns {
@@ -92,12 +88,14 @@ pub(super) fn infer_return(
                     .is_err()
                 {
                     diagnostics.push(
-                        Diagnostic::new(DiagnosticID::TypeMismatch, state.source, "Type mismatch")
-                            .with_observation(Observation::with_help(
+                        Diagnostic::new(DiagnosticID::TypeMismatch, "Type mismatch")
+                            .with_observation(Observation::here(
+                                state.source,
                                 ret.segment.clone(),
                                 format!("Found `{}`", exploration.get_type(ret.ty).unwrap()),
                             ))
-                            .with_observation(Observation::with_help(
+                            .with_observation(Observation::here(
+                                state.source,
                                 return_type_annotation.segment(),
                                 format!(
                                     "Expected `{}` because of return type",
@@ -121,29 +119,29 @@ pub(super) fn infer_return(
                 diagnostics.push(
                     Diagnostic::new(
                         DiagnosticID::CannotInfer,
-                        state.source,
                         "Return type inference is not supported yet",
                     )
-                    .with_observation(Observation::with_help(
+                    .with_observation(Observation::here(
+                        state.source,
                         segment,
                         "No return type is specified",
                     ))
-                    .with_help("Add -> Float to the function declaration"),
+                    .with_help(format!(
+                        "Add -> {} to the function declaration",
+                        exploration.get_type(ty).unwrap()
+                    )),
                 );
                 ty
             }
             Err(_) => {
                 diagnostics.push(
-                    Diagnostic::new(
-                        DiagnosticID::CannotInfer,
-                        state.source,
-                        "Failed to infer return type",
-                    )
-                    .with_observation(Observation::with_help(
-                        func.segment(),
-                        "This function returns multiple types".to_string(),
-                    ))
-                    .with_help("Try adding an explicit return type to the function"),
+                    Diagnostic::new(DiagnosticID::CannotInfer, "Failed to infer return type")
+                        .with_observation(Observation::here(
+                            state.source,
+                            func.segment(),
+                            "This function returns multiple types".to_string(),
+                        ))
+                        .with_help("Try adding an explicit return type to the function"),
                 );
                 ERROR
             }
@@ -152,7 +150,8 @@ pub(super) fn infer_return(
         // Explain if there is any return that this function will not be inferred
         let mut observations = Vec::new();
         for ret in &exploration.returns {
-            observations.push(Observation::with_help(
+            observations.push(Observation::here(
+                state.source,
                 ret.segment.clone(),
                 format!("Returning `{}`", exploration.get_type(ret.ty).unwrap()),
             ));
@@ -161,7 +160,6 @@ pub(super) fn infer_return(
             diagnostics.push(
                 Diagnostic::new(
                     DiagnosticID::CannotInfer,
-                    state.source,
                     "Return type is not inferred for block functions",
                 )
                 .with_observations(observations)
@@ -197,7 +195,6 @@ pub(super) fn type_call(
                 diagnostics.push(
                     Diagnostic::new(
                         DiagnosticID::TypeMismatch,
-                        state.source,
                         format!(
                             "This function takes {} {} but {} {} supplied",
                             parameters.len(),
@@ -206,7 +203,8 @@ pub(super) fn type_call(
                             pluralize(arguments.len(), "was", "were"),
                         ),
                     )
-                    .with_observation(Observation::with_help(
+                    .with_observation(Observation::here(
+                        state.source,
                         call.segment.clone(),
                         "Function is called here",
                     )),
@@ -252,10 +250,10 @@ pub(super) fn type_call(
             diagnostics.push(
                 Diagnostic::new(
                     DiagnosticID::TypeMismatch,
-                    state.source,
                     "Cannot invoke non function type",
                 )
-                .with_observation(Observation::with_help(
+                .with_observation(Observation::here(
+                    state.source,
                     call.segment(),
                     format!("Call expression requires function, found `{ty}`"),
                 )),
@@ -304,21 +302,26 @@ pub(super) fn type_method<'a>(
     let method_name = method_call.name.unwrap_or("apply");
     let methods = exploration.engine.get_methods(callee.ty, method_name);
     if methods.is_none() {
-        diagnostics.push(Diagnostic::new(
-            DiagnosticID::UnknownMethod,
-            state.source,
-            if method_call.name.is_some() {
-                format!(
-                    "No method named `{method_name}` found for type `{}`",
-                    exploration.get_type(callee.ty).unwrap()
-                )
-            } else {
-                format!(
-                    "Type `{}` is not directly callable",
-                    exploration.get_type(callee.ty).unwrap()
-                )
-            },
-        ));
+        diagnostics.push(
+            Diagnostic::new(
+                DiagnosticID::UnknownMethod,
+                if method_call.name.is_some() {
+                    format!(
+                        "No method named `{method_name}` found for type `{}`",
+                        exploration.get_type(callee.ty).unwrap()
+                    )
+                } else {
+                    format!(
+                        "Type `{}` is not directly callable",
+                        exploration.get_type(callee.ty).unwrap()
+                    )
+                },
+            )
+            .with_observation(Observation::underline(
+                state.source,
+                method_call.segment.clone(),
+            )),
+        );
         return None;
     }
 
@@ -337,7 +340,6 @@ pub(super) fn type_method<'a>(
             diagnostics.push(
                 Diagnostic::new(
                     DiagnosticID::TypeMismatch,
-                    state.source,
                     format!(
                         "This method takes {} {} but {} {} supplied",
                         method.parameters.len(),
@@ -346,7 +348,8 @@ pub(super) fn type_method<'a>(
                         pluralize(arguments.len(), "was", "were")
                     ),
                 )
-                .with_observation(Observation::with_help(
+                .with_observation(Observation::here(
+                    state.source,
                     method_call.segment(),
                     "Method is called here",
                 ))
@@ -365,7 +368,8 @@ pub(super) fn type_method<'a>(
                 {
                     let diagnostic =
                         diagnose_arg_mismatch(&exploration.typing, state.source, param, arg)
-                            .with_observation(Observation::with_help(
+                            .with_observation(Observation::here(
+                                state.source,
                                 method_call.segment(),
                                 "Arguments to this method are incorrect",
                             ));
@@ -378,13 +382,13 @@ pub(super) fn type_method<'a>(
         diagnostics.push(
             Diagnostic::new(
                 DiagnosticID::UnknownMethod,
-                state.source,
                 format!(
                     "No matching method found for `{method_name}::{}`",
                     exploration.get_type(callee.ty).unwrap()
                 ),
             )
-            .with_observation(Observation::with_help(
+            .with_observation(Observation::here(
+                state.source,
                 method_call.segment(),
                 "Method is called here",
             )),
@@ -400,18 +404,21 @@ fn diagnose_arg_mismatch(
     param: &Parameter,
     arg: &TypedExpr,
 ) -> Diagnostic {
-    let diagnostic = Diagnostic::new(DiagnosticID::TypeMismatch, source, "Type mismatch")
-        .with_observation(Observation::with_help(
+    let diagnostic = Diagnostic::new(DiagnosticID::TypeMismatch, "Type mismatch").with_observation(
+        Observation::here(
+            source,
             arg.segment.clone(),
             format!(
                 "Expected `{}`, found `{}`",
                 typing.get_type(param.ty).unwrap(),
                 typing.get_type(arg.ty).unwrap()
             ),
-        ));
-    if let Some(decl) = &param.segment {
-        diagnostic.with_observation(Observation::with_help(
-            decl.clone(),
+        ),
+    );
+    if let Some(location) = &param.location {
+        diagnostic.with_observation(Observation::context(
+            location.source,
+            location.segment.clone(),
             "Parameter is declared here",
         ))
     } else {
@@ -440,7 +447,11 @@ fn find_exact_method<'a>(methods: &'a [MethodType], args: &[TypedExpr]) -> Optio
 }
 
 /// Type check a single function parameter.
-pub(crate) fn type_parameter(ctx: &TypeContext, param: &FunctionParameter) -> Parameter {
+pub(crate) fn type_parameter(
+    ctx: &TypeContext,
+    param: &FunctionParameter,
+    source: SourceId,
+) -> Parameter {
     match param {
         FunctionParameter::Named(named) => {
             let type_id = named
@@ -448,7 +459,7 @@ pub(crate) fn type_parameter(ctx: &TypeContext, param: &FunctionParameter) -> Pa
                 .as_ref()
                 .map_or(STRING, |ty| ctx.resolve(ty).unwrap_or(ERROR));
             Parameter {
-                segment: Some(named.segment.clone()),
+                location: Some(SourceLocation::new(source, named.segment.clone())),
                 ty: type_id,
             }
         }

--- a/analyzer/src/steps/typing/lower.rs
+++ b/analyzer/src/steps/typing/lower.rs
@@ -66,7 +66,7 @@ pub(super) fn call_convert_on(
                         typing.get_type(into).unwrap()
                     ),
                 )
-                .with_observation(Observation::underline(state.source, expr.segment())),
+                .with_observation((state.source, expr.segment()).into()),
             );
             return expr;
         }

--- a/analyzer/src/steps/typing/lower.rs
+++ b/analyzer/src/steps/typing/lower.rs
@@ -61,13 +61,12 @@ pub(super) fn call_convert_on(
             diagnostics.push(
                 Diagnostic::new(
                     DiagnosticID::UnknownMethod,
-                    state.source,
                     format!(
                         "No conversion method defined for type `{}`",
                         typing.get_type(into).unwrap()
                     ),
                 )
-                .with_observation(Observation::new(expr.segment())),
+                .with_observation(Observation::underline(state.source, expr.segment())),
             );
             return expr;
         }
@@ -89,8 +88,9 @@ pub(super) fn call_convert_on(
 
     let ty = typing.get_type(expr.ty).unwrap();
     diagnostics.push(
-        Diagnostic::new(DiagnosticID::TypeMismatch, state.source, message(ty)).with_observation(
-            Observation::with_help(
+        Diagnostic::new(DiagnosticID::TypeMismatch, message(ty)).with_observation(
+            Observation::here(
+                state.source,
                 expr.segment(),
                 format!("No method `{method_name}` on type `{ty}`"),
             ),

--- a/analyzer/src/types/ty.rs
+++ b/analyzer/src/types/ty.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 use std::fmt::Display;
 
-use context::source::SourceSegment;
-
+use crate::diagnostic::SourceLocation;
 use crate::relations::{Definition, NativeId};
 use crate::types::hir::TypeId;
 
@@ -69,7 +68,7 @@ pub struct FunctionType {
 /// A function parameter.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Parameter {
-    pub(crate) segment: Option<SourceSegment>,
+    pub(crate) location: Option<SourceLocation>,
     pub ty: TypeId,
 }
 
@@ -108,7 +107,7 @@ impl FunctionType {
         Self {
             parameters: parameters
                 .into_iter()
-                .map(|ty| Parameter { segment: None, ty })
+                .map(|ty| Parameter { location: None, ty })
                 .collect(),
             return_type,
             definition: Definition::Native(id),

--- a/cli/build.rs
+++ b/cli/build.rs
@@ -1,5 +1,6 @@
-use cmake::Config;
 use std::env;
+
+use cmake::Config;
 
 fn main() {
     let dst = Config::new("../vm").build();

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -66,16 +66,11 @@ pub fn resolve_and_execute<'a>(
         }
     }
 
-    let mut stdout = stderr();
+    let mut stderr = stderr();
     let had_errors = !diagnostics.is_empty();
     for diagnostic in diagnostics {
-        let content_id = result
-            .engine
-            .get_original_content(diagnostic.source)
-            .expect("Unknown source");
-        let source = importer.get_source(content_id).expect("Unknown source");
-        display_diagnostic(source, diagnostic, &mut stdout)
-            .expect("IO errors when reporting diagnostic")
+        display_diagnostic(&result.engine, importer, diagnostic, &mut stderr)
+            .expect("IO errors when reporting diagnostic");
     }
     had_errors
 }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -64,9 +64,11 @@ pub fn resolve_and_execute<'a>(
     let mut stdout = stderr();
     let had_errors = !diagnostics.is_empty();
     for diagnostic in diagnostics {
-        let source = importer
-            .get_source(diagnostic.source)
+        let content_id = result
+            .engine
+            .get_original_content(diagnostic.source)
             .expect("Unknown source");
+        let source = importer.get_source(content_id).expect("Unknown source");
         display_diagnostic(source, diagnostic, &mut stdout)
             .expect("IO errors when reporting diagnostic")
     }

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -27,9 +27,14 @@ pub fn resolve_and_execute<'a>(
     entry_point: Name,
     importer: &mut (impl ASTImporter<'a> + ErrorReporter),
 ) -> bool {
-    let result = resolve_all(entry_point, importer);
+    let result = resolve_all(entry_point.clone(), importer);
 
     let errors = importer.take_errors();
+    if errors.is_empty() && result.engine.is_empty() {
+        eprintln!("No module found for entry point {entry_point}");
+        return true;
+    }
+
     let has_errors = !errors.is_empty();
     for error in errors {
         match error {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,18 +1,19 @@
 #![allow(dead_code)]
 
 use std::io;
-use std::ops::Deref;
 use std::process::exit;
 
 use clap::Parser;
 use miette::MietteHandlerOpts;
 
-use context::source::Source;
+use analyzer::name::Name;
 
-use crate::cli::{handle_source, Cli};
+use crate::cli::{Cli, resolve_and_execute};
+use crate::pipeline::FileImporter;
 use crate::repl::prompt;
 
 mod cli;
+mod pipeline;
 mod repl;
 mod report;
 
@@ -24,12 +25,17 @@ fn main() -> io::Result<()> {
     }))
     .expect("miette options setup");
 
+    let mut importer = FileImporter::new(std::env::current_dir()?);
     if let Some(source) = cli.source {
-        let content = std::fs::read_to_string(&source)?;
-        let name = source.to_string_lossy().deref().to_string();
-        let source = Source::new(&content, &name);
-        exit(handle_source(source) as i32)
+        let name = Name::new(
+            source
+                .file_name()
+                .and_then(|name| name.to_str())
+                .expect("Incompatible filename"),
+        );
+        let has_error = resolve_and_execute(name, &mut importer);
+        exit(i32::from(has_error))
     }
-    prompt();
+    prompt(importer);
     Ok(())
 }

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -1,0 +1,135 @@
+use std::fs::read_to_string;
+use std::io;
+use std::path::{MAIN_SEPARATOR_STR, PathBuf};
+
+use analyzer::importer::{ASTImporter, ImportError};
+use analyzer::name::Name;
+use analyzer::relations::SourceId;
+use ast::Expr;
+use ast::group::Block;
+use context::source::{OwnedSource, Source, SourceSegmentHolder};
+use parser::err::ParseError;
+use parser::parse;
+
+/// A collection of parse errors that are bound to a unique source.
+pub struct SourceAwareParseErrors {
+    /// The source identifier from which the errors were generated.
+    pub source: SourceId,
+
+    /// The generated errors.
+    pub errors: Vec<ParseError>,
+}
+
+/// A failure that occurred while importing a source with a [`FileImporter`].
+pub enum FileImportError {
+    /// An IO error occurred while reading the source.
+    IO(io::Error),
+
+    /// Some parse errors occurred after reading the source.
+    Parse(SourceAwareParseErrors),
+}
+
+/// An importer that imports sources from the file system.
+pub struct FileImporter {
+    /// The root directory from which the files are read.
+    root: PathBuf,
+
+    /// The imported sources, as an importer is the owner of the sources.
+    sources: Vec<OwnedSource>,
+
+    /// The errors that occurred while importing the sources.
+    ///
+    /// They contains the specific errors that were masked when using the
+    /// [`ASTImporter`] trait.
+    errors: Vec<FileImportError>,
+}
+
+impl FileImporter {
+    /// Creates a new file importer that will import sources from the given
+    /// root directory.
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root,
+            sources: Vec::new(),
+            errors: Vec::new(),
+        }
+    }
+
+    /// Inserts a new source into the importer.
+    pub fn insert<'a>(&mut self, source: OwnedSource) -> Result<Option<Expr<'a>>, ImportError> {
+        let id = self.sources.len();
+        self.sources.push(source);
+        let source = self
+            .sources
+            .last()
+            .expect("the source was just inserted")
+            .as_source();
+        let report = parse(source);
+        if report.is_ok() {
+            let expressions = unsafe {
+                // SAFETY: A source is owned by the importer and is never removed.
+                // A Source is the reference version to the Strings inside the OwnedSource,
+                // so if the OwnedSource moves, the strings are still valid.
+                // 'a is used here to disambiguate the lifetime of the source and the mutable borrow.
+                std::mem::transmute::<Vec<Expr>, Vec<Expr<'a>>>(report.expr)
+            };
+            Ok(Some(Expr::Block(Block {
+                expressions,
+                segment: source.segment(),
+            })))
+        } else {
+            self.errors
+                .push(FileImportError::Parse(SourceAwareParseErrors {
+                    source: SourceId(id),
+                    errors: report.errors,
+                }));
+            Err(ImportError)
+        }
+    }
+}
+
+impl<'a> ASTImporter<'a> for FileImporter {
+    fn import(&mut self, name: &Name) -> Result<Option<Expr<'a>>, ImportError> {
+        let mut path = self.root.clone();
+        path.push(name.parts().to_owned().join(MAIN_SEPARATOR_STR));
+        path = path.with_extension("msh");
+        match read_to_string(&path) {
+            Ok(content) => self.insert(OwnedSource::new(
+                content,
+                path.strip_prefix(&self.root)
+                    .expect("not relative")
+                    .display()
+                    .to_string(),
+            )),
+            Err(err) => {
+                if err.kind() == io::ErrorKind::NotFound {
+                    Ok(None)
+                } else {
+                    self.errors.push(FileImportError::IO(err));
+                    Err(ImportError)
+                }
+            }
+        }
+    }
+}
+
+/// A trait to access errors and to get sources from an importer.
+pub trait ErrorReporter {
+    /// Takes the errors from the importer.
+    ///
+    /// This leaves the importer in a state where it has no errors.
+    fn take_errors(&mut self) -> Vec<FileImportError>;
+
+    /// Gets a source from the importer.
+    fn get_source(&self, id: SourceId) -> Option<Source>;
+}
+
+impl ErrorReporter for FileImporter {
+    fn take_errors(&mut self) -> Vec<FileImportError> {
+        std::mem::take(&mut self.errors)
+    }
+
+    fn get_source(&self, id: SourceId) -> Option<Source> {
+        self.sources.get(id.0).map(|s| s.as_source())
+    }
+}

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -4,17 +4,16 @@ use std::path::{MAIN_SEPARATOR_STR, PathBuf};
 
 use analyzer::importer::{ASTImporter, ImportError};
 use analyzer::name::Name;
-use analyzer::relations::SourceId;
 use ast::Expr;
 use ast::group::Block;
-use context::source::{OwnedSource, Source, SourceSegmentHolder};
+use context::source::{ContentId, OwnedSource, Source, SourceSegmentHolder};
 use parser::err::ParseError;
 use parser::parse;
 
 /// A collection of parse errors that are bound to a unique source.
 pub struct SourceAwareParseErrors {
     /// The source identifier from which the errors were generated.
-    pub source: SourceId,
+    pub source: ContentId,
 
     /// The generated errors.
     pub errors: Vec<ParseError>,
@@ -80,7 +79,7 @@ impl FileImporter {
         } else {
             self.errors
                 .push(FileImportError::Parse(SourceAwareParseErrors {
-                    source: SourceId(id),
+                    source: ContentId(id),
                     errors: report.errors,
                 }));
             Err(ImportError)
@@ -121,7 +120,7 @@ pub trait ErrorReporter {
     fn take_errors(&mut self) -> Vec<FileImportError>;
 
     /// Gets a source from the importer.
-    fn get_source(&self, id: SourceId) -> Option<Source>;
+    fn get_source(&self, id: ContentId) -> Option<Source>;
 }
 
 impl ErrorReporter for FileImporter {
@@ -129,7 +128,7 @@ impl ErrorReporter for FileImporter {
         std::mem::take(&mut self.errors)
     }
 
-    fn get_source(&self, id: SourceId) -> Option<Source> {
+    fn get_source(&self, id: ContentId) -> Option<Source> {
         self.sources.get(id.0).map(|s| s.as_source())
     }
 }

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -4,9 +4,8 @@ use std::io::Write;
 
 use analyzer::importer::{ASTImporter, ImportError};
 use analyzer::name::Name;
-use analyzer::relations::SourceId;
 use ast::Expr;
-use context::source::{OwnedSource, Source};
+use context::source::{ContentId, OwnedSource, Source};
 use parser::parse;
 
 use crate::cli::resolve_and_execute;
@@ -50,7 +49,7 @@ impl ErrorReporter for InputImporter {
         self.files.take_errors()
     }
 
-    fn get_source(&self, id: SourceId) -> Option<Source> {
+    fn get_source(&self, id: ContentId) -> Option<Source> {
         self.files.get_source(id)
     }
 }

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -2,13 +2,13 @@ use std::io;
 use std::io::BufRead;
 use std::io::Write;
 
-use analyzer::importer::{ASTImporter, Imported, ImportError};
+use analyzer::importer::{ASTImporter, ImportError, Imported};
 use analyzer::name::Name;
 use context::source::{ContentId, OwnedSource, Source};
 use parser::parse;
 
 use crate::cli::resolve_and_execute;
-use crate::pipeline::{ErrorReporter, FileImporter, FileImportError};
+use crate::pipeline::{ErrorReporter, FileImportError, FileImporter};
 use crate::report::print_flush;
 
 /// A wrapper around a [`FileImporter`] that short-circuits the file system for

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -2,7 +2,7 @@ use std::io;
 use std::io::BufRead;
 use std::io::Write;
 
-use analyzer::importer::{ASTImporter, ImportError, Imported};
+use analyzer::importer::{ASTImporter, ImportResult};
 use analyzer::name::Name;
 use context::source::{ContentId, OwnedSource, Source};
 use parser::parse;
@@ -35,7 +35,7 @@ impl InputImporter {
 }
 
 impl<'a> ASTImporter<'a> for InputImporter {
-    fn import(&mut self, name: &Name) -> Result<Option<Imported<'a>>, ImportError> {
+    fn import(&mut self, name: &Name) -> ImportResult<'a> {
         match self.last.take() {
             Some(last) => self.files.insert(last),
             None => self.files.import(name),

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -2,9 +2,8 @@ use std::io;
 use std::io::BufRead;
 use std::io::Write;
 
-use analyzer::importer::{ASTImporter, ImportError};
+use analyzer::importer::{ASTImporter, Imported, ImportError};
 use analyzer::name::Name;
-use ast::Expr;
 use context::source::{ContentId, OwnedSource, Source};
 use parser::parse;
 
@@ -36,7 +35,7 @@ impl InputImporter {
 }
 
 impl<'a> ASTImporter<'a> for InputImporter {
-    fn import(&mut self, name: &Name) -> Result<Option<Expr<'a>>, ImportError> {
+    fn import(&mut self, name: &Name) -> Result<Option<Imported<'a>>, ImportError> {
         match self.last.take() {
             Some(last) => self.files.insert(last),
             None => self.files.import(name),

--- a/cli/src/report.rs
+++ b/cli/src/report.rs
@@ -1,11 +1,13 @@
 use std::io;
 use std::io::Write;
 
-use analyzer::engine::Engine;
 use miette::{LabeledSpan, MietteDiagnostic, Report, Severity, SourceSpan};
 
+use analyzer::engine::Engine;
 use context::source::{ContentId, Source, SourceSegment};
 use parser::err::{ParseError, ParseErrorKind};
+
+use crate::pipeline::ErrorReporter;
 
 macro_rules! print_flush {
     ( $($t:tt)* ) => {
@@ -17,7 +19,6 @@ macro_rules! print_flush {
     }
 }
 
-use crate::pipeline::ErrorReporter;
 pub(crate) use print_flush;
 
 fn offset_empty_span(span: SourceSegment) -> SourceSpan {
@@ -102,7 +103,7 @@ pub fn display_diagnostic<W: Write>(
         {
             let source = importer.get_source(content_id).expect("Unknown source");
             let span = obs.location.segment.clone();
-            diag = diag.and_label(LabeledSpan::new(obs.label, span.start, span.len()));
+            diag = diag.and_label(LabeledSpan::new(obs.message, span.start, span.len()));
             displayed_source = Some(AttachedSource {
                 id: content_id,
                 content: source,

--- a/context/src/source.rs
+++ b/context/src/source.rs
@@ -5,6 +5,10 @@ use miette::{MietteError, MietteSpanContents, SourceCode, SourceSpan, SpanConten
 
 pub type SourceSegment = std::ops::Range<usize>;
 
+/// An identifier to a source code.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ContentId(pub usize);
+
 pub trait SourceSegmentHolder {
     fn segment(&self) -> SourceSegment;
 }


### PR DESCRIPTION
The analyzer has the ability to import multiple sources, but was not implemented for real files.

Importing files
===============

This PR distinguishes three possible outputs if fetching a source from a `Name` fails:

- The source doesn't exist, but a parent may exist. In this case, return `Ok(None)`, to continue trying importing a similar `Name`.
- The source do exist, but is not usable. This might be due to file permissions or to a parsing error. In that case, return `Err(ImportError)` to stop the resolution here.
- The source is intelligible, return `Ok(Some(_))`.

The command line interface is now able to read files and display parse errors that could errors. This can be done either using the `-s <file>` option or in the REPL (still not able to remember previously executed lines).

A file importer looks for in the current working directory for files that ends with the `.msh` extension, but may have exceptions to load direct paths that do not follow this convention.

Mapping diagnostics to the appropriate source code
==================================================

Diagnostics are related to sources, that do not correlate with the ID attributed to the imported files. A single source file may be splitted into multiple `SourceId`s, shifting every index to the right. To get back to the original source code from a `SourceId`, something needed to keep track of the `ContentId` of the source. Since the engine held the origins, it now also remember the original source the expression came from.

Originally, it was up to the `Diagnostic` struct to have the source. Because a single diagnostic can now refer to even different files, it became clear that it is to each `Observation` to store the `SourceId`. While updating all the constructor usages, this PR tries to get on track to differentiate *erroneous* locations from *context* locations in observations.