### PR TITLE
Handle unmatched delimiters at lexer level

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,6 +12,7 @@ harness = false
 
 [dependencies]
 context = { path = "../context", features = ["miette"] }
+lexer = { path = "../lexer" }
 parser = { path = "../parser" }
 analyzer = { path = "../analyzer" }
 ast = { path = "../ast" }

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -6,8 +6,8 @@ use analyzer::importer::ImportResult;
 use analyzer::name::Name;
 use analyzer::relations::SourceId;
 use analyzer::Inject;
-use context::source::{OwnedSource, Source};
-use parser::parse;
+use context::source::OwnedSource;
+use lexer::is_unterminated;
 
 use crate::cli::{use_pipeline, Cli};
 use crate::pipeline::{FileImporter, Pipeline, PipelineStatus};
@@ -97,18 +97,13 @@ fn parse_input() -> Option<OwnedSource> {
             continue;
         }
 
-        let source = Source::new(&content, "stdin");
-        let report = parse(source);
-        if !report.stack_ended {
+        if is_unterminated(&content) {
             content.push('\n');
             print_flush!("-> ");
-            continue; // Silently ignore incomplete input
+            continue;
         }
 
-        return Some(OwnedSource::new(
-            source.source.to_string(),
-            source.name.to_string(),
-        ));
+        return Some(OwnedSource::new(content, "stdin".to_owned()));
     }
     None
 }

--- a/lexer/src/delimiter.rs
+++ b/lexer/src/delimiter.rs
@@ -1,0 +1,110 @@
+use crate::lexer::Lexer;
+use crate::token::{Token, TokenType};
+
+/// An incorrectly placed delimiter.
+///
+/// It contains the byte offset of each delimiter found.
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnmatchedDelimiter {
+    /// The opening delimiter that was recorded.
+    ///
+    /// Will be `None` if only the closing delimiter was found.
+    pub opening: Option<usize>,
+
+    /// The delimiter that is not correct.
+    ///
+    /// Can be `None` if the closing delimiter is missing.
+    pub candidate: Option<usize>,
+
+    /// The correct closing delimiter that was eventually found afterwards.
+    pub closing: Option<usize>,
+}
+
+/// An iterator over the tokens of a string.
+pub(crate) struct TokenStream<'a> {
+    /// The lexer that produces the tokens.
+    lexer: Lexer<'a>,
+
+    /// The stack of keep track of delimiter pairs.
+    pub(crate) open_delimiters: Vec<Token<'a>>,
+
+    /// The vector of unmatched delimiter errors.
+    pub(crate) mismatches: Vec<UnmatchedDelimiter>,
+}
+
+impl<'a> TokenStream<'a> {
+    pub(crate) fn new(input: &'a str) -> Self {
+        Self {
+            lexer: Lexer::new(input),
+            open_delimiters: Vec::new(),
+            mismatches: Vec::new(),
+        }
+    }
+
+    fn verify_pair(&mut self, token: Token<'a>) -> Token<'a> {
+        match token.token_type {
+            TokenType::SquaredLeftBracket
+            | TokenType::RoundedLeftBracket
+            | TokenType::CurlyLeftBracket => {
+                self.open_delimiters.push(token.clone());
+            }
+            TokenType::SquaredRightBracket
+            | TokenType::RoundedRightBracket
+            | TokenType::CurlyRightBracket => {
+                let offset = token.value.as_ptr() as usize - self.lexer.input.as_ptr() as usize;
+                if let Some(open_delimiter) = self.open_delimiters.pop() {
+                    let closing_pair = open_delimiter
+                        .token_type
+                        .closing_pair()
+                        .expect("Invalid opening delimiter passed to the stack");
+                    let open_offset =
+                        open_delimiter.value.as_ptr() as usize - self.lexer.input.as_ptr() as usize;
+                    if token.token_type == closing_pair {
+                        if let Some(last) = self.mismatches.last_mut() {
+                            if last.opening == Some(open_offset) && last.closing.is_none() {
+                                last.closing = Some(offset);
+                            }
+                        }
+                    } else {
+                        self.mismatches.push(UnmatchedDelimiter {
+                            opening: Some(open_offset),
+                            candidate: Some(offset),
+                            closing: None,
+                        });
+                        self.open_delimiters.push(open_delimiter);
+                    }
+                } else {
+                    self.mismatches.push(UnmatchedDelimiter {
+                        opening: None,
+                        candidate: Some(offset),
+                        closing: None,
+                    });
+                }
+            }
+            _ => {}
+        }
+        token
+    }
+}
+
+impl<'a> Iterator for TokenStream<'a> {
+    type Item = Token<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.lexer.next() {
+            Some(token) => Some(self.verify_pair(token)),
+            None => {
+                while let Some(open_delimiter) = self.open_delimiters.pop() {
+                    let offset =
+                        open_delimiter.value.as_ptr() as usize - self.lexer.input.as_ptr() as usize;
+                    self.mismatches.push(UnmatchedDelimiter {
+                        opening: Some(offset),
+                        candidate: None,
+                        closing: None,
+                    });
+                }
+                None
+            }
+        }
+    }
+}

