### PR TITLE
remove inclusion path and type arguments from command calls

### DIFF
--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -631,9 +631,6 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
     }
 
     fn resolve_primitive_call(&mut self, env_id: SourceId, call: &Call) -> Option<()> {
-        if !call.path.is_empty() {
-            return None;
-        }
         let command = self.extract_literal_argument(call, 0)?;
         match command {
             "read" => {

--- a/ast/src/call.rs
+++ b/ast/src/call.rs
@@ -12,16 +12,10 @@ use crate::Expr;
 /// command name.
 #[derive(Debug, Clone, PartialEq, DebugPls)]
 pub struct Call<'a> {
-    ///The relative path where this _function_ is stored.
-    pub path: Vec<&'a str>,
-
     /// The arguments of the command.
     ///
     /// A valid command must have at least one argument which is the command name.
     pub arguments: Vec<Expr<'a>>,
-
-    /// type parameters of the call.
-    pub type_parameters: Vec<Type<'a>>,
 }
 
 impl SourceSegmentHolder for Call<'_> {

--- a/parser/src/aspects/binary_operation.rs
+++ b/parser/src/aspects/binary_operation.rs
@@ -345,33 +345,27 @@ mod tests {
                 left: Box::new(Expr::Subshell(Subshell {
                     expressions: vec![Expr::Binary(BinaryOperation {
                         left: Box::new(Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![
                                 literal(source.source, "echo"),
                                 literal(source.source, "hello"),
                             ],
-                            type_parameters: vec![],
                         })),
                         op: And,
                         right: Box::new(Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![
                                 literal_nth(source.source, "echo", 1),
                                 literal(source.source, "world"),
                             ],
-                            type_parameters: vec![],
                         })),
                     })],
                     segment: find_between(source.source, "(", ")")
                 })),
                 op: Or,
                 right: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal_nth(source.source, "echo", 2),
                         literal(source.source, "damn"),
                     ],
-                    type_parameters: vec![],
                 })),
             })
         )
@@ -387,7 +381,6 @@ mod tests {
             Expr::Binary(BinaryOperation {
                 left: Box::new(Expr::Subshell(Subshell {
                     expressions: vec![Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             literal(source.source, "echo"),
                             literal(source.source, "hello"),
@@ -395,18 +388,15 @@ mod tests {
                             literal(source.source, "world"),
                             literal(source.source, ")"),
                         ],
-                        type_parameters: vec![],
                     })],
                     segment: find_between(source.source, "(", ";)")
                 })),
                 op: Or,
                 right: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal_nth(source.source, "echo", 1),
                         literal(source.source, "damn"),
                     ],
-                    type_parameters: vec![],
                 })),
             })
         )

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -13,7 +13,7 @@ use crate::aspects::literal::{LiteralAspect, LiteralLeniency};
 use crate::aspects::modules::ModulesAspect;
 use crate::aspects::r#type::TypeAspect;
 use crate::aspects::redirection::RedirectionAspect;
-use crate::err::ParseErrorKind;
+use crate::err::{ParseError, ParseErrorKind};
 use crate::moves::{
     blanks, eog, identifier_parenthesis, like, line_end, lookahead, of_type, of_types, repeat,
     spaces, MoveOperations,
@@ -38,12 +38,7 @@ pub trait CallAspect<'a> {
     fn expand_call_chain(&mut self, expr: Expr<'a>) -> ParseResult<Expr<'a>>;
 
     /// Continues to parse a call expression from a known command name expression
-    fn call_arguments(
-        &mut self,
-        path: Vec<&'a str>,
-        command: Expr<'a>,
-        tparams: Vec<Type<'a>>,
-    ) -> ParseResult<Expr<'a>>;
+    fn call_arguments(&mut self, command: Expr<'a>) -> ParseResult<Expr<'a>>;
 
     /// Checks if the cursor is at the start of a programmatic call.
     fn may_be_at_programmatic_call_start(&self) -> bool;
@@ -64,7 +59,10 @@ impl<'a> CallAspect<'a> for Parser<'a> {
             )
             .is_none()
         {
-            return self.call_with_path(path);
+            check_emptiness("Command calls cannot have inclusion path", path, |str| {
+                self.cursor.relative_pos(*str)
+            })?;
+            return self.call();
         }
         // We don't known if this is a programmatic call, a raw call or a lambda definition yet.
 
@@ -93,6 +91,16 @@ impl<'a> CallAspect<'a> for Parser<'a> {
             .advance(spaces().then(of_type(TokenType::FatArrow)))
             .is_some()
         {
+            check_emptiness(
+                "Illegal expression before lambda parameter declaration",
+                path,
+                |str| self.cursor.relative_pos(*str),
+            )?;
+            check_emptiness(
+                "Illegal expression after lambda parameter declaration",
+                type_parameters,
+                Type::segment,
+            )?;
             let body = Box::new(self.value()?);
             let segment = self.cursor.relative_pos(identifier).start..body.segment().end;
             Ok(Expr::LambdaDef(LambdaDef {
@@ -105,13 +113,27 @@ impl<'a> CallAspect<'a> for Parser<'a> {
                 segment,
             }))
         } else {
-            self.call_arguments(path, callee, type_parameters)
+            check_emptiness(
+                "Command calls cannot have generic arguments",
+                type_parameters,
+                Type::segment,
+            )?;
+            check_emptiness("Command calls cannot have inclusion path", path, |str| {
+                self.cursor.relative_pos(*str)
+            })?;
+            self.call_arguments(callee)
         }
     }
 
     fn call(&mut self) -> ParseResult<Expr<'a>> {
-        let path = self.parse_inclusion_path()?;
-        self.call_with_path(path)
+        let callee = self.call_argument()?;
+        let type_parameters = self.parse_type_parameter_list()?.0;
+        check_emptiness(
+            "Command calls cannot have generic arguments",
+            type_parameters,
+            Type::segment,
+        )?;
+        self.call_arguments(callee)
     }
 
     fn programmatic_call(&mut self) -> ParseResult<Expr<'a>> {
