### PR TITLE
Rework operator parsing

### DIFF
--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -470,8 +470,8 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
             Expr::Test(test) => {
                 self.tree_walk(state, &test.expression, to_visit);
             }
-            Expr::Not(not) => {
-                self.tree_walk(state, &not.underlying, to_visit);
+            Expr::Unary(unary) => {
+                self.tree_walk(state, &unary.expr, to_visit);
             }
             Expr::Parenthesis(paren) => {
                 self.tree_walk(state, &paren.expression, to_visit);

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -9,13 +9,13 @@ use crate::control_flow::{For, If, Loop, While};
 use crate::function::{FunctionDeclaration, Return};
 use crate::group::{Block, Parenthesis, Subshell};
 use crate::lambda::LambdaDef;
-use crate::operation::BinaryOperation;
+use crate::operation::{BinaryOperation, UnaryOperation};
 use crate::r#match::Match;
 use crate::r#type::CastedExpr;
 use crate::r#use::Use;
 use crate::range::Iterable;
 use crate::substitution::Substitution;
-use crate::test::{Not, Test};
+use crate::test::Test;
 use crate::value::{Literal, TemplateString};
 use crate::variable::{Assign, VarDeclaration, VarReference};
 
@@ -38,6 +38,7 @@ pub mod variable;
 #[derive(Debug, Clone, PartialEq, DebugPls)]
 pub enum Expr<'a> {
     Assign(Assign<'a>),
+    Unary(UnaryOperation<'a>),
     Binary(BinaryOperation<'a>),
     Literal(Literal),
 
@@ -60,7 +61,6 @@ pub enum Expr<'a> {
     Casted(CastedExpr<'a>),
 
     Test(Test<'a>),
-    Not(Not<'a>),
 
     If(If<'a>),
     While(While<'a>),
@@ -91,6 +91,7 @@ impl SourceSegmentHolder for Expr<'_> {
     fn segment(&self) -> SourceSegment {
         match self {
             Expr::Assign(assign) => assign.segment(),
+            Expr::Unary(unary) => unary.segment(),
             Expr::Binary(binary) => binary.segment(),
             Expr::Literal(literal) => literal.segment.clone(),
             Expr::Match(m) => m.segment.clone(),
@@ -106,7 +107,6 @@ impl SourceSegmentHolder for Expr<'_> {
             Expr::Use(use_) => use_.segment.clone(),
             Expr::Casted(casted) => casted.segment(),
             Expr::Test(test) => test.segment.clone(),
-            Expr::Not(not) => not.segment.clone(),
             Expr::If(if_) => if_.segment.clone(),
             Expr::While(while_) => while_.segment.clone(),
             Expr::Loop(loop_) => loop_.segment.clone(),

--- a/ast/src/operation.rs
+++ b/ast/src/operation.rs
@@ -1,11 +1,31 @@
 use dbg_pls::DebugPls;
-use enum_assoc::Assoc;
 
 use context::source::{SourceSegment, SourceSegmentHolder};
 use lexer::token::TokenType;
+use src_macros::segment_holder;
 
 use crate::operation::BinaryOperator::*;
 use crate::Expr;
+
+/// A prefix unary operation.
+#[segment_holder]
+#[derive(Debug, Clone, PartialEq, DebugPls)]
+pub struct UnaryOperation<'a> {
+    /// The operator of the operation.
+    pub op: UnaryOperator,
+
+    /// The expression the operator is applied to.
+    pub expr: Box<Expr<'a>>,
+}
+
+/// A prefix unary operator.
+#[derive(Debug, Clone, PartialEq, DebugPls)]
+pub enum UnaryOperator {
+    /// The `!` operator.
+    Not,
+    /// The `-` operator.
+    Negate,
+}
 
 /// A binary operation between two expressions.
 #[derive(Debug, Clone, PartialEq, DebugPls)]
@@ -24,63 +44,35 @@ impl SourceSegmentHolder for BinaryOperation<'_> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Assoc, DebugPls)]
-#[func(pub const fn priority(& self) -> i8)]
-#[func(pub const fn token(& self) -> TokenType)]
+#[derive(Debug, Copy, Clone, PartialEq, DebugPls)]
 pub enum BinaryOperator {
     /// The '&&' operator.
-    #[assoc(priority = -2)]
-    #[assoc(token = TokenType::And)]
     And,
     /// The '||' operator.
-    #[assoc(priority = -3)]
-    #[assoc(token = TokenType::Or)]
     Or,
 
     /// The `==` operator.
-    #[assoc(priority = -1)]
-    #[assoc(token = TokenType::EqualEqual)]
     EqualEqual,
     /// The `!=` operator.
-    #[assoc(priority = -1)]
-    #[assoc(token = TokenType::NotEqual)]
     NotEqual,
     /// The `<` operator.
-    #[assoc(priority = -1)]
-    #[assoc(token = TokenType::Less)]
     Less,
     /// The `<=` operator.
-    #[assoc(priority = -1)]
-    #[assoc(token = TokenType::LessEqual)]
     LessEqual,
     /// The `>` operator.
-    #[assoc(priority = -1)]
-    #[assoc(token = TokenType::Greater)]
     Greater,
     /// The `>=` operator.
-    #[assoc(priority = -1)]
-    #[assoc(token = TokenType::GreaterEqual)]
     GreaterEqual,
 
     /// The `+` operator.
-    #[assoc(priority = 0)]
-    #[assoc(token = TokenType::Plus)]
     Plus,
     /// The `-` operator.
-    #[assoc(priority = 0)]
-    #[assoc(token = TokenType::Minus)]
     Minus,
     /// The `*` operator.
-    #[assoc(priority = 1)]
-    #[assoc(token = TokenType::Star)]
     Times,
     /// The `/` operator.
-    #[assoc(priority = 1)]
-    #[assoc(token = TokenType::Slash)]
     Divide,
     /// The `%` operator.
-    #[assoc(priority = 1)]
-    #[assoc(token = TokenType::Percent)]
     Modulo,
 }
 

--- a/ast/src/test.rs
+++ b/ast/src/test.rs
@@ -11,11 +11,3 @@ pub struct Test<'a> {
     ///expression present between brackets
     pub expression: Box<Expr<'a>>,
 }
-
-///a not (`! ..`) expression
-#[segment_holder]
-#[derive(Debug, Clone, PartialEq, DebugPls)]
-pub struct Not<'a> {
-    ///the expression after `!`
-    pub underlying: Box<Expr<'a>>,
-}

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -216,7 +216,14 @@ impl TokenType {
                 | LessEqual
                 | Greater
                 | GreaterEqual
+                | DotDot
+                | As
         )
+    }
+
+    /// Tests if this token is an infix operator.
+    pub fn is_infix_operator(self) -> bool {
+        matches!(self, Not | Minus)
     }
 
     ///is this lexeme a lexeme that cannot fusion with other glued tokens

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -200,8 +200,8 @@ impl TokenType {
         )
     }
 
-    ///is this lexeme a binary operator ?
-    pub fn is_bin_operator(self) -> bool {
+    /// Tests if this token is a valid identifier.
+    pub fn is_infix_operator(self) -> bool {
         matches!(
             self,
             And | Or
@@ -221,8 +221,8 @@ impl TokenType {
         )
     }
 
-    /// Tests if this token is an infix operator.
-    pub fn is_infix_operator(self) -> bool {
+    /// Tests if this token is a prefix operator.
+    pub fn is_prefix_operator(self) -> bool {
         matches!(self, Not | Minus)
     }
 

--- a/parser/src/aspects/binary_operation.rs
+++ b/parser/src/aspects/binary_operation.rs
@@ -1,15 +1,13 @@
-use ast::operation::{BinaryOperation, BinaryOperator};
-use ast::Expr;
+use crate::aspects::redirection::RedirectionAspect;
+use crate::parser::Parser;
 use lexer::token::TokenType;
 
-use crate::moves::{bin_op, spaces, MoveOperations};
-use crate::parser::{ParseResult, Parser};
+const NOT_AN_OPERATOR: u8 = 0;
 
 /// Gets the binding power of an infix operator for a Pratt parser.
 ///
 /// If the token is not an infix operator, 0 is returned.
-pub const fn infix_precedence(tok: TokenType) -> u8 {
-    const NOT_AN_OPERATOR: u8 = 0;
+pub(crate) const fn infix_precedence(tok: TokenType) -> u8 {
     use TokenType::*;
     match tok {
         DotDot => 2,
@@ -23,61 +21,17 @@ pub const fn infix_precedence(tok: TokenType) -> u8 {
     }
 }
 
-/// A parser aspect to parse any kind of binary operations.
-pub trait BinaryOperationsAspect<'p> {
-    /// Parses a binary operation expression.
-    ///
-    /// `expr`: the left-hand side of the binary operation to start with
-    /// `parse_next`: a function that parses the next expression to the right of the binary operation
-    fn binary_operation<P>(&mut self, expr: Expr<'p>, parse_next: P) -> ParseResult<Expr<'p>>
-    where
-        P: FnMut(&mut Self) -> ParseResult<Expr<'p>> + Copy;
-}
-
-impl<'p> BinaryOperationsAspect<'p> for Parser<'p> {
-    fn binary_operation<P>(&mut self, expr: Expr<'p>, parse: P) -> ParseResult<Expr<'p>>
-    where
-        P: FnMut(&mut Self) -> ParseResult<Expr<'p>> + Copy,
-    {
-        // Parse a top-level tree with the lowest precedence
-        self.binary_operation_internal(expr, parse, u8::MIN)
-    }
-}
-
-impl<'p> Parser<'p> {
-    fn binary_operation_internal<P>(
-        &mut self,
-        mut expr: Expr<'p>,
-        mut parse: P,
-        min_precedence: u8,
-    ) -> ParseResult<Expr<'p>>
-    where
-        P: FnMut(&mut Self) -> ParseResult<Expr<'p>> + Copy,
-    {
-        while let Some(binary_op) = self.cursor.lookahead(spaces().then(bin_op())) {
-            let op =
-                BinaryOperator::try_from(binary_op.token_type).expect("Invalid binary operator");
-            let op_priority = infix_precedence(binary_op.token_type);
-            if op_priority < min_precedence {
-                return Ok(expr);
-            }
-            self.cursor.advance(spaces().then(bin_op()));
-
-            let mut right = parse(self)?;
-            while let Some(binary_op) = self.cursor.lookahead(spaces().then(bin_op())) {
-                let local_op_priority = infix_precedence(binary_op.token_type);
-                if local_op_priority <= op_priority {
-                    break;
-                }
-                right = self.binary_operation_internal(right, parse, local_op_priority)?;
-            }
-            expr = Expr::Binary(BinaryOperation {
-                left: Box::new(expr),
-                op,
-                right: Box::new(right),
-            });
-        }
-        Ok(expr)
+/// Gets the binding power of the current token in a shell context.
+///
+/// If the token is not an infix operator, 0 is returned.
+pub(crate) fn shell_infix_precedence(parser: &Parser) -> u8 {
+    use TokenType::*;
+    match parser.cursor.peek().token_type {
+        Or => 1,
+        And => 2,
+        Bar => 3,
+        _ if parser.is_at_redirection_sign() => 4,
+        _ => NOT_AN_OPERATOR,
     }
 }
 

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -352,9 +352,9 @@ mod tests {
         let content = "ls )";
         let source = Source::unknown(content);
         assert_eq!(
-            Parser::new(source).parse_next(),
+            ParseResult::<Vec<Expr>>::from(parse(source)),
             Err(ParseError {
-                message: "expected end of expression or file".to_string(),
+                message: "Unexpected closing delimiter.".to_string(),
                 position: content.find(')').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected,
             })

--- a/parser/src/aspects/group.rs
+++ b/parser/src/aspects/group.rs
@@ -30,7 +30,7 @@ impl<'a> GroupAspect<'a> for Parser<'a> {
     fn block(&mut self) -> ParseResult<Block<'a>> {
         let start = self.ensure_at_group_start(TokenType::CurlyLeftBracket)?;
         let (expressions, segment) =
-            self.sub_exprs(start, TokenType::CurlyRightBracket, Parser::statement)?;
+            self.sub_exprs(start, TokenType::CurlyRightBracket, Parser::declaration)?;
         Ok(Block {
             expressions,
             segment,
@@ -42,7 +42,7 @@ impl<'a> GroupAspect<'a> for Parser<'a> {
         let (expressions, segment) = self.sub_exprs(
             start.clone(),
             TokenType::RoundedRightBracket,
-            Parser::statement,
+            Parser::declaration,
         )?;
         Ok(Subshell {
             expressions,

--- a/parser/src/aspects/loop.rs
+++ b/parser/src/aspects/loop.rs
@@ -25,7 +25,7 @@ impl<'a> LoopAspect<'a> for Parser<'a> {
         )?;
         //consume blanks before condition
         self.cursor.advance(blanks());
-        let condition = Box::new(self.expression_statement()?);
+        let condition = Box::new(self.statement()?);
 
         //consume blanks
         self.cursor.advance(blanks());
@@ -597,7 +597,7 @@ mod tests {
         assert_eq!(
             res,
             Err(ParseError {
-                message: "Expected expression statement".to_string(),
+                message: "Expected statement".to_string(),
                 position: content.len()..content.len(),
                 kind: Unexpected,
             })

--- a/parser/src/aspects/range.rs
+++ b/parser/src/aspects/range.rs
@@ -1,6 +1,8 @@
+use crate::aspects::binary_operation::infix_precedence;
 use ast::range::NumericRange;
 use ast::Expr;
 use lexer::token::TokenType;
+use std::num::NonZeroU8;
 
 use crate::moves::of_type;
 use crate::parser::{ParseResult, Parser};
@@ -13,14 +15,17 @@ pub trait RangeAspect<'a> {
 impl<'a> RangeAspect<'a> for Parser<'a> {
     /// Parses a range or an iterable variable expression.
     fn parse_range(&mut self, start: Expr<'a>) -> ParseResult<NumericRange<'a>> {
+        // Could use a constant when `.expect()` becomes a const fn
+        let precedence = NonZeroU8::new(infix_precedence(TokenType::DotDot) + 1)
+            .expect("Precedence should be non-zero");
         // Read the second bound of the range
         let upper_inclusive = self.cursor.advance(of_type(TokenType::Equal)).is_some();
-        let end = self.next_value()?;
+        let end = self.value_precedence(precedence)?;
 
         // Read the step of the range if it exists
         let mut step: Option<Expr<'a>> = None;
         if self.cursor.advance(of_type(TokenType::DotDot)).is_some() {
-            step = Some(self.next_value()?);
+            step = Some(self.value_precedence(precedence)?);
         }
 
         Ok(NumericRange {

--- a/parser/src/aspects/redirection.rs
+++ b/parser/src/aspects/redirection.rs
@@ -108,7 +108,7 @@ impl<'a> RedirectionAspect<'a> for Parser<'a> {
         })
     }
 
-    fn redirectable(&mut self, mut expr: Expr<'a>) -> ParseResult<Expr<'a>> {
+    fn redirectable(&mut self, expr: Expr<'a>) -> ParseResult<Expr<'a>> {
         let mut redirections = vec![];
         self.cursor.advance(spaces());
 
@@ -131,23 +131,20 @@ impl<'a> RedirectionAspect<'a> for Parser<'a> {
             self.cursor.advance(spaces());
         }
 
-        if !redirections.is_empty() {
-            expr = Expr::Redirected(Redirected {
+        Ok(if redirections.is_empty() {
+            expr
+        } else {
+            Expr::Redirected(Redirected {
                 expr: Box::new(expr),
                 redirections,
-            });
-        }
-        if self.cursor.lookahead(of_type(TokenType::Bar)).is_some() {
-            self.pipeline(expr)
-        } else {
-            Ok(expr)
-        }
+            })
+        })
     }
 
     fn is_at_redirection_sign(&self) -> bool {
         let pivot = self.cursor.peek();
         match pivot.token_type {
-            TokenType::Ampersand | TokenType::Less | TokenType::Greater | TokenType::Bar => true,
+            TokenType::Ampersand | TokenType::Less | TokenType::Greater => true,
             //search for '>' or '<' in case of std-determined redirection sign (ex: 2>>)
             _ => self
                 .cursor

--- a/parser/src/aspects/type.rs
+++ b/parser/src/aspects/type.rs
@@ -1,9 +1,7 @@
-use ast::r#type::{ByName, CallableType, CastedExpr, ParametrizedType, Type};
+use ast::r#type::{ByName, CallableType, ParametrizedType, Type};
 use ast::r#use::InclusionPathItem;
-use ast::Expr;
 use context::display::fmt_comma_separated;
 use context::source::{SourceSegment, SourceSegmentHolder};
-use lexer::token::TokenType::*;
 use lexer::token::TokenType::{
     FatArrow, Identifier, NewLine, RoundedLeftBracket, RoundedRightBracket, SquaredLeftBracket,
     SquaredRightBracket,
@@ -22,9 +20,6 @@ pub trait TypeAspect<'a> {
 
     ///parse a type parameter list (`[...]`)
     fn parse_type_parameter_list(&mut self) -> ParseResult<(Vec<Type<'a>>, SourceSegment)>;
-
-    ///parse a casted expression (ex: {..} as Type)
-    fn parse_cast(&mut self, casted_expr: Expr<'a>) -> ParseResult<CastedExpr<'a>>;
 }
 
 impl<'a> TypeAspect<'a> for Parser<'a> {
@@ -94,20 +89,6 @@ impl<'a> TypeAspect<'a> for Parser<'a> {
             );
         }
         Ok((tparams, segment))
-    }
-
-    fn parse_cast(&mut self, casted_expr: Expr<'a>) -> ParseResult<CastedExpr<'a>> {
-        self.cursor.force(
-            blanks().then(of_type(As)),
-            "expected 'as' for cast expression.",
-        )?;
-        let casted_type = self.parse_type()?;
-        let segment = casted_expr.segment().start..casted_type.segment().end;
-        Ok(CastedExpr {
-            expr: Box::new(casted_expr),
-            casted_type,
-            segment,
-        })
     }
 }
 

--- a/parser/src/moves.rs
+++ b/parser/src/moves.rs
@@ -365,11 +365,6 @@ pub(crate) fn line_end() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool) +
     of_types(&[NewLine, SemiColon, EndOfFile])
 }
 
-///a move that consumes a binary operation character
-pub(crate) fn bin_op() -> PredicateMove<impl (for<'a> Fn(Token<'a>) -> bool) + Copy> {
-    like(TokenType::is_bin_operator)
-}
-
 pub(crate) fn identifier_parenthesis() -> AndThenMove<
     PredicateMove<impl Fn(Token) -> bool + Copy + Sized>,
     PredicateMove<impl Fn(Token) -> bool + Copy + Sized>,

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -60,7 +60,7 @@ fn repos_delimiter_stack() {
                     kind: ParseErrorKind::Unpaired(content.find('{').map(|p| p..p + 1).unwrap())
                 },
                 ParseError {
-                    message: "invalid infix operator".to_string(),
+                    message: "expected end of expression or file".to_string(),
                     position: content.rfind('!').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected
                 }
@@ -108,8 +108,8 @@ fn what_is_an_import() {
                 kind: ParseErrorKind::Unexpected
             },
             ParseError {
-                message: "invalid infix operator".to_owned(),
-                position: content.find('%').map(|p| p..p + 1).unwrap(),
+                message: "Expected value".to_owned(),
+                position: content.find('%').map(|p| p + 1..p + 2).unwrap(),
                 kind: ParseErrorKind::Unexpected
             },
             ParseError {
@@ -191,7 +191,7 @@ fn invalid_binary_operator_cause_one_error() {
                 segment: find_in(content, "val incorrect = 'a'")
             })],
             errors: vec![ParseError {
-                message: "invalid infix operator".to_owned(),
+                message: "expected end of expression or file".to_owned(),
                 position: content.find('!').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
@@ -501,18 +501,15 @@ fn quotes_are_delimiters() {
     let source = Source::unknown(content);
     let report = parse(source);
     assert_eq!(
-        report,
-        ParseReport {
-            expr: vec![],
-            errors: vec![ParseError {
-                message: "expected end of expression or file".to_owned(),
-                position: content
-                    .match_indices('"')
-                    .nth(2)
-                    .map(|(p, _)| p..p + 1)
-                    .unwrap(),
-                kind: ParseErrorKind::Unexpected
-            }],
-        }
+        report.errors,
+        vec![ParseError {
+            message: "expected end of expression or file".to_owned(),
+            position: content
+                .match_indices('"')
+                .nth(2)
+                .map(|(p, _)| p..p + 1)
+                .unwrap(),
+            kind: ParseErrorKind::Unexpected
+        }]
     );
 }


### PR DESCRIPTION
In the current (mostly) recursive descent parser, operator precedence is a combination of wrappers around a left-hand side parser. It becomes more and more hazardous as additions are made. The goal here is to consolidate that by handling prefix, postfix and infix operators in the same place, with a Pratt parser.

Precedence
-----------------

The not operator (`!`) is just one prefix operator, the newly added negate operator (`-`) is another. It increased the need of a proper precedence table:

*From strong to weak, left-associative, unless noted.*
|Operator/Expression|Note|
|------------------------------|------|
|Paths|Currently handled separately|
|Method calls||
|Function calls, array indexing|Indexing is tracked by #50|
|Unary `!`, `-`||
|`as`||
|`*`, `/`, `%`||
|`+`, `-`||
|`==`, `!=`, `<`, `>`, `<=`, `>=`||
|`&&`||
|`\|\|`||
|`..`||
|`=`, `+=`, `-=`, `*=`, `/=`, `%=`|Right-associative, tracked by #50 and #62|

A shell context has a different table:

|Operator/Expression|
|------------------------------|
|Redirection|
|`\|`|
|`&&`|
|`\|\|`|

Predictability
------------------

Those operators are now parsed in one place, removing the legacy `parse_full_expr` parser. `expression_statment` is no more, as it just a statement, where shell operators apply. `if` and `match` are no longer generic, they no longer depend on if they come from a statement or a value.