--- a/lexer/src/lexer.rs
+++ b/lexer/src/lexer.rs
@@ -1,13 +1,7 @@
-#![allow(dead_code)]
-
 use std::iter::Peekable;
 use std::str::CharIndices;
 
-use crate::token::*;
-
-pub fn lex(input: &str) -> Vec<Token> {
-    Lexer::new(input).collect()
-}
+use crate::token::{Token, TokenType};
 
 /// A lexer that iterates over the input string and produces tokens.
 pub(crate) struct Lexer<'a> {
@@ -41,7 +35,7 @@ impl<'a> Iterator for Lexer<'a> {
 
 impl<'a> Lexer<'a> {
     /// Creates a new lexer.
-    fn new(input: &'a str) -> Self {
+    pub(crate) fn new(input: &'a str) -> Self {
         Self {
             iter: input.char_indices().peekable(),
             input,

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -1,3 +1,26 @@
-pub mod lexer;
+use crate::delimiter::{TokenStream, UnmatchedDelimiter};
+use crate::token::Token;
+
+pub mod delimiter;
+mod lexer;
 mod literal;
 pub mod token;
+
+/// Scans the input string and tokenizes it.
+pub fn lex(input: &str) -> (Vec<Token>, Vec<UnmatchedDelimiter>) {
+    let mut stream = TokenStream::new(input);
+    let tokens = Vec::from_iter(&mut stream);
+    let mismatches = stream.mismatches;
+    (tokens, mismatches)
+}
+
+/// Tests if the delimiters in the input string are balanced, but not terminated.
+pub fn is_unterminated(input: &str) -> bool {
+    let mut stream = TokenStream::new(input);
+    for _ in stream.by_ref() {}
+    !stream.mismatches.is_empty()
+        && stream
+            .mismatches
+            .into_iter()
+            .all(|unmatched| unmatched.candidate.is_none())
+}

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -75,7 +75,6 @@ impl<'a> CallAspect<'a> for Parser<'a> {
         let type_parameters = self.parse_type_parameter_list()?.0;
         if let Some(open_parenthesis) = self.cursor.advance(of_type(TokenType::RoundedLeftBracket))
         {
-            self.delimiter_stack.push_back(open_parenthesis.clone());
             let (arguments, segment) = self.parse_comma_separated_arguments(open_parenthesis)?;
 
             let start = *path.first().unwrap_or(&value);
@@ -146,7 +145,6 @@ impl<'a> CallAspect<'a> for Parser<'a> {
             of_type(TokenType::RoundedLeftBracket),
             "Expected opening parenthesis.",
         )?;
-        self.delimiter_stack.push_back(open_parenthesis.clone());
         let (arguments, segment) = self.parse_comma_separated_arguments(open_parenthesis)?;
         let start = *path.first().unwrap_or(&name.value);
         let segment = self.cursor.relative_pos(start).start..segment.end;
@@ -174,7 +172,6 @@ impl<'a> CallAspect<'a> for Parser<'a> {
             of_type(TokenType::RoundedLeftBracket),
             "Expected opening parenthesis.",
         )?;
-        self.delimiter_stack.push_back(open_parenthesis.clone());
         let (arguments, segment) = self.parse_comma_separated_arguments(open_parenthesis)?;
         let segment = dot
             .map(|d| self.cursor.relative_pos(d.value))
@@ -284,7 +281,6 @@ impl<'a> Parser<'a> {
             if let Some(closing_parenthesis) =
                 self.cursor.advance(of_type(TokenType::RoundedRightBracket))
             {
-                self.delimiter_stack.pop_back();
                 segment.end = self.cursor.relative_pos(closing_parenthesis).end;
                 return Ok((args, segment));
             }
@@ -312,7 +308,8 @@ impl<'a> Parser<'a> {
                 )?;
             }
             if self.cursor.lookahead(eog()).is_some() {
-                let closing_parenthesis = self.expect_delimiter(TokenType::RoundedRightBracket)?;
+                let closing_parenthesis =
+                    self.expect_delimiter(open_parenthesis, TokenType::RoundedRightBracket)?;
                 segment.end = self.cursor.relative_pos_ctx(closing_parenthesis).end;
                 break;
             }

--- a/parser/src/aspects/expr_list.rs
+++ b/parser/src/aspects/expr_list.rs
@@ -72,7 +72,6 @@ impl<'a> ExpressionListAspect<'a> for Parser<'a> {
             "expected start of list expression",
             Expected(start.str().unwrap_or("<undefined>").to_string()),
         )?;
-        self.delimiter_stack.push_back(start.clone());
         let mut elements = vec![];
 
         while self.cursor.lookahead(blanks().then(eog())).is_none() {
@@ -95,12 +94,12 @@ impl<'a> ExpressionListAspect<'a> for Parser<'a> {
             self.cursor.force_with(
                 blanks().then(of_type(Comma).or(lookahead(eog()))),
                 "A comma or a closing bracket was expected here",
-                Expected(format!("',' or '{}'", end.str().unwrap_or("<undefined>")).to_string()),
+                Expected(format!("',' or '{}'", end.str().unwrap_or("<undefined>"))),
             )?;
         }
         self.cursor.advance(blanks());
 
-        let end = self.expect_delimiter(end)?;
+        let end = self.expect_delimiter(start.clone(), end)?;
 
         Ok((elements, self.cursor.relative_pos_ctx(start..end)))
     }

--- a/parser/src/aspects/function_declaration.rs
+++ b/parser/src/aspects/function_declaration.rs
@@ -136,7 +136,6 @@ impl<'a> Parser<'a> {
                     ParseErrorKind::Expected("(".to_string()),
                 )
             })?;