@@ -182,12 +204,7 @@ impl<'a> CallAspect<'a> for Parser<'a> {
         Ok(expr)
     }
 
-    fn call_arguments(
-        &mut self,
-        path: Vec<&'a str>,
-        callee: Expr<'a>,
-        tparams: Vec<Type<'a>>,
-    ) -> ParseResult<Expr<'a>> {
+    fn call_arguments(&mut self, callee: Expr<'a>) -> ParseResult<Expr<'a>> {
         let mut arguments = vec![callee];
 
         while self
@@ -197,21 +214,13 @@ impl<'a> CallAspect<'a> for Parser<'a> {
         {
             self.cursor.advance(spaces()); //consume word separations
             if self.is_at_redirection_sign() {
-                return self.redirectable(Expr::Call(Call {
-                    path,
-                    arguments,
-                    type_parameters: tparams,
-                }));
+                return self.redirectable(Expr::Call(Call { arguments }));
             }
 
             arguments.push(self.call_argument()?);
         }
 
-        Ok(Expr::Call(Call {
-            path,
-            arguments,
-            type_parameters: tparams,
-        }))
+        Ok(Expr::Call(Call { arguments }))
     }
 
     fn may_be_at_programmatic_call_start(&self) -> bool {
@@ -224,13 +233,28 @@ impl<'a> CallAspect<'a> for Parser<'a> {
     }
 }
 
-impl<'a> Parser<'a> {
-    fn call_with_path(&mut self, path: Vec<&'a str>) -> ParseResult<Expr<'a>> {
-        let callee = self.call_argument()?;
-        let tparams = self.parse_type_parameter_list()?.0;
-        self.call_arguments(path, callee, tparams)
-    }
+fn check_emptiness<T>(
+    msg: &str,
+    elements: Vec<T>,
+    convert: impl Fn(&T) -> SourceSegment,
+) -> ParseResult<()> {
+    if let Some(first) = elements.first() {
+        let position = elements
+            .last()
+            .map(|last| convert(first).start..convert(last).end)
+            .unwrap_or(convert(first).start..convert(first).end);
 
+        Err(ParseError {
+            message: msg.to_string(),
+            position,
+            kind: ParseErrorKind::InvalidFormat,
+        })
+    } else {
+        Ok(())
+    }
+}
+
+impl<'a> Parser<'a> {
     /// special pivot method for argument methods
     pub(crate) fn call_argument(&mut self) -> ParseResult<Expr<'a>> {
         self.repos("Expected value")?;
@@ -331,46 +355,83 @@ mod tests {
     }
 
     #[test]
-    fn call_with_type_parameter() {
-        let source = Source::unknown("parse[Int] x y");
+    fn call() {
+        let source = Source::unknown("echo x y");
         assert_eq!(
             Parser::new(source).parse_next(),
             Ok(Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![
-                    literal(source.source, "parse"),
+                    literal(source.source, "echo"),
                     literal(source.source, "x"),
                     literal(source.source, "y"),
                 ],
-                type_parameters: vec![Type::Parametrized(ParametrizedType {
-                    path: vec![],
-                    name: "Int",
-                    params: Vec::new(),
-                    segment: find_in(source.source, "Int"),
-                })]
             }))
         );
     }
 
     #[test]
     fn call_with_inclusion_path() {
-        let content = "a::b::parse[Int] x y";
+        let source = Source::unknown("a::b::c x y");
+        assert_eq!(
+            Parser::new(source).parse_next(),
+            Err(ParseError {
+                message: "Command calls cannot have inclusion path".to_string(),
+                position: find_in(source.source, "a::b"),
+                kind: ParseErrorKind::InvalidFormat,
+            })
+        );
+    }
+
+    #[test]
+    fn lambdef_with_inclusion_path() {
+        let source = Source::unknown("a::b => $b");
+        assert_eq!(
+            Parser::new(source).parse_next(),
+            Err(ParseError {
+                message: "Illegal expression before lambda parameter declaration".to_string(),
+                position: find_in(source.source, "a"),
+                kind: ParseErrorKind::InvalidFormat,
+            })
+        );
+    }
+
+    #[test]
+    fn lambdef_with_type_params() {
+        let source = Source::unknown("b[C] => $b");
+        assert_eq!(
+            Parser::new(source).parse_next(),
+            Err(ParseError {
+                message: "Illegal expression after lambda parameter declaration".to_string(),
+                position: find_in(source.source, "C"),
+                kind: ParseErrorKind::InvalidFormat,
+            })
+        );
+    }
+    #[test]
+    fn call_with_type_parameters() {
+        let source = Source::unknown("parse[Int] x y");
+        assert_eq!(
+            Parser::new(source).parse_next(),
+            Err(ParseError {
+                message: "Command calls cannot have generic arguments".to_string(),
+                position: find_in(source.source, "Int"),
+                kind: ParseErrorKind::InvalidFormat,
+            })
+        );
+    }
+
+    #[test]
+    fn call_with_path() {
+        let content = "a/b/parse x y";
         let source = Source::unknown(content);
         assert_eq!(
             Parser::new(source).parse_next(),
             Ok(Expr::Call(Call {
-                path: vec!["a", "b"],
                 arguments: vec![
-                    literal(source.source, "parse"),
+                    literal(source.source, "a/b/parse"),
                     literal(source.source, "x"),
                     literal(source.source, "y")
                 ],
-                type_parameters: vec![Type::Parametrized(ParametrizedType {
-                    path: vec![],
-                    name: "Int",
-                    params: Vec::new(),
-                    segment: find_in(source.source, "Int")
-                })]
             }))
         );
     }
@@ -382,7 +443,6 @@ mod tests {
         assert_eq!(
             result,
             vec![Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![
                     literal(content, "echo"),
                     literal(content, "how"),
@@ -392,7 +452,6 @@ mod tests {
                     literal(content, "you"),
                     literal_nth(content, "!", 1),
                 ],
-                type_parameters: vec![],
             })]
         );
     }
@@ -405,21 +464,17 @@ mod tests {
             parsed,
             vec![
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal(source.source, "grep"),
                         literal(source.source, "-E"),
                         literal(source.source, "regex")
                     ],
-                    type_parameters: vec![]
                 }),
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal(source.source, "echo"),
                         literal(source.source, "test")
                     ],
