### PR TITLE
Automatically test the VM implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
 	"context/macros",
 	"cli",
 	"analyzer",
-	"compiler"
+	"compiler",
+	"vm"
 ]
 resolver = "2"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,12 +11,10 @@ parser = { path = "../parser" }
 analyzer = { path = "../analyzer" }
 ast = { path = "../ast" }
 compiler = { path = "../compiler" }
+vm = { path = "../vm" }
 
 miette = { version = "5.9.0", features = ["fancy"] }
 thiserror = "1.0.38"
 dbg-pls = { version = "0.3.5", features = ["pretty", "colors"] }
 clap = { version = "4.2.2", features = ["derive"] }
 libc = "0.2.147"
-
-[build-dependencies]
-cmake = "0.1.46"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -3,6 +3,11 @@ name = "cli"
 version = "0.1.0"
 edition = "2021"
 
+[[test]]
+name = "lang_tests"
+path = "lang_tests/run.rs"
+harness = false
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -18,3 +23,7 @@ thiserror = "1.0.38"
 dbg-pls = { version = "0.3.5", features = ["pretty", "colors"] }
 clap = { version = "4.2.2", features = ["derive"] }
 libc = "0.2.147"
+
+[dev-dependencies]
+lang_tester = "0.7.3"
+tempfile = "3.7.0"

--- a/cli/lang_tests/flow/break_loop.msh
+++ b/cli/lang_tests/flow/break_loop.msh
@@ -1,0 +1,8 @@
+// Run:
+//   status: success
+//   stdout:
+//     in
+//     out
+
+while true { echo 'in'; break; echo 'inner' }
+echo 'out'

--- a/cli/lang_tests/flow/function_call.msh
+++ b/cli/lang_tests/flow/function_call.msh
@@ -1,0 +1,34 @@
+// Run:
+//   status: success
+//   stdout:
+//    The square of 42 is 1764.
+//    Hello, John ! You are 42 years old.
+//    You are allowed to drink alcohol.
+//    John is at the legal age to drink alcohol.
+//    Concat result: foobar
+
+fun square(n: Int) -> Int = $n * $n
+
+val m = 42
+val n = square($m)
+echo "The square of $m is $n."
+
+fun present(name: String, is_okay: Bool, age: Int) -> Bool = {
+    echo "Hello, $name ! You are $age years old."
+    if [ $age < 18 ] {
+        echo "You are not allowed to drink alcohol."
+        return false
+    } else {
+        echo "You are allowed to drink alcohol."
+    }
+    $age >= 18
+}
+
+if present("John", true, $m) {
+    echo "John is at the legal age to drink alcohol."
+}
+
+fun concat(a: String, b: String) -> String = $a + $b
+fun foo() -> String = concat("foo", "bar")
+
+echo 'Concat result:' foo()

--- a/cli/lang_tests/redir/file_redirection.msh
+++ b/cli/lang_tests/redir/file_redirection.msh
@@ -1,0 +1,17 @@
+// Run:
+//   status: success
+//   stdout:
+//    before
+//    ls: ...
+//    after
+//    1	test-dir
+//   stderr:
+//    error
+
+echo before
+echo test-dir > working-dir
+echo error >&2
+ls /error-dont-exist &>&1
+echo after
+
+cat -n < working-dir

--- a/cli/lang_tests/redir/pipeline_exit.msh
+++ b/cli/lang_tests/redir/pipeline_exit.msh
@@ -1,0 +1,18 @@
+// Run:
+//   status: success
+//   stdout:
+//     present
+//     absent behind successful cat
+
+if echo hello | grep -q l {
+    echo 'present'
+} else {
+    echo 'absent'
+}
+
+// Checks that the last exit status do not mask the previous one.
+if echo hello | grep -q y | cat {
+    echo 'present behind successful cat'
+} else {
+    echo 'absent behind successful cat'
+}

--- a/cli/lang_tests/redir/pipeline_text.msh
+++ b/cli/lang_tests/redir/pipeline_text.msh
@@ -1,0 +1,10 @@
+// Run:
+//   status: success
+//   stdout:
+//          1	Three
+//          2	Two
+//          3	One
+
+echo 'One
+Two
+Three' | tac | cat -n