-        self.delimiter_stack.push_back(parenthesis);
 
         let mut params = Vec::new();
         loop {
@@ -168,7 +167,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        self.expect_delimiter(RoundedRightBracket)?;
+        self.expect_delimiter(parenthesis, RoundedRightBracket)?;
 
         Ok(params)
     }

--- a/parser/src/aspects/literal.rs
+++ b/parser/src/aspects/literal.rs
@@ -69,25 +69,10 @@ impl<'a> LiteralAspect<'a> for Parser<'a> {
             _ if pivot.is_ponctuation()
                 || (leniency == LiteralLeniency::Strict && pivot.is_extended_ponctuation()) =>
             {
-                if pivot.is_closing_ponctuation()
-                    && self
-                        .delimiter_stack
-                        .back()
-                        .map(|d| {
-                            d.token_type
-                                .closing_pair()
-                                .expect("invalid delimiter passed to stack")
-                                != pivot
-                        })
-                        .unwrap_or(false)
-                {
-                    self.mismatched_delimiter(pivot)
-                } else {
-                    self.expected(
-                        format!("Unexpected token '{}'.", token.value),
-                        ParseErrorKind::Unexpected,
-                    )
-                }
+                self.expected(
+                    format!("Unexpected token '{}'.", token.value),
+                    ParseErrorKind::Unexpected,
+                )
             }
 
             _ if leniency == LiteralLeniency::Lenient => self.argument(leniency),

--- a/parser/src/aspects/loop.rs
+++ b/parser/src/aspects/loop.rs
@@ -141,8 +141,6 @@ impl<'a> Parser<'a> {
             of_type(TokenType::RoundedLeftBracket),
             "expected '((' at start of conditional for",
         )?;