-                    type_parameters: vec![],
                 }),
             ]
         )
@@ -432,7 +487,6 @@ mod tests {
         assert_eq!(
             parsed,
             vec![Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![
                     literal(source.source, "g++"),
                     literal(source.source, "-std=c++20"),
@@ -440,7 +494,6 @@ mod tests {
                     literal(source.source, "-Wextra"),
                     literal(source.source, "-Wpedantic"),
                 ],
-                type_parameters: vec![],
             }),]
         )
     }
@@ -452,7 +505,6 @@ mod tests {
         assert_eq!(
             parsed,
             vec![Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![
                     literal(source.source, "grep"),
                     literal(source.source, "-E"),
@@ -461,7 +513,6 @@ mod tests {
                     literal(source.source, "echo"),
                     literal(source.source, "test"),
                 ],
-                type_parameters: vec![]
             }),]
         )
     }

--- a/parser/src/aspects/detached.rs
+++ b/parser/src/aspects/detached.rs
@@ -77,9 +77,7 @@ mod tests {
                 underlying: Box::new(Expr::Block(Block {
                     expressions: vec![Expr::Detached(Detached {
                         underlying: Box::new(Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![literal(source.source, "date")],
-                            type_parameters: vec![],
                         })),
                         segment: find_in(source.source, "date &")
                     })],

--- a/parser/src/aspects/function_declaration.rs
+++ b/parser/src/aspects/function_declaration.rs
@@ -370,9 +370,7 @@ mod tests {
                 parameters: vec![],
                 return_type: None,
                 body: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(source.source, "x")],
-                    type_parameters: vec![],
                 })),
                 segment: source.segment()
             })]
@@ -436,9 +434,7 @@ mod tests {
                 ],
                 return_type: None,
                 body: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal_nth(source.source, "x", 1)],
-                    type_parameters: vec![],
                 })),
                 segment: source.segment()
             })]
@@ -491,9 +487,7 @@ mod tests {
                 ],
                 return_type: None,
                 body: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal_nth(source.source, "x", 1)],
-                    type_parameters: vec![],
                 })),
                 segment: source.segment()
             })]
@@ -612,9 +606,7 @@ mod tests {
                     segment: find_in_nth(source.source, "X", 2)
                 })),
                 body: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal_nth(source.source, "x", 1)],
-                    type_parameters: vec![],
                 })),
                 segment: source.segment()
             })]

--- a/parser/src/aspects/group.rs
+++ b/parser/src/aspects/group.rs
@@ -378,12 +378,10 @@ mod tests {
                                 segment: find_in(source.source, "val x = 89"),
                             }),
                             Expr::Call(Call {
-                                path: Vec::new(),
                                 arguments: vec![
                                     literal(source.source, "command"),
                                     literal(source.source, "call")
                                 ],
-                                type_parameters: vec![],
                             }),
                             Expr::Literal(Literal {
                                 parsed: Int(7),

--- a/parser/src/aspects/if_else.rs
+++ b/parser/src/aspects/if_else.rs
@@ -101,12 +101,10 @@ mod tests {
                     segment: find_between(content, "[", "]"),
                 })),
                 success_branch: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal(source.source, "echo"),
                         literal(source.source, "test")
                     ],
-                    type_parameters: vec![],
                 })),
                 fail_branch: None,
                 segment: source.segment(),