--- a/cli/lang_tests/redir/silent_sigpipe.msh
+++ b/cli/lang_tests/redir/silent_sigpipe.msh
@@ -1,0 +1,7 @@
+// Run:
+//   status: success
+//   stdout:
+//    y
+//    y
+
+yes | head -n 2

--- a/cli/lang_tests/run.rs
+++ b/cli/lang_tests/run.rs
@@ -1,0 +1,33 @@
+use lang_tester::LangTester;
+use std::{fs::read_to_string, process::Command};
+use tempfile::TempDir;
+
+const COMMENT_PREFIX: &str = "//";
+
+fn main() {
+    let tempdir = TempDir::new().unwrap();
+    LangTester::new()
+        .test_dir("lang_tests")
+        .test_file_filter(|p| p.extension().unwrap().to_str().unwrap() == "msh")
+        // Extract the first sequence of commented line(s) as the tests.
+        .test_extract(|p| {
+            read_to_string(p)
+                .unwrap()
+                .lines()
+                // Skip non-commented lines at the start of the file.
+                .skip_while(|l| !l.starts_with(COMMENT_PREFIX))
+                // Extract consecutive commented lines.
+                .take_while(|l| l.starts_with(COMMENT_PREFIX))
+                .map(|l| &l[COMMENT_PREFIX.len()..])
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .test_cmds(move |p| {
+            let mut runtime = Command::new(env!("CARGO_BIN_EXE_cli"));
+            runtime
+                .args(&["-s", p.to_str().unwrap()])
+                .current_dir(tempdir.path());
+            vec![("Run", runtime)]
+        })
+        .run();
+}

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -9,6 +9,7 @@ use analyzer::name::Name;
 use analyzer::resolve_all;
 use analyzer::steps::typing::apply_types;
 use compiler::compile;
+use vm::execute_bytecode;
 
 use crate::disassemble::display_bytecode;
 use crate::pipeline::{ErrorReporter, FileImportError};
@@ -108,17 +109,8 @@ pub fn resolve_and_execute<'a>(
     had_errors
 }
 
-#[link(name = "vm", kind = "static")]
-extern "C" {
-    /// Execute the given bytecode.
-    ///
-    /// # Safety
-    /// If the given bytecode is invalid, this function will cause undefined behavior.
-    fn moshell_exec(bytes: *const u8, byte_count: usize);
-}
-
 fn execute(bytes: &[u8]) {
     unsafe {
-        moshell_exec(bytes.as_ptr(), bytes.len());
+        execute_bytecode(bytes);
     }
 }

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "vm"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "binding/lib.rs"
+
+[[bench]]
+name = "exec_benchmark"
+harness = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+[dev-dependencies]
+criterion = "0.5.1"
+context = { path = "../context" }
+ast = { path = "../ast" }
+parser = { path = "../parser" }
+analyzer = { path = "../analyzer" }
+compiler = { path = "../compiler" }
+
+[build-dependencies]
+cmake = "0.1.50"

--- a/vm/benches/exec_benchmark.rs
+++ b/vm/benches/exec_benchmark.rs
@@ -40,27 +40,31 @@ fn prepare_bytecode(code: &str) -> Vec<u8> {
 
 fn criterion_benchmark(c: &mut Criterion) {
     let bytes = prepare_bytecode(
-        "var u = 0
-    var computing = true
-    var v = 1
-    while $computing {
-        u = $u + 1
-        v = $v + 2
-        computing = $u != 20000
-    }",
+        "
+        var u = 0
+        var computing = true
+        var v = 1
+        while $computing {
+            u = $u + 1
+            v = $v + 2
+            computing = $u != 20000
+        }
+    ",
     );
     c.bench_function("var", |b| {
         b.iter(|| unsafe { execute_bytecode(black_box(&bytes)) })
     });
 
     let bytes = prepare_bytecode(
-        "fun fibonacci(n: Int) -> Int =
+        "
+        fun fibonacci(n: Int) -> Int =
         if [ $n <= 1 ] {
             1
         } else {
             return fibonacci($n - 1) + fibonacci($n - 2)
         }
-    fibonacci(25)",
+        fibonacci(25)
+    ",
     );
     c.bench_function("fib 25", |b| {
         b.iter(|| unsafe { execute_bytecode(black_box(&bytes)) })

--- a/vm/benches/exec_benchmark.rs
+++ b/vm/benches/exec_benchmark.rs
@@ -1,0 +1,71 @@
+use analyzer::importer::{ASTImporter, ImportResult, Imported};
+use analyzer::name::Name;
+use analyzer::resolve_all;
+use analyzer::steps::typing::apply_types;
+use ast::Expr;
+use compiler::compile;
+use context::source::{ContentId, Source};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use parser::parse_trusted;
+use vm::execute_bytecode;
+
+struct SingleImporter<'a>(Option<Expr<'a>>);
+
+impl<'a> ASTImporter<'a> for SingleImporter<'a> {
+    fn import(&mut self, _name: &Name) -> ImportResult<'a> {
+        self.0
+            .take()
+            .map(|expr| Imported {
+                content: ContentId(0),
+                expr,
+            })
+            .into()
+    }
+}
+
+fn prepare_bytecode(code: &str) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let expr = parse_trusted(Source::new(code, "test"));
+    let mut resolve = resolve_all(Name::new("test"), &mut SingleImporter(Some(expr)));
+    assert_eq!(resolve.diagnostics, &[]);
+    let (engine, typing) = apply_types(
+        &resolve.engine,
+        &resolve.relations,
+        &mut resolve.diagnostics,
+    );
+    assert_eq!(resolve.diagnostics, &[]);
+    compile(&engine, &resolve.engine, &typing, &mut bytes).unwrap();
+    bytes
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let bytes = prepare_bytecode(
+        "var u = 0
+    var computing = true
+    var v = 1
+    while $computing {
+        u = $u + 1
+        v = $v + 2
+        computing = $u != 20000
+    }",
+    );
+    c.bench_function("var", |b| {
+        b.iter(|| unsafe { execute_bytecode(black_box(&bytes)) })
+    });
+
+    let bytes = prepare_bytecode(
+        "fun fibonacci(n: Int) -> Int =
+        if [ $n <= 1 ] {
+            1
+        } else {
+            return fibonacci($n - 1) + fibonacci($n - 2)
+        }
+    fibonacci(25)",
+    );
+    c.bench_function("fib 25", |b| {
+        b.iter(|| unsafe { execute_bytecode(black_box(&bytes)) })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/vm/binding/lib.rs
+++ b/vm/binding/lib.rs
@@ -1,0 +1,15 @@
+/// Executes the given bytecode.
+///
+/// The execution will block the thread until the Moshell program terminates.
+///
+/// # Safety
+/// If the given bytecode is invalid, this function can cause undefined behavior.
+/// The caller must ensure that the given bytecode is valid.
+pub unsafe fn execute_bytecode(bytes: &[u8]) {
+    moshell_exec(bytes.as_ptr(), bytes.len());
+}
+
+#[link(name = "vm", kind = "static")]
+extern "C" {
+    fn moshell_exec(bytes: *const u8, byte_count: usize);
+}

--- a/vm/build.rs
+++ b/vm/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 fn main() {
-    let mut config = cmake::Config::new("../vm");
+    let mut config = cmake::Config::new(".");
     if env::var("CARGO_TERM_COLOR").as_deref() == Ok("always") {
         config.env("CMAKE_COLOR_DIAGNOSTICS", "ON");
     }
@@ -25,8 +25,4 @@ fn main() {
             println!("cargo:warning=moshell: unconditional linking of C++ runtime on {target_os}");
         }
     }
-
-    // Hook the build script to re-run if the VM library changes.
-    println!("cargo:rerun-if-changed=../vm/CMakeLists.txt");
-    println!("cargo:rerun-if-changed=../vm/src");
 }


### PR DESCRIPTION
The VM is mostly tested manually or with primitive scripts. It's time to have a proper testing environment that directly targets the CLI binary.

This will allow playing with multiple files to testing the file importer in real conditions. For now, a few tests have been written with the [*lang_tester*](https://github.com/softdevteam/lang_tester/) crate that checks the execution output.

This PR also pull Criterion to benchmark the virtual machine performance. It has been added to a `vm` crate, that now contain the FFI code instead of the `cli` crate. The benchmarks belong to the crate directly, so compiling with the `test` profile will compile Criterion despite not being used. Benchmarks profile variable accesses and function calls.