-        self.delimiter_stack
-            .push_back(outer_opening_parenthesis.clone());
         let kind = self.parse_inner_conditional_for(outer_opening_parenthesis.clone());
 
         match kind {
@@ -159,12 +157,10 @@ impl<'a> Parser<'a> {
         }
     }
     fn parse_inner_conditional_for(&mut self, start: Token<'a>) -> ParseResult<ConditionalFor<'a>> {
-        let inner_opening_parenthesis = self.cursor.force(
+        self.cursor.force(
             of_type(TokenType::RoundedLeftBracket),
             "expected '((' at start of conditional for",
         )?;
-        self.delimiter_stack
-            .push_back(inner_opening_parenthesis.clone());
         match self.parse_three_parts_for() {
             Ok(kind) => {
                 self.expect_one_closing_parentheses_in_for(start)?;
@@ -204,7 +200,7 @@ impl<'a> Parser<'a> {
         outer_opening_parenthesis: Token<'a>,
     ) -> ParseResult<Token<'a>> {
         if self.cursor.lookahead(eog()).is_some() {
-            self.expect_delimiter(TokenType::RoundedRightBracket)
+            self.expect_delimiter(outer_opening_parenthesis, TokenType::RoundedRightBracket)
         } else {
             let mut segment = self.cursor.relative_pos(outer_opening_parenthesis.value);
             segment.end += 1;

--- a/parser/src/aspects/match.rs
+++ b/parser/src/aspects/match.rs
@@ -58,7 +58,6 @@ impl<'a> Parser<'a> {
             "expected match start",
             ParseErrorKind::Expected("{".to_string()),
         )?;
-        self.delimiter_stack.push_back(opening_bracket.clone());
 
         let mut arms: Vec<MatchArm<'a>> = Vec::new();
 
@@ -75,7 +74,6 @@ impl<'a> Parser<'a> {
             "expected '}'",
             ParseErrorKind::Unpaired(self.cursor.relative_pos(opening_bracket.clone())),
         )?;
-        self.delimiter_stack.pop_back();
 
         Ok((
             arms,

--- a/parser/src/aspects/substitution.rs
+++ b/parser/src/aspects/substitution.rs
@@ -157,7 +157,7 @@ mod tests {
         assert_eq!(
             ast,
             Err(ParseError {
-                message: "expected end of expression or file".to_string(),
+                message: "Unexpected closing delimiter.".to_string(),
                 position: content.find(')').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             })

--- a/parser/src/aspects/type.rs
+++ b/parser/src/aspects/type.rs
@@ -233,7 +233,7 @@ mod tests {
 
     use crate::aspects::r#type::TypeAspect;
     use crate::err::ParseError;
-    use crate::err::ParseErrorKind::{Expected, Unexpected, Unpaired};
+    use crate::err::ParseErrorKind::{Expected, Unexpected};
     use crate::parser::Parser;
 
     #[test]
@@ -370,20 +370,6 @@ mod tests {
                 message: "'@' is not a valid type identifier.".to_string(),
                 kind: Unexpected,
                 position: content.find('@').map(|i| i..i + 1).unwrap(),
-            })
-        );
-    }
-
-    #[test]
-    fn type_invalid_eod() {
-        let content = "Complex[  x  }";
-        let source = Source::unknown(content);
-        assert_eq!(
-            Parser::new(source).parse_specific(Parser::parse_type),
-            Err(ParseError {
-                message: "Mismatched closing delimiter.".to_string(),
-                kind: Unpaired(content.find('[').map(|i| i..i + 1).unwrap()),
-                position: content.find('}').map(|i| i..i + 1).unwrap(),
             })
         );
     }

--- a/parser/src/aspects/var_declaration.rs
+++ b/parser/src/aspects/var_declaration.rs
@@ -180,11 +180,18 @@ mod tests {
         let err = parse(source);
         assert_eq!(
             err.errors,
-            vec![ParseError {
-                message: "Unexpected word literal".to_string(),
-                position: find_in(content, "echo"),
-                kind: ParseErrorKind::Unexpected,
-            }]
+            vec![
+                ParseError {
+                    message: "Unexpected word literal".to_string(),
+                    position: find_in(content, "echo"),
+                    kind: ParseErrorKind::Unexpected,
+                },
+                ParseError {
+                    message: "Unexpected token ')'.".to_string(),
+                    position: find_in(content, ")"),
+                    kind: ParseErrorKind::Unexpected,
+                }
+            ]
         )
     }
 

--- a/parser/src/aspects/var_reference.rs
+++ b/parser/src/aspects/var_reference.rs
@@ -21,9 +21,6 @@ impl<'a> VarReferenceAspect<'a> for Parser<'a> {
             .advance(blanks().then(lookahead(any())))
             .unwrap();
         let bracket = self.cursor.advance(of_type(CurlyLeftBracket));
-        if let Some(bracket) = bracket.clone() {
-            self.delimiter_stack.push_back(bracket);
-        }
 
         let name = self
             .cursor
@@ -34,7 +31,7 @@ impl<'a> VarReferenceAspect<'a> for Parser<'a> {
             .map_err(|mut err| {
                 err.position = self.cursor.relative_pos(self.cursor.peek().value);
                 if bracket.is_some() {
-                    self.repos_delimiter_due_to(&err);
+                    self.repos_to_top_delimiter();
                 }
                 err
             })?
@@ -54,7 +51,7 @@ impl<'a> VarReferenceAspect<'a> for Parser<'a> {
 
         if let Some(bracket) = bracket {
             if self.cursor.peek().token_type.is_closing_ponctuation() {
-                self.expect_delimiter(CurlyRightBracket)?;
+                self.expect_delimiter(start, CurlyRightBracket)?;
             } else {
                 self.cursor.force_with(
                     of_type(CurlyRightBracket),

--- a/parser/src/cursor.rs
+++ b/parser/src/cursor.rs
@@ -189,4 +189,8 @@ impl<'a> ParserCursor<'a> {
         let end = context.to.as_ptr() as usize + context.to.len() - self.source.as_ptr() as usize;
         start..end
     }
+
+    pub fn get_source(&self) -> &'a str {
+        self.source
+    }
 }

--- a/parser/src/moves.rs
+++ b/parser/src/moves.rs
@@ -379,9 +379,9 @@ pub(crate) fn identifier_parenthesis() -> AndThenMove<
 
 #[cfg(test)]
 mod tests {
+    use lexer::lex;
     use pretty_assertions::assert_eq;
 
-    use lexer::lexer::lex;
     use lexer::token::{Token, TokenType};
 
     use crate::cursor::ParserCursor;
@@ -389,7 +389,7 @@ mod tests {
 
     #[test]
     fn eox_move() {
-        let tokens = lex(";");
+        let tokens = lex(";").0;
         let cursor = ParserCursor::new(tokens);
         let result = cursor.lookahead(eox());
         assert_eq!(result, Some(Token::new(TokenType::SemiColon, ";")));

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,9 +1,7 @@
-use std::collections::vec_deque::VecDeque;
-
 use ast::range::Iterable;
 use ast::Expr;
 use context::source::Source;
-use lexer::lexer::lex;
+use lexer::lex;
 use lexer::token::TokenType::*;
 use lexer::token::{Token, TokenType};
 
@@ -26,7 +24,9 @@ use crate::aspects::test::TestAspect;
 use crate::aspects::var_declaration::VarDeclarationAspect;
 use crate::cursor::ParserCursor;
 use crate::err::ParseErrorKind::Unexpected;
-use crate::err::{ErrorContext, ParseError, ParseErrorKind, ParseReport};
+use crate::err::{
+    determine_skip_sections, ErrorContext, ParseError, ParseErrorKind, ParseReport, SkipSections,
+};
 use crate::moves::{
     any, bin_op, blanks, eox, like, line_end, next, not, of_type, of_types, repeat, spaces, Move,
     MoveOperations,
@@ -38,7 +38,7 @@ pub(crate) type ParseResult<T> = Result<T, ParseError>;
 pub(crate) struct Parser<'a> {
     pub(crate) cursor: ParserCursor<'a>,
     pub(crate) source: Source<'a>,
-    pub(crate) delimiter_stack: VecDeque<Token<'a>>,
+    pub(crate) skip: SkipSections,
     errors: Vec<ParseError>,
 }
 
@@ -61,11 +61,33 @@ macro_rules! non_infix {
 impl<'a> Parser<'a> {
     /// Creates a new parser from a defined source.
     pub(crate) fn new(source: Source<'a>) -> Self {
+        let (tokens, unmatched) = lex(source.source);
+        let cursor = ParserCursor::new_with_source(tokens, source.source);
+        let skip = determine_skip_sections(source.source.len(), &unmatched);
+        let errors = unmatched
+            .into_iter()
+            .filter_map(|unmatched| {
+                Some(ParseError {
+                    message: if unmatched.opening.is_some() {
+                        "Mismatched closing delimiter."
+                    } else {
+                        "Unexpected closing delimiter."
+                    }
+                    .to_owned(),
+                    position: unmatched.candidate?..(unmatched.candidate? + 1),
+                    kind: if unmatched.opening.is_some() {
+                        ParseErrorKind::Unpaired(unmatched.opening?..unmatched.opening? + 1)
+                    } else {
+                        Unexpected
+                    },
+                })
+            })
+            .collect::<Vec<ParseError>>();
         Self {
-            cursor: ParserCursor::new_with_source(lex(source.source), source.source),
+            cursor,
             source,
-            delimiter_stack: VecDeque::new(),
-            errors: Vec::new(),
+            skip,
+            errors,
         }
     }
 
@@ -76,7 +98,14 @@ impl<'a> Parser<'a> {
         while self.look_for_input() {
             match self.parse_next() {
                 Err(error) => {
+                    let pos = self.cursor.get_pos();
                     self.recover_from(error, line_end());
+                    if self.cursor.get_pos() == pos {
+                        // If the error was not recovered from, advance anyway.
+                        // This prevents infinite loops when delimiters are not
+                        // closed without any candidates.
+                        self.cursor.advance(next());
+                    }
                 }
                 Ok(statement) => statements.push(statement),
             }
@@ -85,7 +114,6 @@ impl<'a> Parser<'a> {
         ParseReport {
             expr: statements,
             errors: self.errors,
-            stack_ended: self.delimiter_stack.is_empty(),
         }
     }
 
@@ -371,38 +399,25 @@ impl<'a> Parser<'a> {
     }
 
     /// Expect a specific delimiter token type and pop it from the delimiter stack.
-    pub(crate) fn expect_delimiter(&mut self, eog: TokenType) -> ParseResult<Token<'a>> {
+    pub(crate) fn expect_delimiter(
+        &mut self,
+        start: Token<'a>,
+        eog: TokenType,
+    ) -> ParseResult<Token<'a>> {
         if let Some(token) = self.cursor.advance(of_type(eog)) {
-            self.delimiter_stack.pop_back();
             Ok(token)
-        } else if self.cursor.peek().token_type.is_closing_ponctuation() {
-            self.mismatched_delimiter(eog)
         } else {
-            self.expected(
+            let err = self.expected(
                 format!(
                     "Expected '{}' delimiter.",
                     eog.str().unwrap_or("specific token")
                 ),
-                self.delimiter_stack
-                    .back()
-                    .map(|last| ParseErrorKind::Unpaired(self.cursor.relative_pos(last)))
-                    .unwrap_or(Unexpected),
-            )
-        }
-    }
-
-    /// Raise a mismatched delimiter error on the current token.
-    pub(crate) fn mismatched_delimiter<T>(&mut self, eog: TokenType) -> ParseResult<T> {
-        if let Some(last) = self.delimiter_stack.back() {
-            self.expected(
-                "Mismatched closing delimiter.",
-                ParseErrorKind::Unpaired(self.cursor.relative_pos(last)),
-            )
-        } else {
-            self.expected(
-                "Unexpected closing delimiter.",
-                ParseErrorKind::Expected(eog.str().unwrap_or("specific token").to_string()),
-            )
+                ParseErrorKind::Unpaired(self.cursor.relative_pos(start)),
+            );
+            if self.cursor.peek().token_type.is_closing_ponctuation() {
+                self.repos_to_top_delimiter();
+            }
+            err
         }
     }
 
@@ -516,6 +531,24 @@ impl<'a> Parser<'a> {
     /// The base behavior is to go to the end of the file or the next valid closing delimiter,
     /// but this can be further configured by the `break_on` parameter.
     pub(crate) fn recover_from(&mut self, error: ParseError, break_on: impl Move + Copy) {
+        if self.skip.contains(error.position.start) {
+            // Mismatched delimiters are already reported by the lexer, so we can skip them
+            // in a section marked as skipped. Contrary to repos_to_top_delimiter, this doesn't
+            // recover after the delimiter, but just before it.
+            while !self.cursor.is_at_end() {
+                let token = self.cursor.peek();
+                if self
+                    .skip
+                    .contains(self.cursor.relative_pos(token.value).start)
+                {
+                    self.cursor.next_opt();
+                } else {
+                    break;
+                }
+            }
+            return;
+        }
+
         match error.kind {
             ParseErrorKind::Unpaired(_) => {
                 self.repos_to_top_delimiter();
@@ -531,12 +564,13 @@ impl<'a> Parser<'a> {
     ///
     /// In most cases, [`Parser::recover_from`] should be used instead.
     ///
-    /// This should be used when a delimiter has been pushed to the stack,
+    /// This should be used when a delimiter was seen by the parser,
     /// but an error occurred before the corresponding closing delimiter was found.
     pub(crate) fn repos_delimiter_due_to(&mut self, error: &ParseError) {
-        // Unpaired delimiters already look for the next valid closing delimiter.
-        // Only handle other errors that would leave the delimiter stack in an invalid state.
-        if !matches!(error.kind, ParseErrorKind::Unpaired(_)) {
+        // Unpaired delimiters are known by the lexer, so we can use that information to
+        // skip them. Repositioning is not strictly necessary, but if used appropriately
+        // the errors will be more precise.
+        if self.skip.contains(error.position.start) {
             self.repos_to_top_delimiter();
         }
     }
@@ -553,62 +587,54 @@ impl<'a> Parser<'a> {
     fn repos_to_next_expr(&mut self, break_on: impl Move + Copy) {
         // If delimiters are encountered while moving, they must be removed from the stack first,
         // before repositioning.
-        let start_len = self.delimiter_stack.len();
+        let mut delimiter_stack = Vec::new();
         while !self.cursor.is_at_end() {
-            // Stop before a break_on token.
-            if self.delimiter_stack.len() == start_len && self.cursor.lookahead(break_on).is_some()
+            if self
+                .skip
+                .contains(self.cursor.relative_pos(self.cursor.peek()).start)
             {
+                self.cursor.next_opt();
+                continue;
+            }
+            // Stop before a break_on token.
+            if delimiter_stack.is_empty() && self.cursor.lookahead(break_on).is_some() {
                 break;
             }
 
             // See if we're at a closing delimiter.
             let token = self.cursor.peek();
             if token.token_type.is_opening_ponctuation() {
-                self.delimiter_stack.push_back(token.clone());
+                delimiter_stack.push(token.token_type);
             }
-            if let Some(last) = self.delimiter_stack.back() {
+            if let Some(last) = delimiter_stack.last() {
                 if last
-                    .token_type
                     .closing_pair()
                     .expect("invalid delimiter passed to stack")
                     == token.token_type
                 {
-                    if self.delimiter_stack.len() > start_len {
-                        self.delimiter_stack.pop_back();
-                    } else {
-                        // Do not consume it to avoid breaking the stack.
-                        // The caller will consume it.
-                        break;
-                    }
+                    delimiter_stack.pop();
                 }
+            } else if token.token_type.is_closing_ponctuation() {
+                // Do not consume it to avoid breaking the stack.
+                // The caller will consume it.
+                break;
             }
             // Otherwise, just advance.
             self.cursor.next_opt();
         }
     }
 
-    /// Goes to the next closing delimiter of the top delimiter on the stack.
+    /// Goes after the next closing delimiter of the top delimiter on the stack.
     ///
-    /// If the stack is empty, this does nothing.
+    /// The implementation will skip invalid sections and goes to the next valid closing delimiter.
     /// Always prefer using [`Parser::recover_from`] instead.
     pub(crate) fn repos_to_top_delimiter(&mut self) {
-        let start_len = self.delimiter_stack.len();
         while let Some(token) = self.cursor.next_opt() {
-            if token.token_type.is_opening_ponctuation() {
-                self.delimiter_stack.push_back(token.clone());
-            } else if let Some(last) = self.delimiter_stack.back() {
-                if last
-                    .token_type
-                    .closing_pair()
-                    .expect("invalid delimiter passed to stack")
-                    == token.token_type
-                {
-                    self.delimiter_stack.pop_back();
-                    if self.delimiter_stack.len() < start_len {
-                        break;
-                    }
-                }
-            } else {
+            if !self
+                .skip
+                .contains(self.cursor.relative_pos(token.value).start)
+                && token.token_type.is_closing_ponctuation()
+            {
                 break;
             }
         }

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -64,7 +64,6 @@ fn repos_delimiter_stack() {
                     kind: ParseErrorKind::Unexpected
                 }
             ],
-            stack_ended: true,
         }
     );
 }
@@ -166,7 +165,6 @@ fn tolerance_in_multiple_groups() {
                     kind: ParseErrorKind::Unexpected
                 }
             ],
-            stack_ended: true,
         }
     );
 }
@@ -195,7 +193,6 @@ fn invalid_binary_operator_cause_one_error() {
                 position: content.find('!').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
-            stack_ended: true,
         }
     );
 }
@@ -261,7 +258,6 @@ fn no_comma_or_two() {
                     kind: ParseErrorKind::Unpaired(content.find('\'').map(|p| p..p + 1).unwrap())
                 }
             ],
-            stack_ended: true,
         }
     );
 }
@@ -292,7 +288,6 @@ fn multiple_errors_in_parameters() {
                     kind: ParseErrorKind::Unpaired(content.find('(').map(|p| p..p + 1).unwrap())
                 }
             ],
-            stack_ended: false,
         }
     );
 }
@@ -333,7 +328,6 @@ fn do_not_self_lock() {
                     kind: ParseErrorKind::Unexpected
                 }
             ],
-            stack_ended: true,
         }
     );
 }
@@ -352,7 +346,6 @@ fn list_are_not_tricked_by_blanks() {
                 position: content.len()..content.len(),
                 kind: ParseErrorKind::Unpaired(content.find('[').map(|p| p..p + 1).unwrap())
             }],
-            stack_ended: false,
         }
     );
 }