@@ -125,13 +123,10 @@ mod tests {
             vec![Expr::If(If {
                 condition: Box::new(Expr::Binary(BinaryOperation {
                     left: Box::new(Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![literal(content, "echo"), literal(content, "a")],
-                        type_parameters: vec![],
                     })),
                     op: And,
                     right: Box::new(Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             Expr::Literal(Literal {
                                 parsed: "test".into(),
@@ -140,13 +135,10 @@ mod tests {
                             literal(content, "-f"),
                             literal(content, "/file/exe"),
                         ],
-                        type_parameters: vec![],
                     }))
                 })),
                 success_branch: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal_nth(content, "echo", 1), literal(content, "test")],
-                    type_parameters: vec![],
                 })),
                 fail_branch: Some(Box::new(Expr::If(If {
                     condition: Box::new(Expr::Test(Test {
@@ -190,9 +182,7 @@ mod tests {
                     segment: find_between(content, "[", "]"),
                 })),
                 success_branch: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(content, "echo"), literal(content, "test")],
-                    type_parameters: vec![],
                 })),
                 fail_branch: Some(Box::new(Expr::If(If {
                     condition: Box::new(Expr::Test(Test {
@@ -260,7 +250,6 @@ mod tests {
                         expression: Box::new(Expr::Binary(BinaryOperation {
                             left: Box::new(Expr::Block(Block {
                                 expressions: vec![Expr::Call(Call {
-                                    path: Vec::new(),
                                     arguments: vec![
                                         literal(content, "date"),
                                         Expr::TemplateString(TemplateString {
@@ -271,7 +260,6 @@ mod tests {
                                             segment: find_in(content, "+\"%Y\"")
                                         })
                                     ],
-                                    type_parameters: vec![],
                                 })],
                                 segment: find_between(content, "{", "}")
                             })),

--- a/parser/src/aspects/lambda_def.rs
+++ b/parser/src/aspects/lambda_def.rs
@@ -176,12 +176,10 @@ mod tests {
                 args: Vec::new(),
                 body: Box::new(Expr::Block(Block {
                     expressions: vec![Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             literal(source.source, "echo"),
                             literal(source.source, "hey")
                         ],
-                        type_parameters: Vec::new(),
                     })],
                     segment: find_between(source.source, "{", "}")
                 })),

--- a/parser/src/aspects/loop.rs
+++ b/parser/src/aspects/loop.rs
@@ -284,7 +284,6 @@ mod tests {
             vec![Expr::Loop(Loop {
                 body: Box::new(Expr::Binary(BinaryOperation {
                     left: Box::new(Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             Expr::Literal(Literal {
                                 parsed: "ssh".into(),
@@ -295,7 +294,6 @@ mod tests {
                                 segment: find_in(source.source, "mabatista1@iut"),
                             }),
                         ],
-                        type_parameters: vec![],
                     })),
                     op: And,
                     right: Box::new(Break(find_in(source.source, "break"))),
@@ -313,12 +311,10 @@ mod tests {
             res,
             vec![Expr::Loop(Loop {
                 body: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![Expr::Literal(Literal {
                         parsed: "date".into(),
                         segment: find_in(source.source, "date"),
                     })],
-                    type_parameters: vec![],
                 })),
                 segment: source.segment()
             })]
@@ -352,12 +348,10 @@ mod tests {
                 })),
                 body: Box::new(Expr::Block(Block {
                     expressions: vec![Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             literal(source.source, "echo"),
                             literal(source.source, "test"),
                         ],
-                        type_parameters: vec![],
                     })],
                     segment: find_in(source.source, "{ echo test }")
                 })),
@@ -391,7 +385,6 @@ mod tests {
                 })),
                 body: Box::new(Expr::Block(Block {
                     expressions: vec![Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             Expr::Literal(Literal {
                                 parsed: "echo".into(),
@@ -402,7 +395,6 @@ mod tests {
                                 segment: find_in(source.source, "$i")
                             }),
                         ],
-                        type_parameters: vec![],
                     })],
                     segment: find_in(source.source, "{\n\techo $i\n}")
                 })),
@@ -435,12 +427,10 @@ mod tests {
                     segment: find_in(source.source, "n in $a..$b"),
                 })),
                 body: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![Expr::Literal(Literal {
                         parsed: "cat".into(),
                         segment: find_in(source.source, "cat")
                     })],
-                    type_parameters: vec![],
                 })),
                 segment: source.segment(),
             })]
@@ -481,12 +471,10 @@ mod tests {
                     segment: find_in(source.source, "i in (1 + 2)..5"),
                 })),
                 body: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![Expr::Literal(Literal {
                         parsed: "ls".into(),
                         segment: find_in(source.source, "ls")
                     })],
-                    type_parameters: vec![],
                 })),
                 segment: source.segment()
             })]
@@ -510,7 +498,6 @@ mod tests {
                 })),
                 body: Box::new(Expr::Block(Block {
                     expressions: vec![Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             Expr::Literal(Literal {
                                 parsed: "file".into(),
@@ -521,7 +508,6 @@ mod tests {
                                 segment: find_in(source.source, "$f")
                             }),
                         ],
-                        type_parameters: vec![],
                     })],
                     segment: find_in(source.source, "{\n\tfile $f\n}")
                 })),
