### PR TITLE
Handle function captures

### DIFF
--- a/analyzer/src/dependency.rs
+++ b/analyzer/src/dependency.rs
@@ -70,6 +70,9 @@ where
             }
         }
     }
+    //FIXME: supposed to be distinct but the current implementation can contain
+    // duplicates in some complex cyclic cases
+    sorted.dedup();
     sorted
 }
 

--- a/analyzer/src/engine.rs
+++ b/analyzer/src/engine.rs
@@ -50,12 +50,13 @@ impl<'a> Engine<'a> {
     }
 
     /// Attaches an environment to an origin if the origin does not already have an attached environment.
-    pub fn attach(&mut self, id: SourceId, env: Environment) {
+    pub fn attach(&mut self, id: SourceId, env: Environment) -> &mut Environment {
         debug_assert!(
             self.origins[id.0].2.is_none(),
             "Could not attach environment to a source that is already attached"
         );
         self.origins[id.0].2.replace(env);
+        self.origins[id.0].2.as_mut().unwrap()
     }
 
     ///Finds an environment by its fully qualified name.
@@ -74,6 +75,13 @@ impl<'a> Engine<'a> {
     /// Gets an environment by its identifier.
     pub fn get_environment(&self, id: SourceId) -> Option<&Environment> {
         self.origins.get(id.0).and_then(|(_, _, env)| env.as_ref())
+    }
+
+    /// Gets an environment by its identifier.
+    pub fn get_environment_mut(&mut self, id: SourceId) -> Option<&mut Environment> {
+        self.origins
+            .get_mut(id.0)
+            .and_then(|(_, _, env)| env.as_mut())
     }
 
     /// Gets the number of origins in the engine.

--- a/analyzer/src/environment/variables.rs
+++ b/analyzer/src/environment/variables.rs
@@ -1,5 +1,5 @@
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use indexmap::map::Entry;
+use indexmap::IndexMap;
 use std::fmt::{Display, Formatter};
 
 use crate::name::Name;
@@ -31,7 +31,7 @@ pub struct Variables {
 
     /// Relations with external variables.
     /// The key is the variable Names, where value is the relation with another external environment's [Locals]
-    externals: HashMap<Name, RelationId>,
+    externals: IndexMap<Name, RelationId>,
 }
 
 impl Variables {
@@ -79,6 +79,15 @@ impl Variables {
     /// or [`Variables::find_exported`] to lookup an exported variable after the collection phase.
     pub fn all_vars(&self) -> &[Variable] {
         &self.locals.vars
+    }
+
+    /// returns an iterator over all variables, with their local identifier
+    pub fn iter(&self) -> impl Iterator<Item = (LocalId, &Variable)> {
+        self.locals
+            .vars
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (LocalId(i), v))
     }
 
     /// Iterates over all the exported variables, local to the environment.

--- a/analyzer/src/types/hir.rs
+++ b/analyzer/src/types/hir.rs
@@ -2,12 +2,18 @@ use ast::call::{RedirFd, RedirOp};
 use ast::value::LiteralValue;
 use context::source::{SourceSegment, SourceSegmentHolder};
 
-use crate::relations::{Definition, LocalId, ObjectId, Symbol};
+use crate::relations::{Definition, LocalId, ObjectId, ResolvedSymbol};
 use crate::types::{ERROR, NOTHING};
 
 /// A type identifier in a [`Typing`] instance.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TypeId(pub ObjectId);
+
+#[derive(Clone, Copy, Debug, PartialEq, Hash, Eq)]
+pub enum Var {
+    Local(LocalId),
+    Capture(ResolvedSymbol),
+}
 
 impl TypeId {
     pub fn is_nothing(self) -> bool {
@@ -43,7 +49,7 @@ impl SourceSegmentHolder for TypedExpr {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct Assignment {
-    pub identifier: Symbol,
+    pub identifier: Var,
     pub rhs: Box<TypedExpr>,
 }
 
@@ -104,7 +110,7 @@ pub enum ExprKind {
     Literal(LiteralValue),
     Assign(Assignment),
     Declare(Declaration),
-    Reference(Symbol),
+    Reference(Var),
     Block(Vec<TypedExpr>),
     Redirect(Redirect),
     Conditional(Conditional),

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -82,10 +82,10 @@ pub fn resolve_and_execute<'a>(
 
     let mut diagnostics = result.diagnostics;
     if diagnostics.is_empty() {
-        let (types, typing) = apply_types(&result.engine, &result.relations, &mut diagnostics);
+        let (types, _) = apply_types(&result.engine, &result.relations, &mut diagnostics);
         if diagnostics.is_empty() {
             let mut bytes = Vec::new();
-            compile(&types, &result.engine, &typing, &mut bytes).expect("write failed");
+            compile(&types, &result.engine, &result.relations, &mut bytes).expect("write failed");
 
             if config.disassemble {
                 display_bytecode(&bytes);

--- a/cli/src/disassemble.rs
+++ b/cli/src/disassemble.rs
@@ -69,25 +69,18 @@ fn display_function(cursor: &mut Cursor<&[u8]>, constants: &[String]) -> io::Res
             Opcode::PushInt => print!("<value {}>", read!(cursor, i64)),
             Opcode::PushByte => print!("<value {}>", read!(cursor, u8)),
             Opcode::PushFloat => print!("<value {}>", read!(cursor, f64)),
-            Opcode::PushString => {
+            Opcode::PushConstantRef => {
                 let constant_idx = read!(cursor, u32) as usize;
                 let str = &constants[constant_idx];
                 let padding = (digits(constants.len() as u64) - digits(constant_idx as u64)) + 10;
                 print!("<constant #{constant_idx}> {:padding$} // \"{str}\"", "")
             }
+            Opcode::PushLocalRef => print!("<local @{} (length: {})>", read!(cursor, u32), read!(cursor, u16)),
             Opcode::Invoke => {
                 let constant_idx = read!(cursor, u32) as usize;
                 let str = &constants[constant_idx];
                 let padding = (digits(constants.len() as u64) - digits(constant_idx as u64)) + 10;
-                print!("<function #{constant_idx}> {:padding$} // {str}", "")
-            }
-            Opcode::GetByte
-            | Opcode::SetByte
-            | Opcode::GetQWord
-            | Opcode::SetQWord
-            | Opcode::GetRef
-            | Opcode::SetRef => {
-                print!("<local @{}>", read!(cursor, u32))
+                print!("<constant #{constant_idx}> {:padding$} // <function> {str}", "")
             }
             Opcode::Exec => print!("<arity {}>", read!(cursor, u8)),
             Opcode::Open => print!("<flags {:#x}>", read!(cursor, i32)),
@@ -124,11 +117,12 @@ pub(crate) fn display_bytecode(bytecode: &[u8]) {
 fn get_opcode_mnemonic(opcode: Opcode) -> &'static str {
     match opcode {
         Opcode::PushInt => "ipsh",
-        Opcode::PushByte => "ipsh",
+        Opcode::PushByte => "bpsh",
         Opcode::PushFloat => "fpsh",
-        Opcode::PushString => "spsh",
+        Opcode::PushConstantRef => "crpsh",
+        Opcode::PushLocalRef => "lrpsh",
         Opcode::GetByte => "bget",
-        Opcode::SetByte => "sset",
+        Opcode::SetByte => "bset",
         Opcode::GetQWord => "qwget",
         Opcode::SetQWord => "qwset",
         Opcode::GetRef => "rget",

--- a/cli/src/disassemble.rs
+++ b/cli/src/disassemble.rs
@@ -75,7 +75,7 @@ fn display_function(cursor: &mut Cursor<&[u8]>, constants: &[String]) -> io::Res
                 let padding = (digits(constants.len() as u64) - digits(constant_idx as u64)) + 10;
                 print!("<constant #{constant_idx}> {:padding$} // \"{str}\"", "")
             }
-            Opcode::PushLocalRef => print!("<local @{} (length: {})>", read!(cursor, u32), read!(cursor, u16)),
+            Opcode::PushLocalRef => print!("<local @{}>", read!(cursor, u32)),
             Opcode::Invoke => {
                 let constant_idx = read!(cursor, u32) as usize;
                 let str = &constants[constant_idx];

--- a/cli/src/disassemble.rs
+++ b/cli/src/disassemble.rs
@@ -80,7 +80,10 @@ fn display_function(cursor: &mut Cursor<&[u8]>, constants: &[String]) -> io::Res
                 let constant_idx = read!(cursor, u32) as usize;
                 let str = &constants[constant_idx];
                 let padding = (digits(constants.len() as u64) - digits(constant_idx as u64)) + 10;
-                print!("<constant #{constant_idx}> {:padding$} // <function> {str}", "")
+                print!(
+                    "<constant #{constant_idx}> {:padding$} // <function> {str}",
+                    ""
+                )
             }
             Opcode::Exec => print!("<arity {}>", read!(cursor, u8)),
             Opcode::Open => print!("<flags {:#x}>", read!(cursor, i32)),

--- a/compiler/src/bytecode.rs
+++ b/compiler/src/bytecode.rs
@@ -51,11 +51,6 @@ impl Bytecode {
         self.bytes.extend(value.to_be_bytes());
     }
 
-    /// emits an unsigned 16 bits integer
-    pub fn emit_u16(&mut self, value: u16) {
-        self.bytes.extend(value.to_be_bytes());
-    }
-
     pub fn emit_i32(&mut self, value: i32) {
         self.bytes.extend(value.to_be_bytes());
     }

--- a/compiler/src/emit/jump.rs
+++ b/compiler/src/emit/jump.rs
@@ -1,5 +1,4 @@
 use analyzer::engine::Engine;
-use analyzer::relations::Relations;
 use analyzer::types::hir::{Conditional, Loop};
 
 use crate::bytecode::{Instructions, Opcode};
@@ -13,7 +12,6 @@ pub fn emit_conditional(
     conditional: &Conditional,
     instructions: &mut Instructions,
     engine: &Engine,
-    relations: &Relations,
     cp: &mut ConstantPool,
     locals: &mut LocalsLayout,
     state: &mut EmissionState,
@@ -25,7 +23,6 @@ pub fn emit_conditional(
         &conditional.condition,
         instructions,
         engine,
-        relations,
         cp,
         locals,
         state,
@@ -40,7 +37,6 @@ pub fn emit_conditional(
         &conditional.then,
         instructions,
         engine,
-        relations,
         cp,
         locals,
         state,
@@ -53,16 +49,7 @@ pub fn emit_conditional(
     // ELSE:
     instructions.patch_jump(jump_to_else);
     if let Some(otherwise) = &conditional.otherwise {
-        emit(
-            otherwise,
-            instructions,
-            engine,
-            relations,
-            cp,
-            locals,
-            state,
-            captures,
-        );
+        emit(otherwise, instructions, engine, cp, locals, state, captures);
     }
 
     // END:
@@ -74,7 +61,6 @@ pub fn emit_loop(
     lp: &Loop,
     instructions: &mut Instructions,
     engine: &Engine,
-    relations: &Relations,
     cp: &mut ConstantPool,
     locals: &mut LocalsLayout,
     state: &mut EmissionState,
@@ -90,16 +76,7 @@ pub fn emit_loop(
         let last_used = state.use_values(true);
 
         // Evaluate the condition.
-        emit(
-            condition,
-            instructions,
-            engine,
-            relations,
-            cp,
-            locals,
-            state,
-            captures,
-        );
+        emit(condition, instructions, engine, cp, locals, state, captures);
         state.use_values(last_used);
 
         // If the condition is false, go to END.
@@ -114,7 +91,6 @@ pub fn emit_loop(
         &lp.body,
         instructions,
         engine,
-        relations,
         cp,
         locals,
         &mut loop_state,

--- a/compiler/src/emit/native.rs
+++ b/compiler/src/emit/native.rs
@@ -1,11 +1,10 @@
-use analyzer::engine::Engine;
 use analyzer::relations::NativeId;
 use analyzer::types::hir::TypedExpr;
-use analyzer::types::Typing;
 
+use crate::Analysis;
 use crate::bytecode::{Instructions, Opcode};
 use crate::constant_pool::ConstantPool;
-use crate::emit::{emit, EmissionState};
+use crate::emit::{EmissionState, emit};
 use crate::locals::LocalsLayout;
 use crate::r#type::ValueStackSize;
 
@@ -21,14 +20,13 @@ pub(crate) fn emit_natives(
     callee: &TypedExpr,
     args: &[TypedExpr],
     instructions: &mut Instructions,
-    typing: &Typing,
-    engine: &Engine,
+    analysis: &Analysis,
     cp: &mut ConstantPool,
     locals: &mut LocalsLayout,
     state: &mut EmissionState,
 ) {
     let last_used = state.use_values(true);
-    emit(callee, instructions, typing, engine, cp, locals, state);
+    emit(callee, instructions, analysis, cp, locals, state);
 
     let pushed_size = match native.0 {
         0 => {
@@ -41,8 +39,7 @@ pub(crate) fn emit_natives(
             emit(
                 args.get(0).expect("A binary expression takes two operands"),
                 instructions,
-                typing,
-                engine,
+                analysis,
                 cp,
                 locals,
                 state,
@@ -71,8 +68,7 @@ pub(crate) fn emit_natives(
             emit(
                 args.get(0).expect("A comparison takes two operands"),
                 instructions,
-                typing,
-                engine,
+                analysis,
                 cp,
                 locals,
                 state,
@@ -161,8 +157,7 @@ pub(crate) fn emit_natives(
                 args.get(0)
                     .expect("Cannot concatenate a string without a second string"),
                 instructions,
-                typing,
-                engine,
+                analysis,
                 cp,
                 locals,
                 state,

--- a/compiler/src/emit/native.rs
+++ b/compiler/src/emit/native.rs
@@ -1,5 +1,5 @@
 use analyzer::engine::Engine;
-use analyzer::relations::{NativeId, Relations};
+use analyzer::relations::NativeId;
 use analyzer::types::hir::TypedExpr;
 
 use crate::bytecode::{Instructions, Opcode};
@@ -22,23 +22,13 @@ pub(crate) fn emit_natives(
     args: &[TypedExpr],
     instructions: &mut Instructions,
     engine: &Engine,
-    relations: &Relations,
     cp: &mut ConstantPool,
     locals: &mut LocalsLayout,
     state: &mut EmissionState,
     captures: &mut Captures,
 ) {
     let last_used = state.use_values(true);
-    emit(
-        callee,
-        instructions,
-        engine,
-        relations,
-        cp,
-        locals,
-        state,
-        captures,
-    );
+    emit(callee, instructions, engine, cp, locals, state, captures);
 
     let pushed_size = match native.0 {
         0 => {
@@ -52,7 +42,6 @@ pub(crate) fn emit_natives(
                 args.get(0).expect("A binary expression takes two operands"),
                 instructions,
                 engine,
-                relations,
                 cp,
                 locals,
                 state,
@@ -83,7 +72,6 @@ pub(crate) fn emit_natives(
                 args.get(0).expect("A comparison takes two operands"),
                 instructions,
                 engine,
-                relations,
                 cp,
                 locals,
                 state,
@@ -174,7 +162,6 @@ pub(crate) fn emit_natives(
                     .expect("Cannot concatenate a string without a second string"),
                 instructions,
                 engine,
-                relations,
                 cp,
                 locals,
                 state,

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -212,7 +212,6 @@ fn compile_chunk(
         &chunk.expression,
         &mut instructions,
         engine,
-        relations,
         cp,
         &mut locals,
         &mut state,

--- a/compiler/src/locals.rs
+++ b/compiler/src/locals.rs
@@ -1,5 +1,8 @@
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
-use analyzer::relations::{LocalId, RelationId, Symbol};
+
+use analyzer::relations::{LocalId, ResolvedSymbol};
+use analyzer::types::hir::Var;
 
 use crate::r#type::ValueStackSize;
 
@@ -8,7 +11,7 @@ pub struct LocalsLayout {
     /// the start indexes of bound Locals
     values_indexes: Vec<Option<u32>>,
     /// the start indexes of bound external values
-    external_refs_indexes: HashMap<RelationId, u32>,
+    external_refs_indexes: HashMap<ResolvedSymbol, u32>,
     /// the length in bytes
     len: u32,
 }
@@ -17,7 +20,11 @@ impl LocalsLayout {
     pub fn new(var_count: usize) -> Self {
         let var_indexes = vec![None; var_count];
         let external_ref_indexes = HashMap::default();
-        Self { values_indexes: var_indexes, external_refs_indexes: external_ref_indexes, len: 0 }
+        Self {
+            values_indexes: var_indexes,
+            external_refs_indexes: external_ref_indexes,
+            len: 0,
+        }
     }
 
     /// Reserves the space in the locals depending on the stack size needed by the given type.
@@ -35,9 +42,14 @@ impl LocalsLayout {
     /// Reserves the space in the eternal's reference
     ///
     /// Different initialization orders will result in different indexes.
-    pub fn set_external_ref_space(&mut self, id: RelationId) {
-        self.external_refs_indexes.insert(id, self.len);
-        self.len += u8::from(ValueStackSize::Reference) as u32;
+    pub fn set_external_ref_space(&mut self, symbol: ResolvedSymbol) {
+        match self.external_refs_indexes.entry(symbol) {
+            Entry::Occupied(_) => {}
+            Entry::Vacant(v) => {
+                v.insert(self.len);
+                self.len += u8::from(ValueStackSize::Reference) as u32;
+            }
+        }
     }
 
     /// Get the starting byte index allocated for the given local.
@@ -46,10 +58,10 @@ impl LocalsLayout {
     ///
     /// # Panics
     /// Panics if te local id is out of bounds.
-    pub fn get_index(&self, symbol: Symbol) -> Option<u32> {
-        match symbol {
-            Symbol::Local(LocalId(id)) => self.values_indexes[id],
-            Symbol::External(id) => self.external_refs_indexes.get(&id).copied(),
+    pub fn get_index(&self, var: Var) -> Option<u32> {
+        match var {
+            Var::Local(LocalId(id)) => self.values_indexes[id],
+            Var::Capture(symbol) => self.external_refs_indexes.get(&symbol).copied(),
         }
     }
 
@@ -57,4 +69,3 @@ impl LocalsLayout {
         self.len
     }
 }
-

--- a/compiler/src/type.rs
+++ b/compiler/src/type.rs
@@ -13,7 +13,7 @@ pub fn get_type_stack_size(tpe: TypeId) -> ValueStackSize {
 }
 
 /// Different sizes a value can have on the stack.
-#[derive(Copy, Clone, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, Debug, PartialEq)]
 pub enum ValueStackSize {
     Zero,
     Byte,

--- a/vm/src/interpreter.cpp
+++ b/vm/src/interpreter.cpp
@@ -522,7 +522,7 @@ bool run_frame(runtime_state &state, stack_frame &frame, CallStack &call_stack, 
             break;
         }
         case OP_SET_Q_WORD: {
-            uint64_t *value = (uint64_t *)operands.pop_reference();
+            int64_t *value = (int64_t *)operands.pop_reference();
             *value = operands.pop_int();
             break;
         }

--- a/vm/src/interpreter.cpp
+++ b/vm/src/interpreter.cpp
@@ -22,7 +22,7 @@ enum Opcode {
     OP_PUSH_INT,          // with 8 byte int value, pushes an int onto the operand stack
     OP_PUSH_BYTE,         // with 1 byte value, pushes a byte onto the operand stack
     OP_PUSH_FLOAT,        // with 8 byte float value, pushes a float onto the operand stack
-    OP_PUSH_CONSTANT_REF, // with 8 byte string index in constant pool, pushes a string ref onto the operand stack
+    OP_PUSH_CONSTANT_REF, // with 8 byte string index in constant pool, pushes a reference to the string constant onto the operand stack
     OP_PUSH_LOCAL_REF,    // with 4 bytes locals index, pushes a reference to the locals address onto the stack
 
     OP_GET_BYTE,   // pops last reference and pushes its byte value onto the operands
@@ -33,20 +33,18 @@ enum Opcode {
     OP_SET_REF,    // pops last reference, pops a ref value then sets the reference's value with ref value
 
     OP_INVOKE,         // with 4 byte function ref string in constant pool, pops parameters from operands then pushes invoked function return in operand stack (if non-void)
-    OP_FORK,           // forks a new process, pushes the pid onto the operand stack of the parent and jumps to the given address in the
-                       // parent
+    OP_FORK,           // forks a new process, pushes the pid onto the operand stack of the parent and jumps to the given address in the parent
     OP_EXEC,           // with 1 byte for the number of arguments, pops the arguments and replaces the current program
     OP_WAIT,           // pops a pid from the operand stack and waits for it to finish
     OP_OPEN,           // opens a file with the name popped from the stack, pushes the file descriptor onto the operand stack
     OP_CLOSE,          // pops a file descriptor from the operand stack and closes the file
-    OP_SETUP_REDIRECT, // peek the fd from the operand stack, pop the source fd from the operand stack, and performs a cancelable
-    // redirection
-    OP_REDIRECT,     // duplicates the file descriptor popped from the operand stack and leave the source fd on the stack
-    OP_POP_REDIRECT, // pops a file descriptor from the operand stack and closes it
-    OP_PIPE,         // creates a pipe, pushes the read and write file descriptors onto the operand stack
-    OP_READ,         // pops a file descriptor to read all the data from, pushes the data onto the stack
-    OP_WRITE,        // pops a file descriptor to write the data to, pops the data to write from the stack
-    OP_EXIT,         // exits the current process with the popped exit code
+    OP_SETUP_REDIRECT, // peek the fd from the operand stack, pop the source fd from the operand stack, and performs a cancelable redirection
+    OP_REDIRECT,       // duplicates the file descriptor popped from the operand stack and leave the source fd on the stack
+    OP_POP_REDIRECT,   // pops a file descriptor from the operand stack and closes it
+    OP_PIPE,           // creates a pipe, pushes the read and write file descriptors onto the operand stack
+    OP_READ,           // pops a file descriptor to read all the data from, pushes the data onto the stack
+    OP_WRITE,          // pops a file descriptor to write the data to, pops the data to write from the stack
+    OP_EXIT,           // exits the current process with the popped exit code
 
     OP_DUP,        // duplicates the last value on the operand stack
     OP_DUP_BYTE,   // duplicates the last byte on the operand stack
@@ -310,10 +308,8 @@ bool run_frame(runtime_state &state, stack_frame &frame, CallStack &call_stack, 
             // Read the locals address
             int32_t local_index = ntohl(*(int32_t *)(instructions + ip));
             ip += sizeof(int32_t);
-            int16_t value_length = ntohl(*(int16_t *)(instructions + ip));
-            ip += sizeof(int16_t);
 
-            char *ref = locals.reference(local_index, value_length);
+            char *ref = &locals.reference(local_index);
 
             // Push the string index onto the stack
             operands.push_reference((uint64_t)ref);

--- a/vm/src/memory/locals.cpp
+++ b/vm/src/memory/locals.cpp
@@ -14,9 +14,9 @@ uint64_t Locals::get_ref(uint64_t at) const {
     return get<uint64_t>(at);
 }
 
-char *Locals::reference(size_t at, size_t count) {
-    check_capacity(at, count, "accessing");
-    return bytes + at;
+char &Locals::reference(size_t at) {
+    check_capacity(at, 1, "accessing");
+    return *(bytes + at);
 }
 
 void Locals::set_q_word(int64_t i, size_t at) {

--- a/vm/src/memory/locals.cpp
+++ b/vm/src/memory/locals.cpp
@@ -1,52 +1,11 @@
 #include "locals.h"
-#include <cstring>
 #include <string>
 
 Locals::Locals(char *bytes, size_t capacity) : bytes{bytes}, capacity{capacity} {}
 
-int64_t Locals::get_q_word(size_t at) const {
-    return get<int64_t>(at);
-}
-char Locals::get_byte(size_t at) const {
-    return get<char>(at);
-}
-uint64_t Locals::get_ref(uint64_t at) const {
-    return get<uint64_t>(at);
-}
-
 char &Locals::reference(size_t at) {
-    check_capacity(at, 1, "accessing");
-    return *(bytes + at);
-}
-
-void Locals::set_q_word(int64_t i, size_t at) {
-    set<int64_t>(i, at);
-}
-void Locals::set_byte(char b, size_t at) {
-    set<char>(b, at);
-}
-void Locals::set_ref(uint64_t r, size_t at) {
-    set<uint64_t>(r, at);
-}
-void Locals::set_bytes(const char *data, size_t size, size_t at) {
-    check_capacity(at, size, "updating");
-    memcpy(static_cast<void *>(bytes), data, size);
-}
-
-inline void Locals::check_capacity(size_t at, size_t space_size, std::string_view action) const {
-    if (at + space_size > capacity) {
-        throw LocalsOutOfBoundError("locals out of bound when " + std::string(action) + " value at index " + std::to_string(at));
+    if (at > capacity) {
+        throw LocalsOutOfBoundError("locals out of bound when accessing value reference at index " + std::to_string(at));
     }
-}
-
-template <typename T>
-T Locals::get(size_t at) const {
-    check_capacity(at, sizeof(T), "accessing");
-    return *(T *)(bytes + (at));
-}
-
-template <typename T>
-void Locals::set(T t, size_t at) {
-    check_capacity(at, sizeof(T), "updating");
-    *(T *)(bytes + at) = t;
+    return *(bytes + at);
 }

--- a/vm/src/memory/locals.cpp
+++ b/vm/src/memory/locals.cpp
@@ -14,6 +14,11 @@ uint64_t Locals::get_ref(uint64_t at) const {
     return get<uint64_t>(at);
 }
 
+char *Locals::reference(size_t at, size_t count) {
+    check_capacity(at, count, "accessing");
+    return bytes + at;
+}
+
 void Locals::set_q_word(int64_t i, size_t at) {
     set<int64_t>(i, at);
 }

--- a/vm/src/memory/locals.h
+++ b/vm/src/memory/locals.h
@@ -46,6 +46,8 @@ public:
      */
     uint64_t get_ref(size_t at) const;
 
+    char* reference(size_t at, size_t count);
+
     /**
      * @throws LocalsOutOfBoundError if `at` + the size of `int64_i` is out of bound
      */

--- a/vm/src/memory/locals.h
+++ b/vm/src/memory/locals.h
@@ -46,7 +46,11 @@ public:
      */
     uint64_t get_ref(size_t at) const;
 
-    char* reference(size_t at, size_t count);
+    /**
+     * returns a reference to given byte
+     * @throws LocalsOutOfBoundError if `at` is out of bound
+     * */
+    char& reference(size_t at);
 
     /**
      * @throws LocalsOutOfBoundError if `at` + the size of `int64_i` is out of bound

--- a/vm/src/memory/locals.h
+++ b/vm/src/memory/locals.h
@@ -34,55 +34,8 @@ public:
     explicit Locals(char *bytes, size_t capacity);
 
     /**
-     * @throws LocalsOutOfBoundError if `at` is out of bound
-     */
-    int64_t get_q_word(size_t at) const;
-    /**
-     * @throws LocalsOutOfBoundError if `at` is out of bound
-     */
-    char get_byte(size_t at) const;
-    /**
-     * @throws LocalsOutOfBoundError if `at` is out of bound
-     */
-    uint64_t get_ref(size_t at) const;
-
-    /**
      * returns a reference to given byte
      * @throws LocalsOutOfBoundError if `at` is out of bound
      * */
-    char& reference(size_t at);
-
-    /**
-     * @throws LocalsOutOfBoundError if `at` + the size of `int64_i` is out of bound
-     */
-    void set_q_word(int64_t i, size_t at);
-    /**
-     * @throws LocalsOutOfBoundError if `at` + the size of `char` is out of bound
-     */
-    void set_byte(char b, size_t at);
-    /**
-     * @throws LocalsOutOfBoundError if `at` + the size of `uint64_t` is out of bound
-     */
-    void set_ref(uint64_t s, size_t at);
-
-    /**
-     * copies the given data from `at` to `at + size`
-     * @throws LocalsOutOfBoundError if `at` + size is out of bound
-     */
-    void set_bytes(const char *data, size_t size, size_t at);
-
-private:
-    /**
-     * ensures that the given space can fit at given position in this reserved locals space.
-     * @param at start position
-     * @param space_size the space needed
-     * @param action kind of action being made
-     */
-    inline void check_capacity(size_t at, size_t space_size, std::string_view action) const;
-
-    template <typename T>
-    T get(size_t at) const;
-
-    template <typename T>
-    void set(T t, size_t at);
+    char &reference(size_t at);
 };


### PR DESCRIPTION
This pull request improves the notion of reference on bytecode/VM side and uses this improvement to make the compiler able to handle var captures within functions.

## Bytecode improvements
Current bytecode specification uses `OP_GET_*` and `OP_SET_*` opcodes to get/set a local value. 
With the need of accessing and updating referenced values, the `OP_GET_*` and `OP_SET_*` no longer have parameters and now pops a reference from operand stack to access and/or update a value.
Thus, the `OP_PUSH_LOCAL_REF` has been introduced and pushes on the operand stack a reference to the given local index.
The `OP_PUSH_STRING` has been refactored to `OP_PUSH_CONSTANT_REF` to match the changes.

before: 
```
val a = 5
$a
```
compiled to :
```cpp
OP_PUSH_INT 5
OP_SET_INT 0 //access local at index 0 and set value

OP_GET_INT 0 //access local at index 0 and get value
```
and now compiles to
```cpp
OP_PUSH_INT 5
OP_PUSH_LOCAL_REF 0 //push address of local 0
OP_SET_INT //pop reference, pop value and set value at reference

OP_PUSH_LOCAL_REF 0 //push address of local 0
OP_GET_INT //pop reference, push accessed value from reference.
```

## LocalsLayout
Locals indexes has been split in two parts, a Vector of indexes for locals, and a HashMap for captures, binding their `ResolvedSymbol` with their start position in the locals's area.

## Other changes
- Replaced `externals: HashMap` with `externals: IndexMap` in `Variables` in order to iterate over them in a source-dependant order.
- Replaced use of `Symbol` in HIR with a new `Var` structure that already contains the `ResolvedSymbol` in `Var::Capture` variant, which lighten the use of `relations` by the compiler. 
- 