@@ -371,7 +364,6 @@ fn expected_value_found_eof() {
                 position: content.find('=').map(|p| p + 1..p + 2).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
-            stack_ended: true,
         }
     );
 }
@@ -390,7 +382,6 @@ fn expected_value_found_semicolon() {
                 position: content.find(';').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
-            stack_ended: true,
         }
     );
 }
@@ -411,7 +402,6 @@ fn for_no_dollar_help() {
                     "Consider removing the '$' prefix: for i in 5..9".to_string()
                 )
             }],
-            stack_ended: true,
         }
     );
 }
@@ -430,7 +420,6 @@ fn expected_double_delimiter_for() {
                 position: content.find(')').map(|p| p + 1..p + 2).unwrap(),
                 kind: ParseErrorKind::Unpaired(content.find('(').map(|p| p..p + 2).unwrap())
             }],
-            stack_ended: false,
         }
     );
 }
@@ -449,7 +438,6 @@ fn expected_double_delimiter_mismatched() {
                 position: content.find(']').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unpaired(content.find('(').map(|p| p + 1..p + 2).unwrap())
             }],
-            stack_ended: true,
         }
     );
 }
@@ -474,7 +462,6 @@ fn double_comma_parentheses() {
                 position: content.rfind(',').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
-            stack_ended: true,
         }
     );
 }
@@ -500,7 +487,6 @@ fn double_comma_function() {
                     kind: ParseErrorKind::Unexpected
                 }
             ],
-            stack_ended: true,
         }
     );
 }
@@ -523,7 +509,6 @@ fn quotes_are_delimiters() {
                     .unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
-            stack_ended: true,
         }
     );
 }


### PR DESCRIPTION
*Mismatched delimiters* is probably the most complicated error case to recover from. Making pairs during parsing is not quite robust, as it  give the responsibility to transform an unexpected token into a mismatched one when an error is found, a note that may be forgotten.

To leverage the parser and reduce the number of errors created in some cases (like `{(}`), delimiter pairs are verified as the lexer produces the tokens. The REPL can now use only the lexer to properly detect unterminated input. This removes the `stack_ended` boolean from the `ParseResult` struct. Erroneous input is still passed to the parser, as the infrastructure is here. It will silently discard parser errors in sections that are already marked as invalid.