@@ -580,7 +566,6 @@ mod tests {
                     segment: find_between(source.source, "((", "))")
                 })),
                 body: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal(source.source, "echo"),
                         Expr::VarReference(VarReference {
@@ -588,7 +573,6 @@ mod tests {
                             segment: find_in_nth(source.source, "$i", 2)
                         }),
                     ],
-                    type_parameters: vec![],
                 })),
                 segment: source.segment(),
             })]

--- a/parser/src/aspects/match.rs
+++ b/parser/src/aspects/match.rs
@@ -419,7 +419,6 @@ mod tests {
                         patterns: vec![MatchPattern::Wildcard(find_in_nth(content, "*", 1))],
                         guard: None,
                         body: Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![
                                 literal(content, "echo"),
                                 Expr::VarReference(VarReference {
@@ -427,7 +426,6 @@ mod tests {
                                     segment: find_in(content, "$it"),
                                 }),
                             ],
-                            type_parameters: vec![],
                         }),
                         segment: find_in(content, "* => echo $it")
                     },
@@ -452,16 +450,13 @@ mod tests {
             ast,
             vec![Expr::Match(Match {
                 operand: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(source.source, "nginx")],
-                    type_parameters: vec![],
                 })),
                 arms: vec![MatchArm {
                     val_name: None,
                     patterns: vec![MatchPattern::Wildcard(find_in(source.source, "*"))],
                     guard: None,
                     body: Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             literal(source.source, "echo"),
                             Expr::VarReference(VarReference {
@@ -469,7 +464,6 @@ mod tests {
                                 segment: find_in(source.source, "$it"),
                             }),
                         ],
-                        type_parameters: vec![],
                     }),
                     segment: find_in(source.source, "* => echo $it")
                 },],
@@ -570,7 +564,6 @@ mod tests {
                         patterns: vec![MatchPattern::Wildcard(find_in_nth(content, "*", 1))],
                         guard: None,
                         body: Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![
                                 literal(content, "echo"),
                                 Expr::VarReference(VarReference {
@@ -578,7 +571,6 @@ mod tests {
                                     segment: find_in(content, "$it"),
                                 }),
                             ],
-                            type_parameters: vec![],
                         }),
                         segment: find_in(content, "* \n\n => \n\n echo $it")
                     },

--- a/parser/src/aspects/redirection.rs
+++ b/parser/src/aspects/redirection.rs
@@ -184,14 +184,10 @@ mod test {
                 expr: Box::new(Expr::Block(Block {
                     expressions: vec![
                         Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![literal(source.source, "ls")],
-                            type_parameters: vec![],
                         }),
                         Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![literal(source.source, "cd")],
-                            type_parameters: vec![],
                         }),
                     ],
                     segment: find_in(content, "{ls; cd;}")
@@ -215,9 +211,7 @@ mod test {
             parsed,
             Expr::Redirected(Redirected {
                 expr: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(source.source, "ls")],
-                    type_parameters: vec![],
                 })),
                 redirections: vec![Redir {
                     fd: RedirFd::Default,
@@ -238,12 +232,10 @@ mod test {
             parsed,
             Expr::Redirected(Redirected {
                 expr: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![Expr::Literal(Literal {
                         parsed: "ls".into(),
                         segment: find_in(content, "ls")
                     })],
-                    type_parameters: vec![],
                 })),
                 redirections: vec![Redir {
                     fd: RedirFd::Default,

--- a/parser/src/aspects/substitution.rs
+++ b/parser/src/aspects/substitution.rs
@@ -127,22 +127,18 @@ mod tests {
                 underlying: Subshell {
                     expressions: vec![Expr::Block(Block {
                         expressions: vec![Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![
                                 literal(source.source, "ls"),
                                 Expr::Substitution(Substitution {
                                     underlying: Subshell {
                                         expressions: vec![Expr::Call(Call {
-                                            path: Vec::new(),
                                             arguments: vec![literal(source.source, "pwd")],
-                                            type_parameters: vec![],
                                         })],
                                         segment: find_in(source.source, "$(pwd)")
                                     },
                                     kind: SubstitutionKind::Capture,
                                 }),
                             ],
-                            type_parameters: vec![],
                         })],
                         segment: find_in(source.source, "{ls $(pwd)}")
                     })],

--- a/parser/src/aspects/test.rs
+++ b/parser/src/aspects/test.rs
@@ -76,14 +76,10 @@ impl<'a> TestAspect<'a> for Parser<'a> {
 impl<'a> Parser<'a> {
     fn parse_test_call(&mut self, start: Token) -> ParseResult<Expr<'a>> {
         let segment = self.cursor.relative_pos_ctx(start.clone());
-        let call = self.call_arguments(
-            Vec::new(),
-            Expr::Literal(Literal {
-                parsed: "test".into(),
-                segment: segment.start..segment.end + 1,
-            }),
-            Vec::new(),
-        )?;
+        let call = self.call_arguments(Expr::Literal(Literal {
+            parsed: "test".into(),
+            segment: segment.start..segment.end + 1,
+        }))?;
 
         self.cursor.force_with(
             //expect trailing ']]'
@@ -151,12 +147,10 @@ mod tests {
         assert_eq!(
             result,
             vec![Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![Expr::Literal(Literal {
                     parsed: "test".into(),
                     segment: find_in(source.source, "[[")
                 })],
-                type_parameters: vec![],
             })]
         )
     }
@@ -168,7 +162,6 @@ mod tests {
         assert_eq!(
             result,
             vec![Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![
                     Expr::Literal(Literal {
                         parsed: "test".into(),
@@ -187,7 +180,6 @@ mod tests {
                         segment: find_in(source.source, "100"),
                     }),
                 ],
-                type_parameters: vec![],
             })]
         )
     }
@@ -202,9 +194,7 @@ mod tests {
             vec![Expr::Binary(BinaryOperation {
                 left: Box::new(Expr::Binary(BinaryOperation {
                     left: Box::new(Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![literal(content, "echo")],
-                        type_parameters: vec![],
                     })),
                     op: BinaryOperator::And,
                     right: Box::new(Expr::Test(Test {
@@ -227,7 +217,6 @@ mod tests {
                 })),
                 op: BinaryOperator::Or,
                 right: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         Expr::Literal(Literal {
                             parsed: "test".into(),
@@ -238,7 +227,6 @@ mod tests {
                             segment: find_in(content, "$1"),
                         }),
                     ],
-                    type_parameters: vec![],
                 })),
             })]
         )
@@ -297,13 +285,11 @@ mod tests {
             result,
             vec![Expr::Not(Not {
                 underlying: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal(source.source, "grep"),
                         literal(source.source, "-E"),
                         literal(source.source, "'^[0-9]+$'"),
                     ],
-                    type_parameters: vec![],
                 })),
                 segment: source.segment()
             })]

--- a/parser/src/aspects/type.rs
+++ b/parser/src/aspects/type.rs
@@ -78,11 +78,7 @@ impl<'a> TypeAspect<'a> for Parser<'a> {
     }
 
     fn parse_type_parameter_list(&mut self) -> ParseResult<(Vec<Type<'a>>, SourceSegment)> {
-        if self
-            .cursor
-            .lookahead(blanks().then(of_type(SquaredLeftBracket)))
-            .is_none()
-        {
+        if self.cursor.lookahead(of_type(SquaredLeftBracket)).is_none() {
             return Ok((Vec::new(), self.cursor.relative_pos_ctx(self.cursor.peek())));
         }
         let start = self.cursor.peek();

--- a/parser/src/aspects/var_declaration.rs
+++ b/parser/src/aspects/var_declaration.rs
@@ -219,7 +219,6 @@ mod tests {
                 },
                 initializer: Some(Box::new(Expr::Block(Block {
                     expressions: vec![Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             Expr::Literal(Literal {
                                 parsed: "echo".into(),
@@ -230,7 +229,6 @@ mod tests {
                                 segment: find_in_nth(&source.source, "a", 1),
                             }),
                         ],
-                        type_parameters: vec![],
                     })],
                     segment: find_in(&source.source, "{echo a}")
                 }))),

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -28,12 +28,10 @@ fn repos_delimiter_stack() {
         ParseReport {
             expr: vec![
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal_nth(source.source, "echo", 1),
                         literal(source.source, "end")
                     ],
-                    type_parameters: Vec::new()
                 }),
                 Expr::VarDeclaration(VarDeclaration {
                     kind: VarKind::Val,

--- a/parser/tests/expr.rs
+++ b/parser/tests/expr.rs
@@ -170,8 +170,6 @@ fn lambda_in_classic_call() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
-            type_parameters: Vec::new(),
             arguments: vec![
                 literal(source.source, "echo"),
                 literal(source.source, "a"),
@@ -281,12 +279,10 @@ fn background_command_echo() {
     let parsed = parse(source).expect("Failed to parse");
     let expected = vec![Expr::Detached(Detached {
         underlying: Box::new(Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 literal(source.source, "echo"),
                 literal(source.source, "hello"),
             ],
-            type_parameters: Vec::new(),
         })),
         segment: find_in(source.source, "echo hello &"),
     })];
@@ -300,9 +296,7 @@ fn command_starting_with_arg() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![literal(source.source, "-"), literal(source.source, "W")],
-            type_parameters: Vec::new()
         })]
     );
 }
@@ -314,7 +308,6 @@ fn constructor_in_call() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 literal(source.source, "echo"),
                 Expr::ProgrammaticCall(ProgrammaticCall {
@@ -329,7 +322,6 @@ fn constructor_in_call() {
                     segment: find_in(source.source, "Bar\\(\\)")
                 }),
             ],
-            type_parameters: Vec::new()
         })]
     );
 }
@@ -373,14 +365,12 @@ fn wildcard_redirect_or() {
         vec![Expr::Binary(BinaryOperation {
             left: Box::new(Expr::Redirected(Redirected {
                 expr: Box::new(Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal(content, "docker"),
                         literal(content, "image"),
                         literal(content, "inspect"),
                         literal(content, "moshell:0.1"),
                     ],
-                    type_parameters: Vec::new()
                 })),
                 redirections: vec![Redir {
                     fd: RedirFd::Wildcard,
@@ -391,12 +381,10 @@ fn wildcard_redirect_or() {
             })),
             op: BinaryOperator::Or,
             right: Box::new(Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![
                     literal(content, "echo"),
                     literal(content, "'Unknown image!'"),
                 ],
-                type_parameters: Vec::new()
             })),
         })]
     );
@@ -466,7 +454,6 @@ fn call_not_assign() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 literal(source.source, "a"),
                 literal(source.source, "'='"),
@@ -475,7 +462,6 @@ fn call_not_assign() {
                     segment: find_in(source.source, "5")
                 }),
             ],
-            type_parameters: Vec::new()
         })]
     );
 }
@@ -540,7 +526,6 @@ fn classic_call() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 literal(source.source, "ssh"),
                 literal(source.source, "localhost"),
@@ -556,7 +541,6 @@ fn classic_call() {
                     segment: find_in(source.source, "2")
                 }),
             ],
-            type_parameters: Vec::new()
         })]
     );
 }
@@ -644,7 +628,6 @@ fn method_call_with_type_params_and_ref() {
                 segment: find_between(source.source, ".", ")")
             }),
             Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![
                     literal(source.source, "echo"),
                     Expr::TemplateString(TemplateString {
@@ -666,7 +649,6 @@ fn method_call_with_type_params_and_ref() {
                         segment: find_between(source.source, "\"", "\"")
                     }),
                 ],
-                type_parameters: Vec::new()
             }),
         ]
     );
@@ -686,12 +668,10 @@ fn comments_mix_with_spaces() {
         parsed,
         vec![Expr::Block(Block {
             expressions: vec![Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![
                     literal(source.source, "ping"),
                     literal(source.source, "localhost")
                 ],
-                type_parameters: Vec::new()
             })],
             segment: source.segment()
         })]
@@ -705,7 +685,6 @@ fn classic_call_no_regression() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 literal(source.source, "test"),
                 literal(source.source, "'=>'"),
@@ -728,7 +707,6 @@ fn classic_call_no_regression() {
                     segment: find_in(source.source, "true$a")
                 }),
             ],
-            type_parameters: Vec::new()
         })]
     );
 }

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -42,7 +42,6 @@ fn with_lexer_var_reference_one() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 literal(source.source, "echo"),
                 literal(source.source, "'$var5'"),
@@ -51,7 +50,6 @@ fn with_lexer_var_reference_one() {
                     segment: find_in_nth(source.source, "$var5", 1),
                 }),
             ],
-            type_parameters: Vec::new()
         })]
     );
 }
@@ -64,7 +62,6 @@ fn with_lexer_var_reference_two() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 Expr::TemplateString(TemplateString {
                     parts: vec![
@@ -82,7 +79,6 @@ fn with_lexer_var_reference_two() {
                     segment: find_in(source.source, "$arg2"),
                 }),
             ],
-            type_parameters: Vec::new()
         })]
     );
 }
@@ -102,7 +98,6 @@ fn with_lexer_var_reference_three() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 literal(source.source, "echo"),
                 Expr::TemplateString(TemplateString {
@@ -126,7 +121,6 @@ fn with_lexer_var_reference_three() {
                     segment: find_between(source.source, "\"", "\""),
                 }),
             ],
-            type_parameters: Vec::new()
         })]
     );
 }
@@ -139,9 +133,7 @@ fn with_lexer_redirection() {
         parsed,
         vec![Expr::Redirected(Redirected {
             expr: Box::new(Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![literal(source.source, "test")],
-                type_parameters: Vec::new(),
             })),
             redirections: vec![Redir {
                 fd: RedirFd::Wildcard,
@@ -161,9 +153,7 @@ fn with_lexer_redirections() {
         parsed,
         vec![Expr::Redirected(Redirected {
             expr: Box::new(Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![literal(source.source, "command")],
-                type_parameters: Vec::new(),
             })),
             redirections: vec![
                 Redir {
@@ -192,18 +182,14 @@ fn with_lexer_pipe_and_redirection() {
         vec![Expr::Pipeline(Pipeline {
             commands: vec![
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(source.source, "ls"), literal(source.source, "-l")],
-                    type_parameters: Vec::new(),
                 }),
                 Expr::Redirected(Redirected {
                     expr: Box::new(Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             literal(source.source, "grep"),
                             literal(source.source, "'hello'"),
                         ],
-                        type_parameters: Vec::new()
                     })),
                     redirections: vec![Redir {
                         fd: RedirFd::Default,
@@ -226,23 +212,17 @@ fn with_lexer_pipe_and_pipe() {
         vec![Expr::Pipeline(Pipeline {
             commands: vec![
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(source.source, "ls")],
-                    type_parameters: Vec::new(),
                 }),
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(source.source, "wc")],
-                    type_parameters: Vec::new(),
                 }),
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![
                         literal(source.source, "tr"),
                         literal(source.source, "-s"),
                         literal(source.source, "' '"),
                     ],
-                    type_parameters: Vec::new()
                 }),
             ],
         }),]
@@ -258,9 +238,7 @@ fn with_lexer_here_string() {
         parsed,
         vec![Expr::Redirected(Redirected {
             expr: Box::new(Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![literal(content, "grep"), literal_nth(content, "e", 1)],
-                type_parameters: Vec::new(),
             })),
             redirections: vec![Redir {
                 fd: RedirFd::Default,
@@ -279,25 +257,21 @@ fn with_lexer_substitution() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 literal(source.source, "echo"),
                 Expr::Substitution(Substitution {
                     underlying: Subshell {
                         expressions: vec![Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![
                                 literal(source.source, "ls"),
                                 literal(source.source, "-l"),
                             ],
-                            type_parameters: Vec::new(),
                         })],
                         segment: find_in(source.source, "$(ls -l)"),
                     },
                     kind: SubstitutionKind::Capture,
                 }),
             ],
-            type_parameters: Vec::new()
         })]
     );
 }
@@ -309,13 +283,11 @@ fn with_lexer_substitution_in_substitution() {
     assert_eq!(
         parsed,
         vec![Expr::Call(Call {
-            path: Vec::new(),
             arguments: vec![
                 literal(source.source, "echo"),
                 Expr::Substitution(Substitution {
                     underlying: Subshell {
                         expressions: vec![Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![
                                 literal(source.source, "ls"),
                                 Expr::TemplateString(TemplateString {
@@ -323,9 +295,7 @@ fn with_lexer_substitution_in_substitution() {
                                         Expr::Substitution(Substitution {
                                             underlying: Subshell {
                                                 expressions: vec![Expr::Call(Call {
-                                                    path: Vec::new(),
                                                     arguments: vec![literal(source.source, "pwd")],
-                                                    type_parameters: Vec::new(),
                                                 })],
                                                 segment: find_in(source.source, "$(pwd)"),
                                             },
@@ -336,14 +306,12 @@ fn with_lexer_substitution_in_substitution() {
                                     segment: find_in(source.source, "\"$(pwd)/test\""),
                                 }),
                             ],
-                            type_parameters: Vec::new(),
                         })],
                         segment: find_in(source.source, "$( ls \"$(pwd)/test\" )"),
                     },
                     kind: SubstitutionKind::Capture,
                 }),
             ],
-            type_parameters: Vec::new()
         })]
     );
 }
@@ -357,23 +325,18 @@ fn pipe_expressions() {
         vec![Expr::Pipeline(Pipeline {
             commands: vec![
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(source.source, "find"), literal(source.source, "."),],
-                    type_parameters: Vec::new(),
                 }),
                 Expr::While(While {
                     condition: Box::new(Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             literal(source.source, "read"),
                             literal(source.source, "-r"),
                             literal(source.source, "filename"),
                         ],
-                        type_parameters: Vec::new(),
                     })),
                     body: Box::new(Expr::Block(Block {
                         expressions: vec![Expr::Call(Call {
-                            path: Vec::new(),
                             arguments: vec![
                                 literal(source.source, "echo"),
                                 Expr::VarReference(VarReference {
@@ -381,7 +344,6 @@ fn pipe_expressions() {
                                     segment: find_in(source.source, "$filename"),
                                 }),
                             ],
-                            type_parameters: Vec::new(),
                         })],
                         segment: find_in(source.source, "{ echo $filename }"),
                     })),
@@ -402,19 +364,15 @@ fn pipe_to_command() {
             commands: vec![
                 Expr::Block(Block {
                     expressions: vec![Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![
                             literal(source.source, "echo"),
                             literal(source.source, "'1\n2'")
                         ],
-                        type_parameters: Vec::new(),
                     })],
                     segment: find_in(source.source, "{ echo '1\n2' }"),
                 }),
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(source.source, "cat")],
-                    type_parameters: Vec::new(),
                 }),
             ],
         })]
@@ -456,12 +414,10 @@ fn loop_assign() {
                     underlying: Subshell {
                         expressions: vec![Expr::Redirected(Redirected {
                             expr: Box::new(Expr::Call(Call {
-                                path: Vec::new(),
                                 arguments: vec![
                                     literal(source.source, "pgrep"),
                                     literal(source.source, "shell"),
                                 ],
-                                type_parameters: Vec::new(),
                             })),
                             redirections: vec![Redir {
                                 fd: RedirFd::Fd(2),
@@ -491,9 +447,7 @@ fn here_string_pipeline() {
             commands: vec![
                 Expr::Redirected(Redirected {
                     expr: Box::new(Expr::Call(Call {
-                        path: Vec::new(),
                         arguments: vec![literal(source.source, "sort")],
-                        type_parameters: Vec::new(),
                     })),
                     redirections: vec![Redir {
                         fd: RedirFd::Default,
@@ -506,9 +460,7 @@ fn here_string_pipeline() {
                     }],
                 }),
                 Expr::Call(Call {
-                    path: Vec::new(),
                     arguments: vec![literal(source.source, "uniq")],
-                    type_parameters: Vec::new(),
                 }),
             ],
         })]
@@ -523,9 +475,7 @@ fn redirect_string_local_exe() {
         parsed,
         vec![Expr::Redirected(Redirected {
             expr: Box::new(Expr::Call(Call {
-                path: Vec::new(),
                 arguments: vec![literal(source.source, "./target/debug/cli")],
-                type_parameters: Vec::new(),
             })),
             redirections: vec![Redir {
                 fd: RedirFd::Default,


### PR DESCRIPTION
This pull request removes from the AST the inclusion `path` and `type_parameters` fields.
As we discussed that moshell functions and system command calls cannot get mixed up, type parameters and inclusion paths makes no more sense in the current moshell's state