### PR TITLE
Implement reefs on analyzer side

### DIFF
--- a/analyzer/src/diagnostic.rs
+++ b/analyzer/src/diagnostic.rs
@@ -29,56 +29,67 @@ pub enum DiagnosticID {
     #[assoc(critical = true)]
     InvalidSymbol,
 
+    /// A symbol path is invalid by its structure
+    /// (for example, the path `reef::foo::reef` is invalid because the last `reef` would targets the current reef)
+    #[assoc(code = 5)]
+    #[assoc(critical = true)]
+    InvalidSymbolPath,
+
     /// There is a `use` statement between two expressions,
     /// `use` needs to be declared before any expressions in an environment.
-    #[assoc(code = 5)]
+    #[assoc(code = 6)]
     #[assoc(critical = true)]
     UseBetweenExprs,
 
     /// A `use` statement is shadowed as the symbol it imports has been imported again below
-    #[assoc(code = 6)]
+    #[assoc(code = 7)]
     ShadowedImport,
 
     /// A symbol have the same fully qualified name (its name with its module's name prepended)
     /// as another module
-    #[assoc(code = 7)]
+    #[assoc(code = 8)]
     #[assoc(critical = true)]
     SymbolConflictsWithModule,
 
     /// A type annotation refers to an unknown type.
-    #[assoc(code = 8)]
+    #[assoc(code = 9)]
     #[assoc(critical = true)]
     UnknownType,
 
     /// A type annotation is not matching the expected type.
-    #[assoc(code = 9)]
+    #[assoc(code = 10)]
     #[assoc(critical = true)]
     TypeMismatch,
 
     /// A type annotation is missing, and cannot be inferred.
-    #[assoc(code = 10)]
+    #[assoc(code = 11)]
     #[assoc(critical = true)]
     CannotInfer,
 
     /// Occurs when a `continue` or `break` directive is declared outside of a loop.
-    #[assoc(code = 11)]
+    #[assoc(code = 12)]
     #[assoc(critical = true)]
     InvalidBreakOrContinue,
 
     /// A type cannot be casted to another type.
-    #[assoc(code = 12)]
+    #[assoc(code = 13)]
     #[assoc(critical = true)]
     IncompatibleCast,
 
     /// A named method is unknown or does not match the expected signature.
-    #[assoc(code = 13)]
+    #[assoc(code = 14)]
     #[assoc(critical = true)]
     UnknownMethod,
 
     /// A variable is being reassigned, but it is not mutable.
-    #[assoc(code = 14)]
+    #[assoc(code = 15)]
     #[assoc(critical = true)]
     CannotReassign,
+
+    /// A variable is being reassigned, but it is not mutable.
+    #[assoc(code = 16)]
+    #[assoc(critical = true)]
+    ReefNotFound,
 }
 
 /// Observations are labels in a code snippet that are used to explain a [`Diagnostic`].

--- a/analyzer/src/diagnostic.rs
+++ b/analyzer/src/diagnostic.rs
@@ -85,11 +85,6 @@ pub enum DiagnosticID {
     #[assoc(code = 15)]
     #[assoc(critical = true)]
     CannotReassign,
-
-    /// A variable is being reassigned, but it is not mutable.
-    #[assoc(code = 16)]
-    #[assoc(critical = true)]
-    ReefNotFound,
 }
 
 /// Observations are labels in a code snippet that are used to explain a [`Diagnostic`].

--- a/analyzer/src/environment/symbols.rs
+++ b/analyzer/src/environment/symbols.rs
@@ -101,12 +101,11 @@ impl SymbolLocation {
     ///
     /// The function can also fail if the `must_be_relative`
     pub fn compute<'a>(
-        path: &'a [InclusionPathItem<'a>],
-        must_be_relative: bool,
+        path: &'a [InclusionPathItem<'a>]
     ) -> Result<Self, Vec<SourceSegment>> {
         let current_reef = path
             .first()
-            .is_some_and(|f| !must_be_relative && matches!(f, InclusionPathItem::Reef(_)));
+            .is_some_and(|f| matches!(f, InclusionPathItem::Reef(_)));
 
         let mut path_it = path.iter();
 

--- a/analyzer/src/imports.rs
+++ b/analyzer/src/imports.rs
@@ -3,9 +3,9 @@ use std::fmt::{Debug, Formatter};
 
 use indexmap::IndexMap;
 
+use crate::environment::variables::SymbolLocation;
 use context::source::SourceSegment;
 
-use crate::name::Name;
 use crate::relations::{ResolvedSymbol, SourceId};
 
 #[derive(Debug, Default)]
@@ -62,10 +62,10 @@ pub enum UnresolvedImport {
     /// A symbol import with an optional alias.
     Symbol {
         alias: Option<String>,
-        qualified_name: Name,
+        loc: SymbolLocation,
     },
     /// Variant to target all the exported symbols of a symbol
-    AllIn(Name),
+    AllIn(SymbolLocation),
 }
 
 /// A resolved symbol import
@@ -75,8 +75,7 @@ pub enum ResolvedImport {
     Symbol(ResolvedSymbol),
     /// The import is an environment
     Env(SourceId),
-
-    /// The import wasn't found
+    /// The import is unresolvable
     Dead,
 }
 

--- a/analyzer/src/imports.rs
+++ b/analyzer/src/imports.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Formatter};
 
 use indexmap::IndexMap;
 
-use crate::environment::variables::SymbolLocation;
+use crate::environment::symbols::{SymbolLocation, SymbolRegistry};
 use context::source::SourceSegment;
 
 use crate::relations::{ResolvedSymbol, SourceId};
@@ -71,8 +71,9 @@ pub enum UnresolvedImport {
 /// A resolved symbol import
 #[derive(PartialEq, Eq, Debug)]
 pub enum ResolvedImport {
-    /// The import is a symbol
-    Symbol(ResolvedSymbol),
+    /// The import is a symbol name.
+    /// A (non empty) hashmap contains the binding, for the bound name, of the symbol according to its registry
+    Symbols(HashMap<SymbolRegistry, ResolvedSymbol>),
     /// The import is an environment
     Env(SourceId),
     /// The import is unresolvable

--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -27,8 +27,6 @@ use crate::relations::SourceId;
 use crate::steps::collect::SymbolCollector;
 use crate::steps::resolve_sources;
 use crate::steps::typing::apply_types;
-use crate::types::engine::TypedEngine;
-use crate::types::Typing;
 
 pub mod diagnostic;
 pub mod engine;
@@ -62,12 +60,6 @@ pub struct Analyzer<'ca, 'e> {
     /// The current state of the resolution.
     pub resolution: ResolutionResult,
 
-    /// The current type knowledge.
-    pub typing: Typing,
-
-    /// The applied types over the [`Engine`].
-    pub engine: TypedEngine,
-
     pub context: ReefContext<'ca, 'e>,
 
     /// The diagnostics that were generated during the analysis.
@@ -79,8 +71,6 @@ impl<'ca, 'e> Analyzer<'ca, 'e> {
     pub fn new(context: ReefContext<'ca, 'e>) -> Self {
         Self {
             resolution: ResolutionResult::default(),
-            typing: Typing::default(),
-            engine: TypedEngine::default(),
             context,
             diagnostics: Vec::new(),
         }
@@ -101,13 +91,7 @@ impl<'ca, 'e> Analyzer<'ca, 'e> {
             &mut self.diagnostics,
         );
         if self.diagnostics.is_empty() {
-            let (engine, typing) = apply_types(
-                &self.context.current_reef().engine,
-                &self.context.current_reef().relations,
-                &mut self.diagnostics,
-            );
-            self.engine = engine;
-            self.typing = typing;
+            apply_types(&mut self.context, &mut self.diagnostics);
         }
         Analysis {
             analyzer: self,
@@ -140,13 +124,7 @@ impl<'ca, 'e> Analyzer<'ca, 'e> {
             &mut self.diagnostics,
         );
         if self.diagnostics.is_empty() {
-            let (engine, typing) = apply_types(
-                &self.context.current_reef().engine,
-                &self.context.current_reef().relations,
-                &mut self.diagnostics,
-            );
-            self.engine = engine;
-            self.typing = typing;
+            apply_types(&mut self.context, &mut self.diagnostics);
         }
         Analysis {
             analyzer: self,

--- a/analyzer/src/lib.rs
+++ b/analyzer/src/lib.rs
@@ -22,7 +22,7 @@ use crate::diagnostic::Diagnostic;
 use crate::importer::{ASTImporter, Imported};
 use crate::imports::Imports;
 use crate::name::Name;
-use crate::reef::{ReefContext, ReefId};
+use crate::reef::{ReefContext};
 use crate::relations::SourceId;
 use crate::steps::collect::SymbolCollector;
 use crate::steps::resolve_sources;
@@ -216,9 +216,6 @@ pub struct Inject<'a> {
 
     /// The environment to inject the source into.
     pub attached: Option<SourceId>,
-
-    /// The injection's reef
-    pub reef: ReefId,
 }
 
 /// The results of an analysis

--- a/analyzer/src/reef.rs
+++ b/analyzer/src/reef.rs
@@ -1,4 +1,4 @@
-use std::collections::hash_map::Entry;
+use crate::Analyzer;
 use std::collections::HashMap;
 
 use crate::engine::Engine;
@@ -19,35 +19,53 @@ pub struct Reef<'e> {
     pub type_context: TypeContext,
 }
 
+impl<'e> Reef<'e> {
+    pub fn new(name: String, analyzer: Analyzer<'e>) -> Self {
+        Self {
+            name,
+            engine: analyzer.resolution.engine,
+            relations: analyzer.resolution.relations,
+            typed_engine: analyzer.engine,
+            typing: analyzer.typing,
+            type_context: analyzer.type_context,
+        }
+    }
+
+    pub fn new_partial(name: String, engine: Engine<'e>, relations: Relations) -> Self {
+        Self {
+            name,
+            engine,
+            relations,
+            typed_engine: TypedEngine::default(),
+            typing: Typing::default(),
+            type_context: TypeContext::default(),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]
 pub struct ReefId(pub ObjectId);
 
-/// An absolute set of reef.
-/// This structure is the highest structure in which the reefs can refer to, because reef's external
-/// relations are relative to this set content.
-///
-/// The reef with id `0` is the lang reef. It is required and is part of the default reef's state.
-///
-/// [ReefId] identifiers are unique and reef names also needs to be. This way, if a new reef is inserted with a
-/// conflicting name, a panic would occur.
-pub struct Reefs<'e> {
+pub struct Externals<'a> {
+    pub current: ReefId,
     names: HashMap<String, ReefId>,
-    reefs: Vec<Reef<'e>>,
+    reefs: Vec<Reef<'a>>,
 }
 
 pub const LANG_REEF: ReefId = ReefId(0);
 
-impl Default for Reefs<'_> {
+impl Default for Externals<'_> {
     /// Creates a Reefs set with the required `lang` reef with id 0
     fn default() -> Self {
         Self {
+            current: ReefId(1),
             names: HashMap::from([("lang".to_string(), LANG_REEF)]),
             reefs: vec![lang_reef()],
         }
     }
 }
 
-impl<'e> Reefs<'e> {
+impl<'e> Externals<'e> {
     /// Return the lang's reef
     pub fn lang(&self) -> &Reef<'e> {
         &self.reefs[LANG_REEF.0]
@@ -63,56 +81,17 @@ impl<'e> Reefs<'e> {
             .and_then(|id| self.get_reef(*id).map(|reef| (reef, *id)))
     }
 
-    /// Declares a new empty reef with given name.
-    ///
-    /// ## Panic
-    /// If the name is already reserved by another reef
-    fn mk_reef(&mut self, name: String) -> ReefId {
-        match self.names.entry(name.clone()) {
-            Entry::Occupied(_) => {
-                panic!("reef named {} already exists", name)
-            }
-            Entry::Vacant(v) => {
-                let id = ReefId(self.reefs.len());
-                self.reefs.push(Reef {
-                    name,
-                    engine: Engine::default(),
-                    relations: Relations::default(),
-                    typed_engine: TypedEngine::default(),
-                    typing: Typing::default(),
-                    type_context: TypeContext::default(),
-                });
-                v.insert(id);
-                id
-            }
-        }
-    }
-
     fn get_reef_mut(&mut self, id: ReefId) -> Option<&mut Reef<'e>> {
         self.reefs.get_mut(id.0)
     }
-}
 
-pub struct ReefContext<'a, 'e> {
-    reefs: &'a mut Reefs<'e>,
-    pub reef_id: ReefId,
-}
-
-impl<'a, 'e> ReefContext<'a, 'e> {
-    pub fn declare_new(reefs: &'a mut Reefs<'e>, name: impl Into<String>) -> Self {
-        let id = reefs.mk_reef(name.into());
-        Self { reefs, reef_id: id }
-    }
-
-    pub fn reefs(&self) -> &Reefs<'e> {
-        self.reefs
-    }
-
-    pub fn current_reef_mut(&mut self) -> &mut Reef<'e> {
-        self.reefs.get_reef_mut(self.reef_id).unwrap()
-    }
-
-    pub fn current_reef(&self) -> &Reef<'e> {
-        self.reefs.get_reef(self.reef_id).unwrap()
+    pub fn register(&mut self, reef: Reef<'e>) -> ReefId {
+        let id = ReefId(self.reefs.len());
+        if self.names.insert(reef.name.clone(), id).is_some() {
+            panic!("Reef with name {} already registered", reef.name);
+        }
+        self.reefs.push(reef);
+        self.current.0 += 1;
+        id
     }
 }

--- a/analyzer/src/reef.rs
+++ b/analyzer/src/reef.rs
@@ -1,0 +1,85 @@
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+
+use crate::engine::Engine;
+use crate::relations::{ObjectId, Relations};
+use crate::types::engine::TypedEngine;
+
+pub struct Reef<'e> {
+    pub name: String,
+    pub engine: Engine<'e>,
+    pub relations: Relations,
+    pub types: TypedEngine,
+}
+
+#[derive(Clone, Copy, Hash, Eq, PartialEq, Debug)]
+pub struct ReefId(pub ObjectId);
+
+#[derive(Default)]
+pub struct Reefs<'e> {
+    names: HashMap<String, ReefId>,
+    reefs: Vec<Reef<'e>>,
+}
+
+impl<'e> Reefs<'e> {
+    fn mk_reef(&mut self, name: String) -> ReefId {
+        match self.names.entry(name.clone()) {
+            Entry::Occupied(_) => {
+                panic!("reef named {} already exists", name)
+            }
+            Entry::Vacant(v) => {
+                let id = ReefId(self.reefs.len());
+                self.reefs.push(Reef {
+                    name,
+                    engine: Engine::default(),
+                    relations: Relations::default(),
+                    types: TypedEngine::default(),
+                });
+                v.insert(id);
+                id
+            }
+        }
+    }
+
+    pub fn get_reef(&self, id: ReefId) -> Option<&Reef<'e>> {
+        self.reefs.get(id.0)
+    }
+
+    pub fn get_reef_by_name(&self, name: &str) -> Option<(&Reef<'e>, ReefId)> {
+        self.names
+            .get(name)
+            .and_then(|id| self.get_reef(*id).map(|reef| (reef, *id)))
+    }
+
+    fn get_reef_mut(&mut self, id: ReefId) -> Option<&mut Reef<'e>> {
+        self.reefs.get_mut(id.0)
+    }
+}
+
+pub struct ReefContext<'a, 'e> {
+    reefs: &'a mut Reefs<'e>,
+    pub reef_id: ReefId,
+}
+
+impl<'a, 'e> ReefContext<'a, 'e> {
+    pub fn declare_new(reefs: &'a mut Reefs<'e>, name: impl Into<String>) -> Self {
+        let id = reefs.mk_reef(name.into());
+        Self { reefs, reef_id: id }
+    }
+
+    pub fn reefs(&self) -> &Reefs<'e> {
+        self.reefs
+    }
+
+    pub fn current_reef_mut(&mut self) -> &mut Reef<'e> {
+        self.reefs
+            .get_reef_mut(self.reef_id)
+            .expect("reefs does not contains current reef")
+    }
+
+    pub fn current_reef(&self) -> &Reef<'e> {
+        self.reefs
+            .get_reef(self.reef_id)
+            .expect("reefs does not contains current reef")
+    }
+}

--- a/analyzer/src/relations.rs
+++ b/analyzer/src/relations.rs
@@ -5,6 +5,7 @@ use context::source::SourceSegment;
 
 use crate::dependency::Dependencies;
 use crate::engine::Engine;
+use crate::reef::ReefId;
 
 /// The object identifier base.
 ///
@@ -84,6 +85,8 @@ impl From<LocalId> for Symbol {
 /// The resolved information about a symbol.
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub struct ResolvedSymbol {
+    /// The symbol's reef
+    pub reef: ReefId,
     /// The module where the symbol is defined.
     ///
     /// This is used to route the symbol to the correct environment.
@@ -94,8 +97,12 @@ pub struct ResolvedSymbol {
 }
 
 impl ResolvedSymbol {
-    pub fn new(source: SourceId, object_id: LocalId) -> Self {
-        Self { source, object_id }
+    pub fn new(reef: ReefId, source: SourceId, object_id: LocalId) -> Self {
+        Self {
+            reef,
+            source,
+            object_id,
+        }
     }
 }
 
@@ -198,6 +205,14 @@ impl Relations {
             .iter()
             .enumerate()
             .map(|(id, relation)| (RelationId(id), relation))
+    }
+
+    pub fn len(&self) -> usize {
+        self.relations.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.relations.is_empty()
     }
 
     /// Returns the state of the given object.

--- a/analyzer/src/relations.rs
+++ b/analyzer/src/relations.rs
@@ -98,7 +98,7 @@ pub struct ResolvedSymbol {
 }
 
 impl ResolvedSymbol {
-    pub fn new(reef: ReefId, source: SourceId, object_id: LocalId) -> Self {
+    pub const fn new(reef: ReefId, source: SourceId, object_id: LocalId) -> Self {
         Self {
             reef,
             source,

--- a/analyzer/src/relations.rs
+++ b/analyzer/src/relations.rs
@@ -221,14 +221,6 @@ impl Relations {
             .map(|(id, relation)| (RelationId(id), relation))
     }
 
-    pub fn len(&self) -> usize {
-        self.relations.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.relations.is_empty()
-    }
-
     /// Returns the state of the given object.
     ///
     /// If the relation is not referenced, returns [`None`].

--- a/analyzer/src/relations.rs
+++ b/analyzer/src/relations.rs
@@ -5,7 +5,8 @@ use context::source::SourceSegment;
 
 use crate::dependency::Dependencies;
 use crate::engine::Engine;
-use crate::reef::ReefId;
+use crate::environment::symbols::SymbolRegistry;
+use crate::reef::{ReefId, LANG_REEF};
 
 /// The object identifier base.
 ///
@@ -14,14 +15,14 @@ use crate::reef::ReefId;
 ///
 /// - [`RelationId`] points to a relation in [`Relation`].
 /// - [`SourceId`] points to a source in [`Engine`], sources are a root AST expression bound to an [`Environment`].
-/// - [`LocalId`] points to a local object in an environment's [`crate::environment::variables::Variables`].
+/// - [`LocalId`] points to a local object in an environment's [`crate::environment::symbols::Symbols`].
 /// - [`NativeId`] refers to an intrinsic function or method.
 /// - [`crate::types::TypeId`] points to a type registered in [`Typing`]
 ///
 /// Some main structures are based on object identifiers
 /// - [`ResolvedSymbol`] contains a [`SourceId`] and a [`LocalId`] which globally targets a symbol inside a given source environment,
 ///                      this structure is emitted by the resolution phase.
-/// - [`Symbol`] refers to a symbol, which is either local (to an unbound environment) or external, where the relation is held by the [`Relations`]
+/// - [`SymbolRef`] refers to a symbol, which is either local (to an unbound environment) or external, where the relation is held by the [`Relations`]
 pub type ObjectId = usize;
 
 /// A relation identifier, that points to a specific relation in the [`Relations`].
@@ -42,7 +43,7 @@ pub struct NativeId(pub ObjectId);
 
 /// An indication where an object is located.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Symbol {
+pub enum SymbolRef {
     /// A local object, referenced by its index in the [`Environment`] it is defined in.
     Local(LocalId),
 
@@ -70,15 +71,15 @@ impl Definition {
     }
 }
 
-impl From<RelationId> for Symbol {
+impl From<RelationId> for SymbolRef {
     fn from(id: RelationId) -> Self {
-        Symbol::External(id)
+        SymbolRef::External(id)
     }
 }
 
-impl From<LocalId> for Symbol {
+impl From<LocalId> for SymbolRef {
     fn from(id: LocalId) -> Self {
-        Symbol::Local(id)
+        SymbolRef::Local(id)
     }
 }
 
@@ -101,6 +102,14 @@ impl ResolvedSymbol {
         Self {
             reef,
             source,
+            object_id,
+        }
+    }
+
+    pub const fn lang_symbol(object_id: LocalId) -> Self {
+        Self {
+            reef: LANG_REEF,
+            source: SourceId(0),
             object_id,
         }
     }
@@ -138,20 +147,25 @@ pub struct Relation {
     /// This relation's state.
     /// See [RelationState] for more details
     pub state: RelationState,
+
+    /// The targeted registry of the symbol
+    pub registry: SymbolRegistry,
 }
 
 impl Relation {
-    pub fn unresolved(origin: SourceId) -> Self {
+    pub fn unresolved(origin: SourceId, registry: SymbolRegistry) -> Self {
         Self {
             origin,
             state: RelationState::Unresolved,
+            registry,
         }
     }
 
-    pub fn resolved(origin: SourceId, resolved: ResolvedSymbol) -> Self {
+    pub fn resolved(origin: SourceId, resolved: ResolvedSymbol, registry: SymbolRegistry) -> Self {
         Self {
             origin,
             state: RelationState::Resolved(resolved),
+            registry,
         }
     }
 }
@@ -170,9 +184,9 @@ pub struct Relations {
 
 impl Relations {
     /// Tracks a new object and returns its identifier.
-    pub fn track_new_object(&mut self, origin: SourceId) -> RelationId {
+    pub fn track_new_object(&mut self, origin: SourceId, registry: SymbolRegistry) -> RelationId {
         let id = self.relations.len();
-        self.relations.push(Relation::unresolved(origin));
+        self.relations.push(Relation::unresolved(origin, registry));
         RelationId(id)
     }
 
@@ -188,7 +202,7 @@ impl Relations {
         let environment = engine
             .get_environment(object.origin)
             .expect("object relation targets to an unknown environment");
-        Some(environment.find_references(Symbol::External(tracked_object)))
+        Some(environment.find_references(SymbolRef::External(tracked_object)))
     }
 
     /// Returns a mutable iterator over all the objects.

--- a/analyzer/src/steps.rs
+++ b/analyzer/src/steps.rs
@@ -1,6 +1,7 @@
 use crate::diagnostic::Diagnostic;
 use crate::importer::ASTImporter;
 use crate::name::Name;
+use crate::reef::ReefContext;
 use crate::steps::collect::SymbolCollector;
 use crate::steps::resolve::SymbolResolver;
 use crate::ResolutionResult;
@@ -10,25 +11,24 @@ pub mod resolve;
 mod shared_diagnostics;
 pub mod typing;
 
-pub(super) fn resolve_sources<'a>(
+pub(super) fn resolve_sources<'ca, 'e>(
     mut to_visit: Vec<Name>,
-    result: &mut ResolutionResult<'a>,
-    importer: &mut impl ASTImporter<'a>,
+    result: &mut ResolutionResult,
+    importer: &mut impl ASTImporter<'e>,
+    context: &mut ReefContext<'ca, 'e>,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     while !to_visit.is_empty() {
         diagnostics.extend(SymbolCollector::collect_symbols(
-            &mut result.engine,
-            &mut result.relations,
             &mut result.imports,
+            context,
             &mut to_visit,
             &mut result.visited,
             importer,
         ));
         diagnostics.extend(SymbolResolver::resolve_symbols(
-            &result.engine,
-            &mut result.relations,
             &mut result.imports,
+            context,
             &mut to_visit,
             &result.visited,
         ));

--- a/analyzer/src/steps.rs
+++ b/analyzer/src/steps.rs
@@ -1,7 +1,7 @@
 use crate::diagnostic::Diagnostic;
 use crate::importer::ASTImporter;
 use crate::name::Name;
-use crate::reef::ReefContext;
+use crate::reef::Externals;
 use crate::steps::collect::SymbolCollector;
 use crate::steps::resolve::SymbolResolver;
 use crate::ResolutionResult;
@@ -11,24 +11,28 @@ pub mod resolve;
 mod shared_diagnostics;
 pub mod typing;
 
-pub(super) fn resolve_sources<'ca, 'e>(
+pub(super) fn resolve_sources<'a>(
     mut to_visit: Vec<Name>,
-    result: &mut ResolutionResult,
-    importer: &mut impl ASTImporter<'e>,
-    context: &mut ReefContext<'ca, 'e>,
+    result: &mut ResolutionResult<'a>,
+    importer: &mut impl ASTImporter<'a>,
+    externals: &Externals,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     while !to_visit.is_empty() {
         diagnostics.extend(SymbolCollector::collect_symbols(
+            &mut result.engine,
+            &mut result.relations,
             &mut result.imports,
-            context,
+            externals,
             &mut to_visit,
             &mut result.visited,
             importer,
         ));
         diagnostics.extend(SymbolResolver::resolve_symbols(
+            &result.engine,
+            &mut result.relations,
             &mut result.imports,
-            context,
+            externals,
             &mut to_visit,
             &result.visited,
         ));

--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -4,7 +4,7 @@ use ast::call::Call;
 use ast::control_flow::ForKind;
 use ast::function::FunctionParameter;
 use ast::r#match::MatchPattern;
-use ast::r#use::{Import as ImportExpr, InclusionPathItem};
+use ast::r#use::Import as ImportExpr;
 use ast::range;
 use ast::value::LiteralValue;
 use ast::Expr;
@@ -13,12 +13,13 @@ use range::Iterable;
 
 use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
 use crate::engine::Engine;
-use crate::environment::variables::TypeInfo;
+use crate::environment::variables::{SymbolLocation, TypeInfo};
 use crate::environment::Environment;
 use crate::importer::{ASTImporter, ImportResult, Imported};
 use crate::imports::{Imports, UnresolvedImport};
 use crate::name::Name;
-use crate::relations::{RelationState, Relations, SourceId, Symbol};
+use crate::reef::ReefContext;
+use crate::relations::{RelationState, SourceId, Symbol};
 use crate::steps::resolve::SymbolResolver;
 use crate::steps::shared_diagnostics::diagnose_invalid_symbol;
 use crate::Inject;
@@ -54,30 +55,29 @@ impl ResolutionState {
     }
 }
 
-pub struct SymbolCollector<'a, 'e> {
-    engine: &'a mut Engine<'e>,
-    relations: &'a mut Relations,
+pub struct SymbolCollector<'a, 'ca, 'e> {
     imports: &'a mut Imports,
+    context: &'a mut ReefContext<'ca, 'e>,
     diagnostics: Vec<Diagnostic>,
 
     /// The stack of environments currently being collected.
     stack: Vec<SourceId>,
 }
 
-impl<'a, 'e> SymbolCollector<'a, 'e> {
+impl<'a, 'ca, 'e> SymbolCollector<'a, 'ca, 'e> {
     /// Explores the entry point and all its recursive dependencies.
     ///
     /// This collects all the symbols that are used, locally or not yet resolved if they are global.
     /// Returns a vector of diagnostics raised by the collection process.
+    #[allow(clippy::too_many_arguments)]
     pub fn collect_symbols(
-        engine: &'a mut Engine<'e>,
-        relations: &'a mut Relations,
         imports: &'a mut Imports,
+        context: &'a mut ReefContext<'ca, 'e>,
         to_visit: &mut Vec<Name>,
         visited: &mut HashSet<Name>,
         importer: &mut impl ASTImporter<'e>,
     ) -> Vec<Diagnostic> {
-        let mut collector = Self::new(engine, relations, imports);
+        let mut collector = Self::new(imports, context);
         collector.collect(importer, to_visit, visited);
         collector.check_symbols_identity();
         collector.diagnostics
@@ -85,26 +85,28 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
 
     pub fn inject(
         inject: Inject<'e>,
-        engine: &'a mut Engine<'e>,
-        relations: &'a mut Relations,
         imports: &'a mut Imports,
+        context: &'a mut ReefContext<'ca, 'e>,
         to_visit: &mut Vec<Name>,
     ) -> Vec<Diagnostic> {
+        let mut collector = Self::new(imports, context);
+        let engine = &mut collector.context.current_reef_mut().engine;
+
         assert_ne!(
             inject.attached,
             Some(SourceId(engine.len())),
             "Cannot inject a module to itself"
         );
-        let mut collector = Self::new(engine, relations, imports);
-        let root_block = collector.engine.take(inject.imported.expr);
+
+        let root_block = engine.take(inject.imported.expr);
 
         let mut env = Environment::script(inject.name);
         env.parent = inject.attached;
         let mut state = ResolutionState::new(
             inject.imported.content,
-            collector.engine.track(inject.imported.content, root_block),
+            engine.track(inject.imported.content, root_block),
         );
-        collector.engine.attach(state.module, env);
+        engine.attach(state.module, env);
         collector.stack.push(state.module);
 
         collector.tree_walk(&mut state, root_block, to_visit);
@@ -113,24 +115,22 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
         collector.diagnostics
     }
 
-    fn new(
-        engine: &'a mut Engine<'e>,
-        relations: &'a mut Relations,
-        imports: &'a mut Imports,
-    ) -> Self {
+    fn new(imports: &'a mut Imports, context: &'a mut ReefContext<'ca, 'e>) -> Self {
         Self {
-            engine,
-            relations,
             imports,
+            context,
             diagnostics: Vec::new(),
             stack: Vec::new(),
         }
     }
 
     fn current_env(&mut self) -> &mut Environment {
-        self.engine
-            .get_environment_mut(*self.stack.last().unwrap())
-            .unwrap()
+        let current_env_id = *self.stack.last().unwrap();
+        self.engine().get_environment_mut(current_env_id).unwrap()
+    }
+
+    fn engine(&mut self) -> &mut Engine<'e> {
+        &mut self.context.current_reef_mut().engine
     }
 
     /// Performs a check over the collected symbols of root environments
@@ -141,6 +141,8 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
     /// there is no way to identify if either `a::b` is the symbol, or `a::b` is the module.
     fn check_symbols_identity(&mut self) {
         let roots = self
+            .context
+            .current_reef()
             .engine
             .environments()
             .filter(|(_, e)| e.parent.is_none()); //keep root environments
@@ -161,8 +163,8 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                     .expect("local symbol references an unknown variable");
                 let var_fqn = env_name.appended(Name::new(&var.name));
 
-                let clashed_module = self
-                    .engine
+                let engine = &self.context.current_reef().engine;
+                let clashed_module = engine
                     .environments()
                     .find(|(_, e)| e.parent.is_none() && e.fqn == var_fqn)
                     .map(|(_, e)| e);
@@ -170,7 +172,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                 if let Some(clashed_module) = clashed_module {
                     let inner_modules = {
                         //we know that the inner envs contains at least one environment (the env being clashed with)
-                        let list = list_inner_modules(self.engine, &env.fqn)
+                        let list = list_inner_modules(engine, &env.fqn)
                             .map(|e| e.fqn.simple_name())
                             .collect::<Vec<_>>();
 
@@ -220,15 +222,14 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
         module_name: Name,
         to_visit: &mut Vec<Name>,
     ) {
+        let engine = &mut self.context.current_reef_mut().engine;
         // Immediately transfer the ownership of the AST to the engine.
-        let root_block = self.engine.take(imported.expr);
+        let root_block = engine.take(imported.expr);
 
         let env = Environment::script(module_name);
-        let mut state = ResolutionState::new(
-            imported.content,
-            self.engine.track(imported.content, root_block),
-        );
-        self.engine.attach(state.module, env);
+        let mut state =
+            ResolutionState::new(imported.content, engine.track(imported.content, root_block));
+        engine.attach(state.module, env);
         self.stack.push(state.module);
 
         self.tree_walk(&mut state, root_block, to_visit);
@@ -264,33 +265,45 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
     fn collect_symbol_import(
         &mut self,
         import: &'e ImportExpr<'e>,
-        relative_path: Vec<String>,
+        mut relative_path: Vec<String>,
+        is_current_reef_explicit: bool, //true if the current reef target has already been specified
         mod_id: SourceId,
         to_visit: &mut Vec<Name>,
     ) {
         match import {
             ImportExpr::Symbol(s) => {
-                let mut symbol_name = relative_path;
-                symbol_name.extend(map_inclusion_path(&s.path));
+                match SymbolLocation::compute(&s.path, mod_id, is_current_reef_explicit) {
+                    Ok(mut loc) => {
+                        let alias = s.alias.map(|s| s.to_string());
 
-                let name = Name::from(symbol_name);
-                let alias = s.alias.map(|s| s.to_string());
+                        relative_path.extend(loc.name.into_vec());
+                        loc.name = Name::from(relative_path);
+                        loc.is_current_reef_explicit |= is_current_reef_explicit;
 
-                to_visit.push(name.clone());
-                let unresolved = UnresolvedImport::Symbol {
-                    alias,
-                    qualified_name: name.clone(),
-                };
-                self.add_checked_import(mod_id, unresolved, import, name)
+                        let name = loc.name.clone();
+                        to_visit.push(name.clone());
+
+                        let unresolved = UnresolvedImport::Symbol { alias, loc };
+                        self.add_checked_import(mod_id, unresolved, import, name)
+                    }
+                    Err(diag) => self.diagnostics.push(diag),
+                }
             }
             ImportExpr::AllIn(items, _) => {
-                let mut symbol_name = relative_path;
-                symbol_name.extend(map_inclusion_path(items));
+                match SymbolLocation::compute(items, mod_id, is_current_reef_explicit) {
+                    Ok(mut loc) => {
+                        relative_path.extend(loc.name.into_vec());
+                        loc.name = Name::from(relative_path);
 
-                let name = Name::from(symbol_name);
-                to_visit.push(name.clone());
-                let unresolved = UnresolvedImport::AllIn(name.clone());
-                self.add_checked_import(mod_id, unresolved, import, name)
+                        loc.is_current_reef_explicit |= is_current_reef_explicit;
+
+                        let name = loc.name.clone();
+                        to_visit.push(name.clone());
+                        let unresolved = UnresolvedImport::AllIn(loc);
+                        self.add_checked_import(mod_id, unresolved, import, name)
+                    }
+                    Err(diag) => self.diagnostics.push(diag),
+                }
             }
 
             ImportExpr::Environment(_, _) => {
@@ -303,12 +316,23 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                 self.diagnostics.push(diagnostic);
             }
             ImportExpr::List(list) => {
-                for list_import in &list.imports {
-                    //append ImportList's path to current relative path
-                    let mut relative = relative_path.clone();
-                    relative.extend(map_inclusion_path(&list.root));
+                match SymbolLocation::compute(&list.root, mod_id, is_current_reef_explicit) {
+                    Ok(mut loc) => {
+                        relative_path.extend(loc.name.into_vec());
+                        loc.name = Name::from(relative_path);
 
-                    self.collect_symbol_import(list_import, relative, mod_id, to_visit)
+                        for list_import in &list.imports {
+                            let relative_path = loc.name.clone().into_vec();
+                            self.collect_symbol_import(
+                                list_import,
+                                relative_path,
+                                true,
+                                mod_id,
+                                to_visit,
+                            )
+                        }
+                    }
+                    Err(diag) => self.diagnostics.push(diag),
                 }
             }
         }
@@ -330,14 +354,20 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                     self.diagnostics.push(diagnostic);
                     return;
                 }
-                self.collect_symbol_import(&import.import, Vec::new(), state.module, to_visit);
+                self.collect_symbol_import(
+                    &import.import,
+                    Vec::new(),
+                    false,
+                    state.module,
+                    to_visit,
+                );
                 return;
             }
             Expr::Assign(assign) => {
                 let symbol = self.identify_variable(
                     *self.stack.last().unwrap(),
                     state.module,
-                    &Name::new(assign.name),
+                    SymbolLocation::unspecified(Name::new(assign.name)),
                     assign.segment(),
                 );
                 self.current_env().annotate(assign, symbol);
@@ -356,7 +386,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                                 let symbol = self.identify_variable(
                                     *self.stack.last().unwrap(),
                                     state.module,
-                                    &Name::new(reference.name),
+                                    SymbolLocation::unspecified(Name::new(reference.name)),
                                     reference.segment(),
                                 );
                                 self.current_env().annotate(reference, symbol);
@@ -391,17 +421,20 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                 }
             }
             Expr::ProgrammaticCall(call) => {
-                let path: Vec<_> = map_inclusion_path(&call.path).collect();
-                let name = Name::from(path);
+                match SymbolLocation::compute(&call.path, state.module, false) {
+                    Ok(loc) => {
+                        let symbol = self.identify_variable(
+                            *self.stack.last().unwrap(),
+                            state.module,
+                            loc,
+                            call.segment(),
+                        );
 
-                let symbol = self.identify_variable(
-                    *self.stack.last().unwrap(),
-                    state.module,
-                    &name,
-                    call.segment(),
-                );
+                        self.current_env().annotate(call, symbol);
+                    }
+                    Err(diag) => self.diagnostics.push(diag),
+                }
 
-                self.current_env().annotate(call, symbol);
                 for arg in &call.arguments {
                     self.tree_walk(state, arg, to_visit);
                 }
@@ -440,7 +473,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                 let symbol = self.identify_variable(
                     *self.stack.last().unwrap(),
                     state.module,
-                    &Name::new(var.name),
+                    SymbolLocation::unspecified(Name::new(var.name)),
                     var.segment(),
                 );
                 self.current_env().annotate(var, symbol);
@@ -547,12 +580,13 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                     .variables
                     .declare_local(func.name.to_owned(), TypeInfo::Function);
                 self.current_env().annotate(func, symbol);
-                let func_id = self.engine.track(state.content, expr);
+
+                let func_id = self.engine().track(state.content, expr);
                 self.current_env().bind_source(func, func_id);
                 let func_env = self.current_env().fork(state.module, func.name);
-
-                let func_env = self.engine.attach(func_id, func_env);
                 self.stack.push(func_id);
+
+                let func_env = self.engine().attach(func_id, func_env);
 
                 for param in &func.parameters {
                     let symbol = func_env.variables.declare_local(
@@ -568,20 +602,19 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                     }
                 }
                 self.tree_walk(&mut state.fork(func_id), &func.body, to_visit);
-                Self::resolve_captures(
-                    &self.stack,
-                    self.engine,
-                    self.relations,
-                    &mut self.diagnostics,
-                );
+
+                Self::resolve_captures(&self.stack, self.context, &mut self.diagnostics);
                 self.stack.pop();
             }
             Expr::LambdaDef(lambda) => {
-                let func_id = self.engine.track(state.content, expr);
-                let env = self.current_env();
-                let func_env = env.fork(state.module, &format!("lambda@{}", func_id.0));
-                let func_env = self.engine.attach(func_id, func_env);
+                let func_id = self.engine().track(state.content, expr);
+
+                let func_env = self
+                    .current_env()
+                    .fork(state.module, &format!("lambda@{}", func_id.0));
                 self.stack.push(func_id);
+                let func_env = self.engine().attach(func_id, func_env);
+
                 for param in &lambda.args {
                     let symbol = func_env
                         .variables
@@ -589,12 +622,7 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
                     func_env.annotate(param, symbol);
                 }
                 self.tree_walk(&mut state.fork(func_id), &lambda.body, to_visit);
-                Self::resolve_captures(
-                    &self.stack,
-                    self.engine,
-                    self.relations,
-                    &mut self.diagnostics,
-                );
+                Self::resolve_captures(&self.stack, self.context, &mut self.diagnostics);
                 self.stack.pop();
             }
             Expr::Literal(_) | Expr::Continue(_) | Expr::Break(_) => {}
@@ -604,15 +632,19 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
 
     fn resolve_captures(
         stack: &[SourceId],
-        engine: &Engine,
-        relations: &mut Relations,
+        ctx: &mut ReefContext,
         diagnostics: &mut Vec<Diagnostic>,
     ) {
+        let reef_id = ctx.reef_id;
+        let reef = ctx.current_reef_mut();
+
         let stack: Vec<_> = stack
             .iter()
-            .map(|id| (*id, engine.get_environment(*id).unwrap()))
+            .map(|id| (*id, reef.engine.get_environment(*id).unwrap()))
             .collect();
-        SymbolResolver::resolve_captures(&stack, relations, diagnostics);
+
+        let relations = &mut reef.relations;
+        SymbolResolver::resolve_captures(&stack, relations, reef_id, diagnostics);
     }
 
     fn extract_literal_argument(&self, call: &'a Call, nth: usize) -> Option<&'a str> {
@@ -625,12 +657,17 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
         }
     }
 
-    fn resolve_primitive_call(&mut self, env_id: SourceId, call: &Call) -> Option<()> {
+    fn resolve_primitive_call(&mut self, env_id: SourceId, call: &'a Call) -> Option<()> {
         let command = self.extract_literal_argument(call, 0)?;
         match command {
             "read" => {
                 let var = self.extract_literal_argument(call, 1)?;
-                let env = self.engine.get_environment_mut(env_id).unwrap();
+                let env = self
+                    .context
+                    .current_reef_mut()
+                    .engine
+                    .get_environment_mut(env_id)
+                    .unwrap();
                 let symbol = env
                     .variables
                     .declare_local(var.to_owned(), TypeInfo::Variable);
@@ -647,30 +684,41 @@ impl<'a, 'e> SymbolCollector<'a, 'e> {
         &mut self,
         source: SourceId,
         origin: SourceId,
-        name: &Name,
+        location: SymbolLocation,
         segment: SourceSegment,
     ) -> Symbol {
-        let variables = &mut self.engine.get_environment_mut(source).unwrap().variables;
+        let reef = self.context.current_reef_mut();
+
+        let variables = &mut reef.engine.get_environment_mut(source).unwrap().variables;
 
         macro_rules! track_global {
             () => {
                 *variables
-                    .external(name.clone())
-                    .or_insert_with(|| self.relations.track_new_object(origin))
+                    .external(location)
+                    .or_insert_with(|| reef.relations.track_new_object(origin))
             };
         }
 
-        match variables.find_reachable(name.root()) {
+        //if a reef is explicitly specified, then the reef and symbol's name must be resolved first
+        if location.is_current_reef_explicit {
+            return Symbol::External(track_global!());
+        }
+
+        match variables.find_reachable(location.name.root()) {
             None => Symbol::External(track_global!()),
-            Some(id) if name.is_qualified() => {
+            Some(id) if location.name.is_qualified() => {
                 let var = variables.get_var(id).unwrap();
-                self.diagnostics
-                    .push(diagnose_invalid_symbol(var.ty, origin, name, &[segment]));
+                self.diagnostics.push(diagnose_invalid_symbol(
+                    var.ty,
+                    origin,
+                    &location.name,
+                    &[segment],
+                ));
                 // instantly declare a dead resolution object
                 // We could have returned None here to ignore the symbol but it's more appropriate to
                 // bind the variable occurrence with a dead object to signify that it's bound symbol invalid.
                 let id = track_global!();
-                self.relations[id].state = RelationState::Dead;
+                reef.relations[id].state = RelationState::Dead;
                 Symbol::External(id)
             }
             Some(id) => Symbol::Local(id),
@@ -720,14 +768,6 @@ fn list_inner_modules<'a>(
         .map(|(_, e)| e)
 }
 
-// NOTE: will get removed once the analyzer will be able to support external libraries (reefs)
-fn map_inclusion_path<'a>(v: &'a [InclusionPathItem<'a>]) -> impl Iterator<Item = String> + 'a {
-    v.iter().map(|item| match item {
-        InclusionPathItem::Symbol(s, _) => s.to_string(),
-        InclusionPathItem::Reef(_) => panic!("`reef` not supported by analyzer"),
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use pretty_assertions::assert_eq;
@@ -737,41 +777,47 @@ mod tests {
     use parser::parse_trusted;
 
     use crate::importer::StaticImporter;
+    use crate::reef::Reefs;
     use crate::relations::{LocalId, RelationId, Symbol};
 
     use super::*;
 
-    fn tree_walk<'a, 'e>(
+    fn tree_walk<'e>(
         expr: &'e Expr<'e>,
-        engine: &'a mut Engine<'e>,
-        relations: &mut Relations,
+        context: &mut ReefContext<'_, 'e>,
     ) -> (Vec<Diagnostic>, Environment) {
-        let env = Environment::script(Name::new("test"));
         let mut imports = Imports::default();
-        let mut state = ResolutionState::new(ContentId(0), engine.track(ContentId(0), expr));
-        let mut collector = SymbolCollector::new(engine, relations, &mut imports);
-        collector.engine.attach(SourceId(0), env);
+        let mut collector = SymbolCollector::new(&mut imports, context);
+
+        let env = Environment::script(Name::new("test"));
+        let mut state =
+            ResolutionState::new(ContentId(0), collector.engine().track(ContentId(0), expr));
+
+        collector.engine().attach(SourceId(0), env);
         collector.stack.push(SourceId(0));
         collector.tree_walk(&mut state, &expr, &mut vec![]);
-        let env = collector.engine.get_environment(SourceId(0)).unwrap();
+        let env = collector
+            .engine()
+            .get_environment(SourceId(0))
+            .unwrap()
+            .clone();
         collector.stack.pop();
-        (collector.diagnostics, env.clone())
+        (collector.diagnostics, env)
     }
 
     #[test]
     fn use_between_expressions() {
         let content = "use a; $a; use c; $c";
-        let mut engine = Engine::default();
-        let mut relations = Relations::default();
+        let mut reefs = Reefs::default();
+        let mut context = ReefContext::declare_new(&mut reefs, "test");
         let mut imports = Imports::default();
         let mut importer = StaticImporter::new(
             [(Name::new("test"), Source::unknown(content))],
             parse_trusted,
         );
         let res = SymbolCollector::collect_symbols(
-            &mut engine,
-            &mut relations,
             &mut imports,
+            &mut context,
             &mut vec![Name::new("test")],
             &mut HashSet::new(),
             &mut importer,
@@ -791,11 +837,14 @@ mod tests {
     #[test]
     fn bind_local_variables() {
         let expr = parse_trusted(Source::unknown("var bar = 4; $bar"));
-        let mut engine = Engine::default();
-        let mut relations = Relations::default();
-        let diagnostics = tree_walk(&expr, &mut engine, &mut relations).0;
+        let mut reefs = Reefs::default();
+        let mut context = ReefContext::declare_new(&mut reefs, "test");
+        let diagnostics = tree_walk(&expr, &mut context).0;
         assert_eq!(diagnostics, vec![]);
-        assert_eq!(relations.iter().collect::<Vec<_>>(), vec![]);
+        assert_eq!(
+            context.current_reef().relations.iter().collect::<Vec<_>>(),
+            vec![]
+        );
     }
 
     #[test]
@@ -806,8 +855,8 @@ mod tests {
         let math_add_src = Source::unknown("");
         let math_divide_src = Source::unknown("");
 
-        let mut engine = Engine::default();
-        let mut relations = Relations::default();
+        let mut reefs = Reefs::default();
+        let mut context = ReefContext::declare_new(&mut reefs, "test");
         let mut imports = Imports::default();
         let mut importer = StaticImporter::new(
             [
@@ -820,9 +869,8 @@ mod tests {
         );
 
         let diagnostics = SymbolCollector::collect_symbols(
-            &mut engine,
-            &mut relations,
             &mut imports,
+            &mut context,
             &mut vec![Name::new("math")],
             &mut HashSet::new(),
             &mut importer,
@@ -838,15 +886,15 @@ mod tests {
     fn shadowed_imports() {
         let source = "use A; use B; use A; use B";
         let test_src = Source::unknown(source);
-        let mut engine = Engine::default();
-        let mut relations = Relations::default();
+        let mut reefs = Reefs::default();
+        let mut context = ReefContext::declare_new(&mut reefs, "test");
+
         let mut imports = Imports::default();
         let mut importer = StaticImporter::new([(Name::new("test"), test_src)], parse_trusted);
 
         let diagnostics = SymbolCollector::collect_symbols(
-            &mut engine,
-            &mut relations,
             &mut imports,
+            &mut context,
             &mut vec![Name::new("test")],
             &mut HashSet::new(),
             &mut importer,
@@ -886,18 +934,25 @@ mod tests {
         let src = "fun id(a) = return $a";
         let source = Source::unknown(src);
         let expr = parse_trusted(source);
-        let mut engine = Engine::default();
-        let mut relations = Relations::default();
-        let (diagnostics, env) = tree_walk(&expr, &mut engine, &mut relations);
+        let mut reefs = Reefs::default();
+        let mut context = ReefContext::declare_new(&mut reefs, "test");
+        let (diagnostics, env) = tree_walk(&expr, &mut context);
         assert_eq!(diagnostics, vec![]);
-        assert_eq!(relations.iter().collect::<Vec<_>>(), vec![]);
+        assert_eq!(
+            context.current_reef().relations.iter().collect::<Vec<_>>(),
+            vec![]
+        );
         assert_eq!(
             env.get_raw_symbol(source.segment()),
             Some(Symbol::Local(LocalId(0)))
         );
         assert_eq!(env.get_raw_symbol(find_in(src, "a")), None);
         assert_eq!(env.get_raw_symbol(find_in(src, "$a")), None);
-        let func_env = engine.get_environment(SourceId(1)).unwrap();
+        let func_env = context
+            .current_reef()
+            .engine
+            .get_environment(SourceId(1))
+            .unwrap();
         assert_eq!(
             func_env.get_raw_symbol(find_in(src, "a")),
             Some(Symbol::Local(LocalId(0)))
@@ -913,11 +968,14 @@ mod tests {
         let src = "read foo";
         let source = Source::unknown(src);
         let expr = parse_trusted(source);
-        let mut engine = Engine::default();
-        let mut relations = Relations::default();
-        let (diagnostics, env) = tree_walk(&expr, &mut engine, &mut relations);
+        let mut reefs = Reefs::default();
+        let mut context = ReefContext::declare_new(&mut reefs, "test");
+        let (diagnostics, env) = tree_walk(&expr, &mut context);
         assert_eq!(diagnostics, vec![]);
-        assert_eq!(relations.iter().collect::<Vec<_>>(), vec![]);
+        assert_eq!(
+            context.current_reef().relations.iter().collect::<Vec<_>>(),
+            vec![]
+        );
         assert_eq!(env.get_raw_symbol(find_in(src, "read")), None);
         assert_eq!(
             env.get_raw_symbol(find_in(src, "foo")),
@@ -931,13 +989,17 @@ mod tests {
         let source = Source::unknown(src);
         let expr = parse_trusted(source);
 
-        let mut engine = Engine::default();
-        let mut relations = Relations::default();
-        let (diagnostics, _) = tree_walk(&expr, &mut engine, &mut relations);
+        let mut reefs = Reefs::default();
+        let mut context = ReefContext::declare_new(&mut reefs, "test");
+        let (diagnostics, _) = tree_walk(&expr, &mut context);
+        let engine = &context.current_reef().engine;
+        let relations = &context.current_reef().relations;
         assert_eq!(diagnostics, vec![]);
         assert_eq!(
-            relations
-                .find_references(&engine, RelationId(0))
+            context
+                .current_reef()
+                .relations
+                .find_references(engine, RelationId(0))
                 .map(|mut references| {
                     references.sort_by_key(|range| range.start);
                     references
@@ -945,11 +1007,11 @@ mod tests {
             Some(vec![find_in(src, "$bar"), find_in_nth(src, "$bar", 1)])
         );
         assert_eq!(
-            relations.find_references(&engine, RelationId(1)),
+            relations.find_references(engine, RelationId(1)),
             Some(vec![find_in(src, "baz($foo, $bar)")])
         );
         assert_eq!(
-            relations.find_references(&engine, RelationId(2)),
+            relations.find_references(engine, RelationId(2)),
             Some(vec![find_in(src, "$foo")])
         );
     }

--- a/analyzer/src/steps/resolve.rs
+++ b/analyzer/src/steps/resolve.rs
@@ -6,7 +6,7 @@ use crate::environment::symbols::{resolve_loc, SymbolRegistry};
 use crate::environment::Environment;
 use crate::imports::Imports;
 use crate::name::Name;
-use crate::reef::{ReefAccessor, ReefContext, ReefId};
+use crate::reef::{ReefContext, ReefId};
 use crate::relations::{
     LocalId, RelationId, RelationState, Relations, ResolvedSymbol, SourceId, SymbolRef,
 };
@@ -85,7 +85,7 @@ impl<'a, 'ca, 'e> SymbolResolver<'a, 'ca, 'e> {
         let ((capture_env_id, capture_env), parents) =
             env_stack.split_last().expect("env_stack is empty");
 
-        'capture: for (loc, relation_id) in capture_env.symbols.external_vars() {
+        'capture: for (loc, relation_id) in capture_env.symbols.external_symbols() {
             let name = &loc.name;
             for (pos, (env_id, env)) in parents.iter().rev().enumerate() {
                 let relation = &mut relations[relation_id];
@@ -337,7 +337,7 @@ mod tests {
     use crate::importer::StaticImporter;
     use crate::imports::{Imports, ResolvedImport, SourceImports, UnresolvedImport};
     use crate::name::Name;
-    use crate::reef::{ReefAccessor, ReefContext, ReefId, Reefs};
+    use crate::reef::{ReefContext, ReefId, Reefs, LANG_REEF};
     use crate::relations::{
         LocalId, Relation, RelationId, RelationState, ResolvedSymbol, SourceId,
     };
@@ -398,7 +398,7 @@ mod tests {
         let reef = reefs.get_reef(ReefId(2)).unwrap();
         assert_eq!(reef.name, "test");
         assert_eq!(reefs.get_reef(ReefId(1)).unwrap().name, "std");
-        assert_eq!(reefs.get_reef(ReefId(0)).unwrap().name, "lang");
+        assert_eq!(reefs.get_reef(LANG_REEF).unwrap().name, "lang");
 
         assert_eq!(
             result.imports.get_imports(SourceId(2)).unwrap(),

--- a/analyzer/src/steps/resolve.rs
+++ b/analyzer/src/steps/resolve.rs
@@ -243,13 +243,13 @@ impl<'a, 'ca, 'e> SymbolResolver<'a, 'ca, 'e> {
                 }
 
                 //if the symbol is a type, and if its name is unqualified, try to resolve it from the special `lang` reef.
-                if registry == SymbolRegistry::Types && !symbol_name.is_qualified() {
+                if registry == SymbolRegistry::Types && (!symbol_name.is_qualified() || (symbol_name.parts().len() == 2 && symbol_name.root() == "lang")) {
                     if let Some(primitive_type) = self
                         .context
                         .reefs()
                         .lang()
                         .type_context
-                        .get_type(symbol_name.root())
+                        .get_type_id(symbol_name.simple_name())
                     {
                         result = SymbolResolutionResult::Resolved(ResolvedSymbol::lang_symbol(
                             LocalId(primitive_type.0),
@@ -348,7 +348,7 @@ mod tests {
     use crate::{resolve_all, ResolutionResult};
 
     #[test]
-    fn test_reefs() {
+    fn test_reefs_external_symbols_resolution() {
         let mut reefs = Reefs::default();
 
         fn define_reef<'a, 'e, const N: usize>(
@@ -574,7 +574,7 @@ mod tests {
     }
 
     #[test]
-    fn test_imports_resolution() {
+    fn test_reef_imports_resolution() {
         let math_src = Source::unknown("val PI = 3.14");
         let std_src = Source::unknown("val Foo = 'moshell_std'; val Bar = $Foo");
         let io_src = Source::unknown("fun output() = (); fun input() = ()");

--- a/analyzer/src/steps/resolve/diagnostics.rs
+++ b/analyzer/src/steps/resolve/diagnostics.rs
@@ -52,11 +52,17 @@ pub fn diagnose_unresolved_external_symbols(
     env_id: SourceId,
     env: &Environment,
     name: &Name,
+    because_reef_not_found: bool,
 ) -> Diagnostic {
-    let diagnostic = Diagnostic::new(
-        DiagnosticID::UnknownSymbol,
-        format!("Could not resolve symbol `{name}`."),
-    );
+    let mut diagnostic_message = format!("Could not resolve symbol `{name}`");
+
+    if because_reef_not_found {
+        diagnostic_message.push_str(&format!(", because reef `{}` was not found", name.root()))
+    }
+
+    diagnostic_message.push('.');
+
+    let diagnostic = Diagnostic::new(DiagnosticID::UnknownSymbol, diagnostic_message);
 
     let mut observations: Vec<Observation> = env
         .list_definitions()

--- a/analyzer/src/steps/resolve/import.rs
+++ b/analyzer/src/steps/resolve/import.rs
@@ -1,105 +1,142 @@
-use crate::diagnostic::Diagnostic;
+use crate::diagnostic::{Diagnostic, DiagnosticID, Observation, SourceLocation};
 use crate::engine::Engine;
+use crate::environment::variables::resolve_loc;
 use crate::environment::Environment;
 use crate::imports::{ResolvedImport, SourceImports, UnresolvedImport};
 use crate::name::Name;
+use crate::reef::ReefContext;
 use crate::relations::{ResolvedSymbol, SourceId};
 use crate::steps::resolve::{diagnose_unresolved_import, SymbolResolver};
 
-impl<'a, 'e> SymbolResolver<'a, 'e> {
+impl<'a, 'ca, 'e> SymbolResolver<'a, 'ca, 'e> {
     /// Attempts to resolve all given unresolved imports, returning a [ResolvedImports] structure containing the
     /// imports that could get resolved.
     /// This method will append a new diagnostic for each imports that could not be resolved.
     pub fn resolve_imports(
+        context: &ReefContext<'ca, 'e>,
         env_id: SourceId,
         imports: &mut SourceImports,
-        engine: &Engine,
         diagnostics: &mut Vec<Diagnostic>,
     ) {
         //iterate over our unresolved imports
         for (unresolved, segment) in imports.take_unresolved_imports() {
             match unresolved {
                 // If the unresolved import is a symbol
-                UnresolvedImport::Symbol {
-                    alias,
-                    qualified_name: name,
-                } => {
-                    // try to get referenced module of the import
-                    let result = get_mod_from_absolute(engine, &name);
-                    match result {
-                        // if the environment wasn't found, attempt to resolve it in next cycle
-                        None => {
-                            // if the environment wasn't found, and its name was already known, push a diagnostic as it does not exists
-                            let diagnostic =
-                                diagnose_unresolved_import(env_id, &name, None, segment.clone());
-                            diagnostics.push(diagnostic);
-                            imports.set_resolved_import(
-                                alias.unwrap_or(name.simple_name().to_string()),
-                                ResolvedImport::Dead,
-                                segment,
-                            );
-                        }
-                        //else, try to resolve it
-                        Some((found_env_id, found_env)) => {
-                            let symbol_name = name.simple_name().to_string();
-                            if found_env.fqn == name {
-                                //it's the environment that is being imported
-                                imports.set_resolved_import(
-                                    alias.unwrap_or(symbol_name),
-                                    ResolvedImport::Env(found_env_id),
-                                    segment,
-                                );
-                                continue;
-                            }
+                UnresolvedImport::Symbol { alias, loc } => {
+                    // resolve path and targeted reef
 
-                            let symbol_id = found_env.variables.find_exported(&symbol_name);
-
-                            if let Some(symbol_id) = symbol_id {
-                                let resolved = ResolvedSymbol::new(found_env_id, symbol_id);
-                                imports.set_resolved_import(
-                                    alias.unwrap_or(symbol_name),
-                                    ResolvedImport::Symbol(resolved),
+                    match resolve_loc(&loc, context) {
+                        None => diagnostics.push(
+                            Diagnostic::new(DiagnosticID::InvalidSymbolPath, "Invalid import")
+                                .with_observation(Observation::context(
+                                    env_id,
                                     segment,
-                                );
-                                continue;
+                                    format!("Cannot find reef `{}`", loc.name.root()),
+                                )),
+                        ),
+                        Some((reef, reef_id)) => {
+                            let name = &loc.name;
+                            // try to get referenced module of the reef
+                            let result = get_mod(name, &reef.engine);
+                            match result {
+                                None => {
+                                    // if the environment wasn't found, and its name was already known, push a diagnostic as it does not exists
+                                    let diagnostic = diagnose_unresolved_import(
+                                        env_id,
+                                        name,
+                                        None,
+                                        segment.clone(),
+                                    );
+                                    diagnostics.push(diagnostic);
+                                    imports.set_resolved_import(
+                                        alias.unwrap_or(name.simple_name().to_string()),
+                                        ResolvedImport::Dead,
+                                        segment,
+                                    );
+                                }
+                                //else, try to resolve it
+                                Some((found_env_id, found_env)) => {
+                                    let symbol_name = name.simple_name().to_string();
+                                    if found_env.fqn == *name {
+                                        //it's the environment that is being imported
+                                        imports.set_resolved_import(
+                                            alias.unwrap_or(symbol_name),
+                                            ResolvedImport::Env(found_env_id),
+                                            segment,
+                                        );
+                                        continue;
+                                    }
+
+                                    let symbol_id = found_env.variables.find_exported(&symbol_name);
+
+                                    if let Some(symbol_id) = symbol_id {
+                                        let resolved =
+                                            ResolvedSymbol::new(reef_id, found_env_id, symbol_id);
+                                        imports.set_resolved_import(
+                                            alias.unwrap_or(symbol_name),
+                                            ResolvedImport::Symbol(resolved),
+                                            segment,
+                                        );
+                                        continue;
+                                    }
+                                    // the symbol inside the resolved environment could not be found
+                                    let diagnostic = diagnose_unresolved_import(
+                                        env_id,
+                                        name,
+                                        Some(found_env.fqn.clone()),
+                                        segment.clone(),
+                                    );
+                                    imports.set_resolved_import(
+                                        alias.unwrap_or(symbol_name),
+                                        ResolvedImport::Dead,
+                                        segment,
+                                    );
+                                    diagnostics.push(diagnostic);
+                                }
                             }
-                            // the symbol inside the resolved environment could not be found
-                            let diagnostic = diagnose_unresolved_import(
-                                env_id,
-                                &name,
-                                Some(found_env.fqn.clone()),
-                                segment.clone(),
-                            );
-                            imports.set_resolved_import(
-                                alias.unwrap_or(symbol_name),
-                                ResolvedImport::Dead,
-                                segment,
-                            );
-                            diagnostics.push(diagnostic);
                         }
                     }
                 }
 
                 //if the unresolved import is an 'AllIn' import, meaning that it imports all symbols from given module
-                UnresolvedImport::AllIn(name) => {
-                    // try to get referenced environment of the import
-                    match get_mod_from_absolute(engine, &name) {
-                        None => {
-                            // if the environment wasn't found, and its name was already known, push a diagnostic as it does not exists
-                            let diagnostic =
-                                diagnose_unresolved_import(env_id, &name, None, segment.clone());
-                            diagnostics.push(diagnostic);
-                        }
-                        Some((env_id, env)) => {
-                            for var in env.variables.exported_vars() {
-                                let var_id = env.variables.find_exported(&var.name).unwrap();
-
-                                let import_symbol = ResolvedSymbol::new(env_id, var_id);
-                                imports.set_resolved_import(
-                                    var.name.clone(),
-                                    ResolvedImport::Symbol(import_symbol),
-                                    segment.clone(),
-                                );
+                UnresolvedImport::AllIn(loc) => {
+                    match resolve_loc(&loc, context) {
+                        None => diagnostics.push(
+                            Diagnostic::new(
+                                DiagnosticID::ImportResolution,
+                                format!("unable to find reef `{}`.", loc.name.root()),
+                            )
+                            .with_observation(Observation::new(
+                                SourceLocation::new(env_id, segment),
+                            )),
+                        ),
+                        Some((reef, _)) => {
+                            let name = loc.name;
+                            // try to get referenced environment of the import
+                            match get_mod(&name, &reef.engine) {
+                                None => {
+                                    // if the environment wasn't found, and its name was already known, push a diagnostic as it does not exists
+                                    let diagnostic = diagnose_unresolved_import(
+                                        env_id,
+                                        &name,
+                                        None,
+                                        segment.clone(),
+                                    );
+                                    diagnostics.push(diagnostic);
+                                }
+                                Some((env_id, env)) => {
+                                    for var in env.variables.exported_vars() {
+                                        let var_id =
+                                            env.variables.find_exported(&var.name).unwrap();
+                                        let import_symbol =
+                                            ResolvedSymbol::new(context.reef_id, env_id, var_id);
+                                        imports.set_resolved_import(
+                                            var.name.clone(),
+                                            ResolvedImport::Symbol(import_symbol),
+                                            segment.clone(),
+                                        );
+                                    }
+                                }
                             }
                         }
                     }
@@ -111,10 +148,7 @@ impl<'a, 'e> SymbolResolver<'a, 'e> {
 
 /// Gets a module environment from the given fully qualified name, then pop the name until it finds a valid environment.
 /// returns None if the name's root could not get resolved
-fn get_mod_from_absolute<'a>(
-    engine: &'a Engine,
-    name: &Name,
-) -> Option<(SourceId, &'a Environment)> {
+fn get_mod<'a>(name: &Name, engine: &'a Engine) -> Option<(SourceId, &'a Environment)> {
     let mut env_name = Some(name.clone());
     while let Some(name) = env_name {
         if let Some((id, env)) = engine.find_environment_by_name(&name) {

--- a/analyzer/src/steps/resolve/import.rs
+++ b/analyzer/src/steps/resolve/import.rs
@@ -144,7 +144,7 @@ impl<'a, 'ca, 'e> SymbolResolver<'a, 'ca, 'e> {
                                         HashMap<SymbolRegistry, ResolvedSymbol>,
                                     > = HashMap::new();
 
-                                    for (var_id, var) in env.symbols.exported_vars() {
+                                    for (var_id, var) in env.symbols.exported_symbols() {
                                         let symbols =
                                             symbols_map.entry(var.name.clone()).or_default();
 

--- a/analyzer/src/steps/resolve/import.rs
+++ b/analyzer/src/steps/resolve/import.rs
@@ -28,11 +28,11 @@ impl<'a, 'ca, 'e> SymbolResolver<'a, 'ca, 'e> {
 
                     match resolve_loc(&loc, context) {
                         None => diagnostics.push(
-                            Diagnostic::new(DiagnosticID::InvalidSymbolPath, "Invalid import")
+                            Diagnostic::new(DiagnosticID::ImportResolution, "Invalid import")
                                 .with_observation(Observation::context(
                                     env_id,
                                     segment,
-                                    format!("Cannot find reef `{}`", loc.name.root()),
+                                    format!("unable to find reef `{}`", loc.name.root()),
                                 )),
                         ),
                         Some((reef, reef_id)) => {

--- a/analyzer/src/steps/resolve/symbol.rs
+++ b/analyzer/src/steps/resolve/symbol.rs
@@ -21,7 +21,7 @@ pub enum SymbolResolutionResult {
     NotFound,
 }
 
-impl<'a, 'ca, 'e> SymbolResolver<'a, 'ca, 'e> {
+impl<'a, 'e> SymbolResolver<'a, 'e> {
     pub fn resolve_symbol_from_locals(
         env_id: SourceId,
         env: &Environment,

--- a/analyzer/src/steps/shared_diagnostics.rs
+++ b/analyzer/src/steps/shared_diagnostics.rs
@@ -3,12 +3,12 @@
 use context::source::SourceSegment;
 
 use crate::diagnostic::{Diagnostic, DiagnosticID, Observation, SourceLocation};
-use crate::environment::variables::TypeInfo;
+use crate::environment::symbols::SymbolInfo;
 use crate::name::Name;
 use crate::relations::SourceId;
 
 pub fn diagnose_invalid_symbol(
-    base_type: TypeInfo,
+    base_type: SymbolInfo,
     env_id: SourceId,
     name: &Name,
     segments: &[SourceSegment],

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -13,7 +13,7 @@ use context::source::{SourceSegment, SourceSegmentHolder};
 
 use crate::dependency::topological_sort;
 use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
-use crate::reef::{ReefAccessor, ReefContext, ReefId, Reefs};
+use crate::reef::{ReefContext, ReefId, Reefs};
 use crate::relations::{Definition, SourceId, SymbolRef};
 use crate::steps::typing::coercion::{check_type_annotation, coerce_condition, convert_expression};
 use crate::steps::typing::exploration::{Exploration, UniversalReefAccessor};
@@ -1123,7 +1123,7 @@ mod tests {
 
     use crate::importer::StaticImporter;
     use crate::name::Name;
-    use crate::reef::{ReefAccessor, ReefContext, ReefId, Reefs};
+    use crate::reef::{ReefContext, ReefId, Reefs};
     use crate::relations::{LocalId, NativeId};
     use crate::resolve_all;
     use crate::types::hir::{Convert, MethodCall};

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -13,11 +13,10 @@ use context::source::{SourceSegment, SourceSegmentHolder};
 
 use crate::dependency::topological_sort;
 use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
-use crate::engine::Engine;
-use crate::environment::Environment;
-use crate::relations::{Definition, Relations, SourceId, Symbol};
+use crate::reef::{ReefAccessor, ReefContext, ReefId, Reefs};
+use crate::relations::{Definition, SourceId, SymbolRef};
 use crate::steps::typing::coercion::{check_type_annotation, coerce_condition, convert_expression};
-use crate::steps::typing::exploration::{diagnose_unknown_type, Exploration};
+use crate::steps::typing::exploration::{Exploration, UniversalReefAccessor};
 use crate::steps::typing::function::{
     find_operand_implementation, infer_return, type_call, type_method, type_parameter, Return,
 };
@@ -29,37 +28,44 @@ use crate::types::hir::{
     Redirect, TypedExpr, Var,
 };
 use crate::types::operator::name_operator_method;
-use crate::types::ty::Type;
-use crate::types::{Typing, BOOL, ERROR, EXIT_CODE, FLOAT, INT, NOTHING, STRING, UNIT};
+use crate::types::ty::{Type, TypeRef};
+use crate::types::{
+    convert_description, convert_many, get_type, resolve_type, Typing, BOOL, ERROR, EXIT_CODE,
+    FLOAT, INT, NOTHING, STRING, UNIT,
+};
 
 mod coercion;
-mod exploration;
+pub mod exploration;
 mod function;
 mod lower;
 
-pub fn apply_types(
-    engine: &Engine,
-    relations: &Relations,
-    diagnostics: &mut Vec<Diagnostic>,
-) -> (TypedEngine, Typing) {
-    let environments = topological_sort(&relations.as_dependencies(engine));
+pub fn apply_types(context: &mut ReefContext, diagnostics: &mut Vec<Diagnostic>) {
+    let reef = context.current_reef();
+    let dependencies = reef.relations.as_dependencies(&reef.engine);
+    let environments = topological_sort(&dependencies);
+
     let mut exploration = Exploration {
-        engine: TypedEngine::with_lang(engine.len()),
-        typing: Typing::with_lang(),
-        ctx: TypeContext::with_lang(),
+        type_engine: TypedEngine::new(reef.engine.len()),
+        typing: Typing::default(),
+        ctx: TypeContext::default(),
         returns: Vec::new(),
     };
+
     for env_id in environments {
         let entry = apply_types_to_source(
             &mut exploration,
             diagnostics,
-            engine,
-            relations,
-            TypingState::new(env_id),
+            context.reefs(),
+            TypingState::new(env_id, context.reef_id),
         );
-        exploration.engine.insert(env_id, entry);
+        exploration.type_engine.insert(env_id, entry);
     }
-    (exploration.engine, exploration.typing)
+
+    let reef = context.current_reef_mut();
+
+    reef.type_context = exploration.ctx;
+    reef.typed_engine = exploration.type_engine;
+    reef.typing = exploration.typing;
 }
 
 /// A state holder, used to informs the type checker about what should be
@@ -67,6 +73,7 @@ pub fn apply_types(
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 struct TypingState {
     source: SourceId,
+    reef: ReefId,
     local_type: bool,
 
     // if not in loop, `continue` and `break` will raise a diagnostic
@@ -75,9 +82,10 @@ struct TypingState {
 
 impl TypingState {
     /// Creates a new initial state, for a script.
-    fn new(source: SourceId) -> Self {
+    fn new(source: SourceId, reef: ReefId) -> Self {
         Self {
             source,
+            reef,
             local_type: false,
             in_loop: false,
         }
@@ -111,47 +119,50 @@ impl TypingState {
 fn apply_types_to_source(
     exploration: &mut Exploration,
     diagnostics: &mut Vec<Diagnostic>,
-    engine: &Engine,
-    relations: &Relations,
+    reefs: &Reefs,
     state: TypingState,
 ) -> Chunk {
     let source_id = state.source;
-    let expr = engine.get_expression(source_id).unwrap();
-    let env = engine.get_environment(source_id).unwrap();
+
     exploration.prepare();
+
+    let current_reef = reefs.get_reef(state.reef).unwrap();
+    let engine = &current_reef.engine;
+
+    let expr = engine.get_expression(source_id).unwrap();
     match expr {
         Expr::FunctionDeclaration(func) => {
-            let attached_env = env.parent.unwrap_or(source_id);
             for param in &func.parameters {
-                let param = type_parameter(&exploration.ctx, param, attached_env);
-                exploration.ctx.push_local_type(state.source, param.ty);
+                let ura = exploration.universal_accessor(state.reef, reefs);
+
+                let param = type_parameter(&ura, state.reef, param, source_id);
+                exploration.ctx.push_local_typed(source_id, param.ty);
             }
+
             let typed_expr = ascribe_types(
                 exploration,
-                relations,
                 diagnostics,
-                env,
+                reefs,
                 &func.body,
                 state.with_local_type(),
             );
-            let return_type = infer_return(func, &typed_expr, diagnostics, exploration, state);
-            Chunk::function(
-                typed_expr,
-                func.parameters
-                    .iter()
-                    .map(|param| type_parameter(&exploration.ctx, param, attached_env))
-                    .collect(),
-                return_type,
-            )
+
+            let return_type =
+                infer_return(func, &typed_expr, diagnostics, exploration, reefs, state);
+
+            let chunk_params = func
+                .parameters
+                .iter()
+                .map(|param| {
+                    let ura = exploration.universal_accessor(state.reef, reefs);
+
+                    type_parameter(&ura, state.reef, param, source_id)
+                })
+                .collect();
+
+            Chunk::function(typed_expr, chunk_params, return_type)
         }
-        expr => Chunk::script(ascribe_types(
-            exploration,
-            relations,
-            diagnostics,
-            env,
-            expr,
-            state,
-        )),
+        expr => Chunk::script(ascribe_types(exploration, diagnostics, reefs, expr, state)),
     }
 }
 
@@ -172,9 +183,8 @@ fn ascribe_literal(lit: &Literal) -> TypedExpr {
 fn ascribe_template_string(
     tpl: &TemplateString,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
     if tpl.parts.is_empty() {
@@ -184,26 +194,29 @@ fn ascribe_template_string(
             segment: tpl.segment(),
         };
     }
-    let plus_method = exploration
-        .engine
+
+    let plus_method = reefs
+        .lang()
+        .typed_engine
         .get_method_exact(
-            STRING,
+            STRING.type_id,
             name_operator_method(BinaryOperator::Plus),
             &[STRING],
             STRING,
         )
         .expect("string type should have a concatenation method")
         .definition;
+
     let mut it = tpl.parts.iter().map(|part| {
         let typed_part = ascribe_types(
             exploration,
-            relations,
             diagnostics,
-            env,
+            reefs,
             part,
             state.without_local_type(),
         );
-        convert_into_string(typed_part, exploration, diagnostics, state)
+        let ura = exploration.universal_accessor(state.reef, reefs);
+        convert_into_string(typed_part, &ura, diagnostics, state)
     });
     let acc = it.next().unwrap();
     it.fold(acc, |acc, current| {
@@ -223,29 +236,33 @@ fn ascribe_template_string(
 fn ascribe_assign(
     assign: &Assign,
     exploration: &mut Exploration,
-    relations: &Relations,
+    reefs: &Reefs,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
     state: TypingState,
 ) -> TypedExpr {
     let rhs = ascribe_types(
         exploration,
-        relations,
         diagnostics,
-        env,
+        reefs,
         &assign.value,
         state.with_local_type(),
     );
+
+    let current_reef = reefs.get_reef(state.reef).unwrap();
+
+    let env = current_reef.engine.get_environment(state.source).unwrap();
     let symbol = env.get_raw_symbol(assign.segment()).unwrap();
-    let actual_type = exploration
-        .get_type(
-            exploration
-                .ctx
-                .get(relations, state.source, symbol)
-                .unwrap()
-                .type_id,
-        )
-        .unwrap();
+
+    let relations = &current_reef.relations;
+
+    let actual_type_ref = exploration
+        .ctx
+        .get(relations, state.source, symbol)
+        .unwrap()
+        .type_ref;
+
+    let ura = exploration.universal_accessor(state.reef, reefs);
+    let actual_type = get_type(actual_type_ref, &ura).unwrap();
     if actual_type.is_named() {
         diagnostics.push(
             Diagnostic::new(
@@ -267,16 +284,10 @@ fn ascribe_assign(
         .ctx
         .get(relations, state.source, symbol)
         .unwrap();
-    let var_ty = var_obj.type_id;
+    let var_ty = var_obj.type_ref;
     let rhs_type = rhs.ty;
-    let rhs = match convert_expression(
-        rhs,
-        var_ty,
-        &mut exploration.typing,
-        &exploration.engine,
-        state,
-        diagnostics,
-    ) {
+
+    let rhs = match convert_expression(rhs, var_ty, state, &ura, diagnostics) {
         Ok(rhs) => rhs,
         Err(_) => {
             diagnostics.push(
@@ -284,8 +295,8 @@ fn ascribe_assign(
                     DiagnosticID::TypeMismatch,
                     format!(
                         "Cannot assign a value of type `{}` to something of type `{}`",
-                        exploration.get_type(rhs_type).unwrap(),
-                        exploration.get_type(var_ty).unwrap()
+                        get_type(rhs_type, &ura).unwrap(),
+                        get_type(var_ty, &ura).unwrap()
                     ),
                 )
                 .with_observation(Observation::here(
@@ -320,8 +331,8 @@ fn ascribe_assign(
     }
 
     let identifier = match symbol {
-        Symbol::Local(id) => Var::Local(id),
-        Symbol::External(id) => {
+        SymbolRef::Local(id) => Var::Local(id),
+        SymbolRef::External(id) => {
             Var::External(relations[id].state.expect_resolved("non resolved relation"))
         }
     };
@@ -339,9 +350,8 @@ fn ascribe_assign(
 fn ascribe_var_declaration(
     decl: &VarDeclaration,
     exploration: &mut Exploration,
-    relations: &Relations,
+    reefs: &Reefs,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
     state: TypingState,
 ) -> TypedExpr {
     let mut initializer = decl
@@ -350,14 +360,14 @@ fn ascribe_var_declaration(
         .map(|expr| {
             ascribe_types(
                 exploration,
-                relations,
                 diagnostics,
-                env,
+                reefs,
                 expr,
                 state.with_local_type(),
             )
         })
         .expect("Variables without initializers are not supported yet");
+
     let id = exploration.ctx.push_local(
         state.source,
         if decl.kind == VarKind::Val {
@@ -367,13 +377,8 @@ fn ascribe_var_declaration(
         },
     );
     if let Some(type_annotation) = &decl.var.ty {
-        initializer = check_type_annotation(
-            exploration,
-            type_annotation,
-            initializer,
-            diagnostics,
-            state,
-        );
+        let ura = exploration.universal_accessor(state.reef, reefs);
+        initializer = check_type_annotation(&ura, type_annotation, initializer, diagnostics, state);
     }
     TypedExpr {
         kind: ExprKind::Declare(Declaration {
@@ -387,28 +392,35 @@ fn ascribe_var_declaration(
 
 fn ascribe_var_reference(
     var_ref: &VarReference,
-    source: SourceId,
-    env: &Environment,
-    exploration: &Exploration,
-    relations: &Relations,
+    state: TypingState,
+    ura: &UniversalReefAccessor,
 ) -> TypedExpr {
-    let symbol = env.get_raw_symbol(var_ref.segment.clone()).unwrap();
-    let type_id = exploration
-        .ctx
-        .get(relations, source, symbol)
+    let env = ura
+        .get_engine(state.reef)
         .unwrap()
-        .type_id;
+        .get_environment(state.source)
+        .unwrap();
+    let relations = ura.get_relations(state.reef).unwrap();
+
+    let symbol = env.get_raw_symbol(var_ref.segment()).unwrap();
+    let type_ref = ura
+        .get_types(state.reef)
+        .unwrap()
+        .context
+        .get(relations, state.source, symbol)
+        .unwrap()
+        .type_ref;
 
     let var = match symbol {
-        Symbol::Local(id) => Var::Local(id),
-        Symbol::External(id) => {
+        SymbolRef::Local(id) => Var::Local(id),
+        SymbolRef::External(id) => {
             Var::External(relations[id].state.expect_resolved("non resolved relation"))
         }
     };
 
     TypedExpr {
         kind: ExprKind::Reference(var),
-        ty: type_id,
+        ty: type_ref,
         segment: var_ref.segment.clone(),
     }
 }
@@ -416,9 +428,8 @@ fn ascribe_var_reference(
 fn ascribe_block(
     block: &Block,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
     let mut expressions = Vec::with_capacity(block.expressions.len());
@@ -430,9 +441,8 @@ fn ascribe_block(
     while let Some(expr) = it.next() {
         expressions.push(ascribe_types(
             exploration,
-            relations,
             diagnostics,
-            env,
+            reefs,
             expr,
             if it.peek().is_some() {
                 state.without_local_type()
@@ -452,29 +462,16 @@ fn ascribe_block(
 fn ascribe_redirected(
     redirected: &Redirected,
     exploration: &mut Exploration,
-    relations: &Relations,
+    reefs: &Reefs,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
     state: TypingState,
 ) -> TypedExpr {
-    let expr = ascribe_types(
-        exploration,
-        relations,
-        diagnostics,
-        env,
-        &redirected.expr,
-        state,
-    );
+    let expr = ascribe_types(exploration, diagnostics, reefs, &redirected.expr, state);
+
     let mut redirections = Vec::with_capacity(redirected.redirections.len());
     for redirection in &redirected.redirections {
-        let operand = ascribe_types(
-            exploration,
-            relations,
-            diagnostics,
-            env,
-            &redirection.operand,
-            state,
-        );
+        let operand = ascribe_types(exploration, diagnostics, reefs, &redirection.operand, state);
+        let ura = exploration.universal_accessor(state.reef, reefs);
         let operand = if matches!(redirection.operator, RedirOp::FdIn | RedirOp::FdOut) {
             if operand.ty != INT {
                 diagnostics.push(
@@ -482,7 +479,7 @@ fn ascribe_redirected(
                         DiagnosticID::TypeMismatch,
                         format!(
                             "File descriptor redirections must be given an integer, not `{}`",
-                            exploration.get_type(operand.ty).unwrap()
+                            get_type(operand.ty, &ura).unwrap()
                         ),
                     )
                     .with_observation(Observation::here(
@@ -494,7 +491,7 @@ fn ascribe_redirected(
             }
             operand
         } else {
-            convert_into_string(operand, exploration, diagnostics, state)
+            convert_into_string(operand, &ura, diagnostics, state)
         };
         redirections.push(Redir {
             fd: redirection.fd,
@@ -516,18 +513,16 @@ fn ascribe_redirected(
 fn ascribe_pipeline(
     pipeline: &Pipeline,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
     let mut commands = Vec::with_capacity(pipeline.commands.len());
     for command in &pipeline.commands {
         commands.push(ascribe_types(
             exploration,
-            relations,
             diagnostics,
-            env,
+            reefs,
             command,
             state,
         ));
@@ -542,16 +537,15 @@ fn ascribe_pipeline(
 fn ascribe_substitution(
     substitution: &Substitution,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
     let commands = substitution
         .underlying
         .expressions
         .iter()
-        .map(|command| ascribe_types(exploration, relations, diagnostics, env, command, state))
+        .map(|command| ascribe_types(exploration, diagnostics, reefs, command, state))
         .collect::<Vec<_>>();
     TypedExpr {
         kind: ExprKind::Capture(commands),
@@ -563,21 +557,14 @@ fn ascribe_substitution(
 fn ascribe_return(
     ret: &ast::function::Return,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
-    let expr = ret.expr.as_ref().map(|expr| {
-        Box::new(ascribe_types(
-            exploration,
-            relations,
-            diagnostics,
-            env,
-            expr,
-            state,
-        ))
-    });
+    let expr = ret
+        .expr
+        .as_ref()
+        .map(|expr| Box::new(ascribe_types(exploration, diagnostics, reefs, expr, state)));
     exploration.returns.push(Return {
         ty: expr.as_ref().map_or(UNIT, |expr| expr.ty),
         segment: ret.segment.clone(),
@@ -591,33 +578,45 @@ fn ascribe_return(
 
 fn ascribe_function_declaration(
     fun: &FunctionDeclaration,
-    source: SourceId,
-    env: &Environment,
+    state: TypingState,
+    reefs: &Reefs,
     exploration: &mut Exploration,
 ) -> TypedExpr {
-    let declaration = env.get_raw_env(fun.segment.clone()).unwrap();
+    let env = reefs
+        .get_reef(state.reef)
+        .unwrap()
+        .engine
+        .get_environment(state.source)
+        .unwrap();
+
+    let func_env_id = env.get_raw_env(fun.segment()).unwrap();
+
     let type_id = exploration
         .typing
-        .add_type(Type::Function(Definition::User(declaration)));
-    let local_id = exploration.ctx.push_local_type(source, type_id);
+        .add_type(Type::Function(Definition::User(func_env_id)));
+    let type_ref = TypeRef::new(state.reef, type_id);
+
+    let local_id = exploration.ctx.push_local_typed(state.source, type_ref);
+
+    let ura = exploration.universal_accessor(state.reef, reefs);
 
     // Forward declare the function
     let parameters = fun
         .parameters
         .iter()
-        .map(|param| type_parameter(&exploration.ctx, param, source))
+        .map(|param| type_parameter(&ura, state.reef, param, func_env_id))
         .collect::<Vec<_>>();
     let return_type = fun
         .return_type
         .as_ref()
-        .map_or(UNIT, |ty| exploration.ctx.resolve(ty).unwrap_or(ERROR));
+        .map_or(UNIT, |ty| resolve_type(&ura, state.reef, func_env_id, ty));
 
-    exploration.engine.insert_if_absent(
-        declaration,
+    exploration.type_engine.insert_if_absent(
+        func_env_id,
         Chunk::function(
             TypedExpr {
                 kind: ExprKind::Noop,
-                ty: type_id,
+                ty: type_ref,
                 segment: fun.segment.clone(),
             },
             parameters,
@@ -637,18 +636,20 @@ fn ascribe_function_declaration(
 fn ascribe_binary(
     bin: &BinaryOperation,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
-    let left_expr = ascribe_types(exploration, relations, diagnostics, env, &bin.left, state);
-    let right_expr = ascribe_types(exploration, relations, diagnostics, env, &bin.right, state);
+    let left_expr = ascribe_types(exploration, diagnostics, reefs, &bin.left, state);
+    let right_expr = ascribe_types(exploration, diagnostics, reefs, &bin.right, state);
     let name = name_operator_method(bin.op);
-    let method = exploration
-        .engine
-        .get_methods(left_expr.ty, name)
+
+    let ura = exploration.universal_accessor(state.reef, reefs);
+    let left_expr_typed_engine = ura.get_types(left_expr.ty.reef).unwrap().engine;
+    let method = left_expr_typed_engine
+        .get_methods(left_expr.ty.type_id, name)
         .and_then(|methods| find_operand_implementation(methods, &right_expr));
+
     let ty = match method {
         Some(method) => method.return_type,
         _ => {
@@ -660,8 +661,8 @@ fn ascribe_binary(
                         format!(
                             "No operator `{}` between type `{}` and `{}`",
                             name,
-                            exploration.get_type(left_expr.ty).unwrap(),
-                            exploration.get_type(right_expr.ty).unwrap()
+                            get_type(left_expr.ty, &ura).unwrap(),
+                            get_type(right_expr.ty, &ura).unwrap()
                         ),
                     )),
             );
@@ -682,36 +683,22 @@ fn ascribe_binary(
 fn ascribe_casted(
     casted: &CastedExpr,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
-    let expr = ascribe_types(
-        exploration,
-        relations,
-        diagnostics,
-        env,
-        &casted.expr,
-        state,
-    );
-    let ty = exploration
-        .ctx
-        .resolve(&casted.casted_type)
-        .unwrap_or(ERROR);
-    if ty.is_err() {
-        diagnostics.push(diagnose_unknown_type(
-            state.source,
-            casted.casted_type.segment(),
-        ))
-    } else if expr.ty.is_ok() && exploration.typing.convert_description(ty, expr.ty).is_err() {
+    let expr = ascribe_types(exploration, diagnostics, reefs, &casted.expr, state);
+    let ura = exploration.universal_accessor(state.reef, reefs);
+    let ty = resolve_type(&ura, state.reef, state.source, &casted.casted_type);
+
+    if expr.ty.is_ok() && convert_description(&ura, ty, expr.ty).is_err() {
         diagnostics.push(
             Diagnostic::new(
                 DiagnosticID::IncompatibleCast,
                 format!(
                     "Casting `{}` as `{}` is invalid",
-                    exploration.get_type(expr.ty).unwrap(),
-                    exploration.get_type(ty).unwrap()
+                    get_type(expr.ty, &ura).unwrap(),
+                    get_type(ty, &ura).unwrap()
                 ),
             )
             .with_observation(Observation::here(
@@ -734,16 +721,14 @@ fn ascribe_casted(
 fn ascribe_unary(
     unary: &UnaryOperation,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
     let expr = ascribe_types(
         exploration,
-        relations,
         diagnostics,
-        env,
+        reefs,
         &unary.expr,
         state.with_local_type(),
     );
@@ -752,11 +737,20 @@ fn ascribe_unary(
     }
 
     match unary.op {
-        UnaryOperator::Not => ascribe_not(expr, unary.segment(), exploration, diagnostics, state),
+        UnaryOperator::Not => ascribe_not(
+            expr,
+            unary.segment(),
+            exploration,
+            diagnostics,
+            reefs,
+            state,
+        ),
         UnaryOperator::Negate => {
-            let method = exploration
-                .engine
-                .get_method_exact(expr.ty, "neg", &[], expr.ty);
+            let lang_reef = reefs.lang();
+            let method =
+                lang_reef
+                    .typed_engine
+                    .get_method_exact(expr.ty.type_id, "neg", &[], expr.ty);
             match method {
                 Some(method) => TypedExpr {
                     kind: ExprKind::MethodCall(MethodCall {
@@ -775,7 +769,11 @@ fn ascribe_unary(
                                 unary.segment(),
                                 format!(
                                     "`{}` does not implement the `neg` method",
-                                    exploration.get_type(expr.ty).unwrap(),
+                                    get_type(
+                                        expr.ty,
+                                        &exploration.universal_accessor(state.reef, reefs)
+                                    )
+                                    .unwrap(),
                                 ),
                             )),
                     );
@@ -791,20 +789,17 @@ fn ascribe_not(
     segment: SourceSegment,
     exploration: &mut Exploration,
     diagnostics: &mut Vec<Diagnostic>,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
-    let not_method = exploration
-        .engine
-        .get_method_exact(BOOL, "not", &[], BOOL)
+    let lang_reef = reefs.lang();
+    let not_method = lang_reef
+        .typed_engine
+        .get_method_exact(BOOL.type_id, "not", &[], BOOL)
         .expect("A Bool should be invertible");
-    match convert_expression(
-        not,
-        BOOL,
-        &mut exploration.typing,
-        &exploration.engine,
-        state,
-        diagnostics,
-    ) {
+
+    let ura = exploration.universal_accessor(state.reef, reefs);
+    match convert_expression(not, BOOL, state, &ura, diagnostics) {
         Ok(expr) => TypedExpr {
             kind: ExprKind::MethodCall(MethodCall {
                 callee: Box::new(expr),
@@ -822,7 +817,7 @@ fn ascribe_not(
                         segment,
                         format!(
                             "Cannot invert non-boolean type `{}`",
-                            exploration.get_type(expr.ty).unwrap()
+                            get_type(expr.ty, &ura).unwrap()
                         ),
                     ),
                 ),
@@ -835,58 +830,41 @@ fn ascribe_not(
 fn ascribe_if(
     block: &If,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
-    let condition = ascribe_types(
-        exploration,
-        relations,
-        diagnostics,
-        env,
-        &block.condition,
-        state,
-    );
-    let condition = coerce_condition(condition, exploration, state, diagnostics);
+    let condition = ascribe_types(exploration, diagnostics, reefs, &block.condition, state);
+    let ura = exploration.universal_accessor(state.reef, reefs);
+
+    let condition = coerce_condition(condition, &ura, state, diagnostics);
     let mut then = ascribe_types(
         exploration,
-        relations,
         diagnostics,
-        env,
+        reefs,
         &block.success_branch,
         state,
     );
+
     let mut otherwise = block
         .fail_branch
         .as_ref()
-        .map(|expr| ascribe_types(exploration, relations, diagnostics, env, expr, state));
+        .map(|expr| ascribe_types(exploration, diagnostics, reefs, expr, state));
+
     let ty = if state.local_type {
-        match exploration
-            .typing
-            .convert_many([then.ty, otherwise.as_ref().map_or(UNIT, |expr| expr.ty)])
-        {
+        let ura = exploration.universal_accessor(state.reef, reefs);
+
+        match convert_many(
+            &ura,
+            [then.ty, otherwise.as_ref().map_or(UNIT, |expr| expr.ty)],
+        ) {
             Ok(ty) => {
                 // Generate appropriate casts and implicits conversions
-                then = convert_expression(
-                    then,
-                    ty,
-                    &mut exploration.typing,
-                    &exploration.engine,
-                    state,
-                    diagnostics,
-                )
-                .expect("Type mismatch should already have been caught");
+                then = convert_expression(then, ty, state, &ura, diagnostics)
+                    .expect("Type mismatch should already have been caught");
                 otherwise = otherwise.map(|expr| {
-                    convert_expression(
-                        expr,
-                        ty,
-                        &mut exploration.typing,
-                        &exploration.engine,
-                        state,
-                        diagnostics,
-                    )
-                    .expect("Type mismatch should already have been caught")
+                    convert_expression(expr, ty, state, &ura, diagnostics)
+                        .expect("Type mismatch should already have been caught")
                 });
                 ty
             }
@@ -898,13 +876,13 @@ fn ascribe_if(
                 .with_observation(Observation::here(
                     state.source,
                     block.success_branch.segment(),
-                    format!("Found `{}`", exploration.get_type(then.ty).unwrap()),
+                    format!("Found `{}`", get_type(then.ty, &ura).unwrap()),
                 ));
                 if let Some(otherwise) = &otherwise {
                     diagnostic = diagnostic.with_observation(Observation::here(
                         state.source,
                         otherwise.segment(),
-                        format!("Found `{}`", exploration.get_type(otherwise.ty).unwrap()),
+                        format!("Found `{}`", get_type(otherwise.ty, &ura).unwrap()),
                     ));
                 }
                 diagnostics.push(diagnostic);
@@ -928,17 +906,17 @@ fn ascribe_if(
 fn ascribe_call(
     call: &Call,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
     let args = call
         .arguments
         .iter()
         .map(|expr| {
-            let expr = ascribe_types(exploration, relations, diagnostics, env, expr, state);
-            convert_into_string(expr, exploration, diagnostics, state)
+            let expr = ascribe_types(exploration, diagnostics, reefs, expr, state);
+            let ura = exploration.universal_accessor(state.reef, reefs);
+            convert_into_string(expr, &ura, diagnostics, state)
         })
         .collect::<Vec<_>>();
 
@@ -952,28 +930,19 @@ fn ascribe_call(
 fn ascribe_pfc(
     call: &ProgrammaticCall,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
     let arguments = call
         .arguments
         .iter()
-        .map(|expr| ascribe_types(exploration, relations, diagnostics, env, expr, state))
+        .map(|expr| ascribe_types(exploration, diagnostics, reefs, expr, state))
         .collect::<Vec<_>>();
-    let symbol = env
-        .get_raw_symbol(call.segment.clone())
-        .expect("Environment has not tracked the symbol for programmatic call");
-    let function_match = type_call(
-        call,
-        arguments,
-        symbol,
-        diagnostics,
-        exploration,
-        relations,
-        state,
-    );
+
+    let ura = exploration.universal_accessor(state.reef, reefs);
+
+    let function_match = type_call(call, arguments, diagnostics, &ura, state);
     TypedExpr {
         kind: ExprKind::FunctionCall(FunctionCall {
             arguments: function_match.arguments,
@@ -987,25 +956,20 @@ fn ascribe_pfc(
 fn ascribe_method_call(
     method: &ast::call::MethodCall,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
-    let callee = ascribe_types(
-        exploration,
-        relations,
-        diagnostics,
-        env,
-        &method.source,
-        state,
-    );
+    let callee = ascribe_types(exploration, diagnostics, reefs, &method.source, state);
     let arguments = method
         .arguments
         .iter()
-        .map(|expr| ascribe_types(exploration, relations, diagnostics, env, expr, state))
+        .map(|expr| ascribe_types(exploration, diagnostics, reefs, expr, state))
         .collect::<Vec<_>>();
-    let method_type = type_method(method, &callee, &arguments, diagnostics, exploration, state);
+
+    let ura = exploration.universal_accessor(state.reef, reefs);
+
+    let method_type = type_method(method, &callee, &arguments, diagnostics, &ura, state);
     TypedExpr {
         kind: ExprKind::MethodCall(MethodCall {
             callee: Box::new(callee),
@@ -1020,23 +984,23 @@ fn ascribe_method_call(
 fn ascribe_loop(
     loo: &Expr,
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     state: TypingState,
 ) -> TypedExpr {
     let (condition, body) = match loo {
         Expr::While(w) => {
             let condition = ascribe_types(
                 exploration,
-                relations,
                 diagnostics,
-                env,
+                reefs,
                 &w.condition,
                 state.with_local_type(),
             );
+            let ura = exploration.universal_accessor(state.reef, reefs);
+
             (
-                Some(coerce_condition(condition, exploration, state, diagnostics)),
+                Some(coerce_condition(condition, &ura, state, diagnostics)),
                 &w.body,
             )
         }
@@ -1045,9 +1009,8 @@ fn ascribe_loop(
     };
     let body = ascribe_types(
         exploration,
-        relations,
         diagnostics,
-        env,
+        reefs,
         body,
         state.without_local_type().with_in_loop(),
     );
@@ -1094,71 +1057,54 @@ fn ascribe_continue_or_break(
 /// In case of an error, the expression is still returned, but the type is set to [`ERROR`].
 fn ascribe_types(
     exploration: &mut Exploration,
-    relations: &Relations,
     diagnostics: &mut Vec<Diagnostic>,
-    env: &Environment,
+    reefs: &Reefs,
     expr: &Expr,
     state: TypingState,
 ) -> TypedExpr {
     match expr {
         Expr::FunctionDeclaration(fd) => {
-            ascribe_function_declaration(fd, state.source, env, exploration)
+            ascribe_function_declaration(fd, state, reefs, exploration)
         }
         Expr::Literal(lit) => ascribe_literal(lit),
         Expr::TemplateString(tpl) => {
-            ascribe_template_string(tpl, exploration, relations, diagnostics, env, state)
+            ascribe_template_string(tpl, exploration, diagnostics, reefs, state)
         }
-        Expr::Assign(assign) => {
-            ascribe_assign(assign, exploration, relations, diagnostics, env, state)
-        }
+        Expr::Assign(assign) => ascribe_assign(assign, exploration, reefs, diagnostics, state),
         Expr::VarDeclaration(decl) => {
-            ascribe_var_declaration(decl, exploration, relations, diagnostics, env, state)
+            ascribe_var_declaration(decl, exploration, reefs, diagnostics, state)
         }
-        Expr::VarReference(var) => {
-            ascribe_var_reference(var, state.source, env, exploration, relations)
-        }
-        Expr::If(block) => ascribe_if(block, exploration, relations, diagnostics, env, state),
-        Expr::Call(call) => ascribe_call(call, exploration, relations, diagnostics, env, state),
-        Expr::ProgrammaticCall(call) => {
-            ascribe_pfc(call, exploration, relations, diagnostics, env, state)
-        }
+        Expr::VarReference(var) => ascribe_var_reference(
+            var,
+            state,
+            &exploration.universal_accessor(state.reef, reefs),
+        ),
+        Expr::If(block) => ascribe_if(block, exploration, diagnostics, reefs, state),
+        Expr::Call(call) => ascribe_call(call, exploration, diagnostics, reefs, state),
+        Expr::ProgrammaticCall(call) => ascribe_pfc(call, exploration, diagnostics, reefs, state),
         Expr::MethodCall(method) => {
-            ascribe_method_call(method, exploration, relations, diagnostics, env, state)
+            ascribe_method_call(method, exploration, diagnostics, reefs, state)
         }
-        Expr::Block(b) => ascribe_block(b, exploration, relations, diagnostics, env, state),
+        Expr::Block(b) => ascribe_block(b, exploration, diagnostics, reefs, state),
         Expr::Redirected(redirected) => {
-            ascribe_redirected(redirected, exploration, relations, diagnostics, env, state)
+            ascribe_redirected(redirected, exploration, reefs, diagnostics, state)
         }
         Expr::Pipeline(pipeline) => {
-            ascribe_pipeline(pipeline, exploration, relations, diagnostics, env, state)
+            ascribe_pipeline(pipeline, exploration, diagnostics, reefs, state)
         }
         Expr::Substitution(subst) => {
-            ascribe_substitution(subst, exploration, relations, diagnostics, env, state)
+            ascribe_substitution(subst, exploration, diagnostics, reefs, state)
         }
-        Expr::Return(r) => ascribe_return(r, exploration, relations, diagnostics, env, state),
-        Expr::Parenthesis(paren) => ascribe_types(
-            exploration,
-            relations,
-            diagnostics,
-            env,
-            &paren.expression,
-            state,
-        ),
-        Expr::Binary(bo) => ascribe_binary(bo, exploration, relations, diagnostics, env, state),
-        Expr::Casted(casted) => {
-            ascribe_casted(casted, exploration, relations, diagnostics, env, state)
+        Expr::Return(r) => ascribe_return(r, exploration, diagnostics, reefs, state),
+        Expr::Parenthesis(paren) => {
+            ascribe_types(exploration, diagnostics, reefs, &paren.expression, state)
         }
-        Expr::Test(test) => ascribe_types(
-            exploration,
-            relations,
-            diagnostics,
-            env,
-            &test.expression,
-            state,
-        ),
-        Expr::Unary(unary) => ascribe_unary(unary, exploration, relations, diagnostics, env, state),
+        Expr::Unary(unary) => ascribe_unary(unary, exploration, diagnostics, reefs, state),
+        Expr::Binary(bo) => ascribe_binary(bo, exploration, diagnostics, reefs, state),
+        Expr::Casted(casted) => ascribe_casted(casted, exploration, diagnostics, reefs, state),
+        Expr::Test(test) => ascribe_types(exploration, diagnostics, reefs, &test.expression, state),
         e @ (Expr::While(_) | Expr::Loop(_)) => {
-            ascribe_loop(e, exploration, relations, diagnostics, env, state)
+            ascribe_loop(e, exploration, diagnostics, reefs, state)
         }
         e @ (Expr::Continue(_) | Expr::Break(_)) => {
             ascribe_continue_or_break(e, diagnostics, state.source, state.in_loop)
@@ -1177,7 +1123,7 @@ mod tests {
 
     use crate::importer::StaticImporter;
     use crate::name::Name;
-    use crate::reef::{ReefContext, Reefs};
+    use crate::reef::{ReefAccessor, ReefContext, ReefId, Reefs};
     use crate::relations::{LocalId, NativeId};
     use crate::resolve_all;
     use crate::types::hir::{Convert, MethodCall};
@@ -1185,36 +1131,44 @@ mod tests {
 
     use super::*;
 
-    fn extract(source: Source) -> Result<(Typing, TypedExpr), Vec<Diagnostic>> {
-        let typing = Typing::with_lang();
+    fn extract(source: Source) -> Result<Reefs, Vec<Diagnostic>> {
         let name = Name::new(source.name);
         let mut diagnostics = Vec::new();
         let mut reefs = Reefs::default();
         let mut context = ReefContext::declare_new(&mut reefs, "test");
+
         resolve_all(
             name.clone(),
             &mut context,
             &mut StaticImporter::new([(name, source)], parse_trusted),
             &mut diagnostics,
         );
-        assert_eq!(diagnostics, vec![]);
 
-        let (typed, _) = apply_types(
-            &context.current_reef().engine,
-            &context.current_reef().relations,
-            &mut diagnostics,
-        );
-        let expr = typed.get_user(SourceId(0)).unwrap();
         if !diagnostics.is_empty() {
             return Err(diagnostics);
         }
-        Ok((typing, expr.expression.clone()))
+
+        apply_types(&mut context, &mut diagnostics);
+
+        if !diagnostics.is_empty() {
+            return Err(diagnostics);
+        }
+
+        Ok(reefs)
     }
 
     pub(crate) fn extract_expr(source: Source) -> Result<Vec<TypedExpr>, Vec<Diagnostic>> {
-        extract(source).map(|(_, expr)| {
-            if let ExprKind::Block(exprs) = expr.kind {
-                exprs
+        extract(source).map(|reefs| {
+            let expr = &reefs
+                .get_reef(ReefId(1))
+                .unwrap()
+                .typed_engine
+                .get_user(SourceId(0))
+                .unwrap()
+                .expression;
+
+            if let ExprKind::Block(exprs) = &expr.kind {
+                exprs.clone()
             } else {
                 unreachable!()
             }
@@ -1222,8 +1176,17 @@ mod tests {
     }
 
     pub(crate) fn extract_type(source: Source) -> Result<Type, Vec<Diagnostic>> {
-        let (typing, expr) = extract(source)?;
-        Ok(typing.get_type(expr.ty).unwrap().clone())
+        let reefs = extract(source)?;
+        let reef = reefs.get_reef(ReefId(1)).unwrap();
+        let expr = &reef.typed_engine.get_user(SourceId(0)).unwrap().expression;
+
+        let tpe = reefs
+            .get_reef(expr.ty.reef)
+            .and_then(|reef| reef.typing.get_type(expr.ty.type_id))
+            .unwrap()
+            .clone();
+
+        Ok(tpe)
     }
 
     #[test]
@@ -1263,24 +1226,6 @@ mod tests {
                 SourceId(0),
                 find_in(content, "1.6"),
                 "Found `Float`",
-            ))])
-        );
-    }
-
-    #[test]
-    fn unknown_type_annotation() {
-        let content = "val a: ABC = 1.6";
-        let res = extract_type(Source::unknown(content));
-        assert_eq!(
-            res,
-            Err(vec![Diagnostic::new(
-                DiagnosticID::UnknownType,
-                "Unknown type annotation",
-            )
-            .with_observation(Observation::here(
-                SourceId(0),
-                find_in(content, "ABC"),
-                "Not found in scope",
             ))])
         );
     }
@@ -1399,24 +1344,6 @@ mod tests {
     }
 
     #[test]
-    fn unknown_type_in_cast() {
-        let content = "4 as Imaginary";
-        let res = extract_type(Source::unknown(content));
-        assert_eq!(
-            res,
-            Err(vec![Diagnostic::new(
-                DiagnosticID::UnknownType,
-                "Unknown type annotation",
-            )
-            .with_observation(Observation::here(
-                SourceId(0),
-                find_in(content, "Imaginary"),
-                "Not found in scope",
-            ))])
-        );
-    }
-
-    #[test]
     fn incompatible_cast() {
         let content = "val n = 'a' as Int";
         let res = extract_type(Source::unknown(content));
@@ -1487,7 +1414,7 @@ mod tests {
                 "Expected `String`, found `Int`",
             ))
             .with_observation(Observation::context(
-                SourceId(0),
+                SourceId(1),
                 find_in(content, "str: String"),
                 "Parameter is declared here",
             ))]),

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -30,7 +30,7 @@ use crate::types::hir::{
 use crate::types::operator::name_operator_method;
 use crate::types::ty::{Type, TypeRef};
 use crate::types::{
-    convert_description, convert_many, get_type, resolve_type, Typing, BOOL, ERROR, EXIT_CODE,
+    convert_description, convert_many, get_type, resolve_type, Typing, BOOL, ERROR, EXITCODE,
     FLOAT, INT, NOTHING, STRING, UNIT,
 };
 
@@ -529,7 +529,7 @@ fn ascribe_pipeline(
     }
     TypedExpr {
         kind: ExprKind::Pipeline(commands),
-        ty: EXIT_CODE,
+        ty: EXITCODE,
         segment: pipeline.segment(),
     }
 }
@@ -922,7 +922,7 @@ fn ascribe_call(
 
     TypedExpr {
         kind: ExprKind::ProcessCall(args),
-        ty: EXIT_CODE,
+        ty: EXITCODE,
         segment: call.segment(),
     }
 }
@@ -1731,7 +1731,7 @@ mod tests {
                             segment: find_in(content, "4.2"),
                         }
                     ]),
-                    ty: EXIT_CODE,
+                    ty: EXITCODE,
                     segment: find_in(content, "grep $n 4.2"),
                 }
             ])

--- a/analyzer/src/steps/typing/coercion.rs
+++ b/analyzer/src/steps/typing/coercion.rs
@@ -1,45 +1,165 @@
 use context::source::SourceSegmentHolder;
 
 use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
-use crate::steps::typing::exploration::UniversalReefAccessor;
+use crate::environment::symbols::SymbolInfo;
+use crate::reef::LANG_REEF;
+use crate::relations::{SourceId, SymbolRef};
+use crate::steps::typing::exploration::{Exploration, Links};
 use crate::steps::typing::lower::call_convert_on;
-use crate::steps::typing::TypingState;
 use crate::types::hir::TypedExpr;
-use crate::types::ty::TypeRef;
-use crate::types::{convert_description, get_type, resolve_type, BOOL};
+use crate::types::ty::{Type, TypeId, TypeRef};
+use crate::types::{UnificationError, BOOL, NOTHING};
+
+/// Unifies two type identifiers, returning the type that the right hand side was unified to.
+///
+/// Unification is successful when the assignation type is a superset of the rvalue type, i.e
+/// when the assignation type is a parent conceptually or technically of the rvalue type.
+/// It is not reflexive, i.e. `unify(a, b)` is not the same as `unify(b, a)`.
+///
+/// A conversion may be not as simple as a reinterpretation of the value, and may require
+/// a conversion function to be called. Use [`convert_expression`] to
+/// generate the conversion code for a typed expression.
+pub(super) fn convert_description(
+    exploration: &Exploration, // TODO: &mut ?
+    assign_to: TypeRef,
+    rvalue: TypeRef,
+) -> Result<TypeRef, UnificationError> {
+    if assign_to.is_err() || rvalue.is_err() {
+        // An error is compatible with everything, as it is a placeholder.
+        return Ok(assign_to);
+    }
+
+    if rvalue == assign_to {
+        // if both references are the same then no need to lookup, it's the same type
+        return Ok(assign_to);
+    }
+
+    let lhs = exploration
+        .get_type(assign_to)
+        .unwrap_or_else(|| panic!("cannot find type {assign_to:?}`"));
+    let rhs = exploration
+        .get_type(rvalue)
+        .unwrap_or_else(|| panic!("cannot find type {rvalue:?}`"));
+    if lhs == rhs {
+        return Ok(assign_to);
+    }
+
+    // apply the `A U Nothing => A` rule
+    if *rhs == Type::Nothing {
+        return Ok(assign_to);
+    }
+
+    let rvalue_typing = exploration.get_types(rvalue.reef).unwrap();
+
+    if let Some(implicit) = rvalue_typing.implicits.get(&rvalue.type_id) {
+        let implicit = exploration
+            .get_type(*implicit)
+            .unwrap_or_else(|| panic!("cannot find type {implicit:?}`"));
+        if lhs == implicit {
+            return Ok(assign_to);
+        }
+    }
+    Err(UnificationError())
+}
+
+/// Unifies multiple type identifiers in any direction.
+pub(super) fn convert_many<I: IntoIterator<Item = TypeRef>>(
+    exploration: &mut Exploration,
+    types: I,
+) -> Result<TypeRef, UnificationError> {
+    let mut types = types
+        .into_iter()
+        .filter(|ty| ty.is_ok() && !ty.is_nothing());
+
+    let first = types.next().unwrap_or(NOTHING);
+    types.try_fold(first, |acc, ty| {
+        convert_description(exploration, acc, ty)
+            .or_else(|_| convert_description(exploration, ty, acc))
+    })
+}
+
+/// Finds the type reference from an annotation.
+pub(super) fn resolve_type(
+    exploration: &mut Exploration,
+    links: Links,
+    type_annotation: &ast::r#type::Type,
+    _diagnostics: &mut [Diagnostic],
+) -> TypeRef {
+    match type_annotation {
+        ast::r#type::Type::Parametrized(param) => {
+            if !param.params.is_empty() {
+                unimplemented!();
+            }
+            let env = links.env();
+            let type_symbol_ref = env.get_raw_symbol(type_annotation.segment()).unwrap();
+            let type_symbol = match type_symbol_ref {
+                SymbolRef::Local(l) => env.symbols.get(l).unwrap(),
+                SymbolRef::External(r) => {
+                    let resolved_symbol = links.relations[r]
+                        .state
+                        .expect_resolved("unresolved type symbol during typechecking");
+
+                    if resolved_symbol.reef == LANG_REEF {
+                        let primitive_id = TypeId(resolved_symbol.object_id.0);
+                        return TypeRef::new(LANG_REEF, primitive_id);
+                    }
+
+                    let type_env = exploration.get_external_env(env, resolved_symbol).unwrap();
+                    type_env.symbols.get(resolved_symbol.object_id).unwrap()
+                }
+            };
+
+            if let SymbolInfo::Type(type_ref) = type_symbol.ty {
+                type_ref
+            } else {
+                panic!(
+                    "type {type_annotation} refers to a {} symbol ",
+                    type_symbol.ty
+                )
+            }
+        }
+        ast::r#type::Type::Callable(_) => unimplemented!(),
+        ast::r#type::Type::ByName(_) => unimplemented!(),
+    }
+}
 
 /// Ensures that the type annotation accepts the given value.
 ///
 /// A type annotation might generate a conversion function call, which is returned.
 pub(super) fn check_type_annotation(
-    reefs: &UniversalReefAccessor,
+    exploration: &mut Exploration,
     type_annotation: &ast::r#type::Type,
     value: TypedExpr,
+    links: Links,
     diagnostics: &mut Vec<Diagnostic>,
-    state: TypingState,
 ) -> TypedExpr {
     if value.ty.is_err() {
         return value;
     }
 
-    let expected_type = resolve_type(reefs, state.reef, state.source, type_annotation);
+    let expected_type = resolve_type(exploration, links, type_annotation, diagnostics);
 
-    convert_expression(value, expected_type, state, reefs, diagnostics).unwrap_or_else(|value| {
-        diagnostics.push(
-            Diagnostic::new(DiagnosticID::TypeMismatch, "Type mismatch")
-                .with_observation(Observation::here(
-                    state.source,
-                    type_annotation.segment(),
-                    format!("Expected `{}`", get_type(expected_type, reefs).unwrap()),
-                ))
-                .with_observation(Observation::here(
-                    state.source,
-                    value.segment(),
-                    format!("Found `{}`", get_type(value.ty, reefs).unwrap()),
-                )),
-        );
-        value
-    })
+    convert_expression(value, expected_type, exploration, links.source, diagnostics).unwrap_or_else(
+        |value| {
+            diagnostics.push(
+                Diagnostic::new(DiagnosticID::TypeMismatch, "Type mismatch")
+                    .with_observation(Observation::here(
+                        links.source,
+                        type_annotation.segment(),
+                        format!(
+                            "Expected `{}`",
+                            exploration.get_type(expected_type).unwrap()
+                        ),
+                    ))
+                    .with_observation(Observation::here(
+                        links.source,
+                        value.segment(),
+                        format!("Found `{}`", exploration.get_type(value.ty).unwrap()),
+                    )),
+            );
+            value
+        },
+    )
 }
 
 /// Tries to convert an expression to the given assignation type.
@@ -54,18 +174,18 @@ pub(super) fn check_type_annotation(
 pub(super) fn convert_expression(
     rvalue: TypedExpr,
     assign_to: TypeRef,
-    state: TypingState,
-    ura: &UniversalReefAccessor,
+    exploration: &mut Exploration,
+    source: SourceId,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<TypedExpr, TypedExpr> {
-    match convert_description(ura, assign_to, rvalue.ty) {
+    match convert_description(exploration, assign_to, rvalue.ty) {
         Ok(ty) => Ok(call_convert_on(
             rvalue,
             ty,
-            ura,
+            exploration,
             |ty| format!("Cannot convert type `{ty}`"),
             diagnostics,
-            state,
+            source,
         )),
         Err(_) => Err(rvalue),
     }
@@ -77,21 +197,21 @@ pub(super) fn convert_expression(
 /// Otherwise, the converted expression is returned.
 pub(super) fn coerce_condition(
     condition: TypedExpr,
-    ura: &UniversalReefAccessor,
-    state: TypingState,
+    exploration: &mut Exploration,
+    source: SourceId,
     diagnostics: &mut Vec<Diagnostic>,
 ) -> TypedExpr {
-    match convert_expression(condition, BOOL, state, ura, diagnostics) {
+    match convert_expression(condition, BOOL, exploration, source, diagnostics) {
         Ok(condition) => condition,
         Err(condition) => {
             diagnostics.push(
                 Diagnostic::new(DiagnosticID::TypeMismatch, "Condition must be a boolean")
                     .with_observation(Observation::here(
-                        state.source,
+                        source,
                         condition.segment(),
                         format!(
                             "Type `{}` cannot be used as a condition",
-                            get_type(condition.ty, ura).unwrap()
+                            exploration.get_type(condition.ty).unwrap()
                         ),
                     )),
             );

--- a/analyzer/src/steps/typing/exploration.rs
+++ b/analyzer/src/steps/typing/exploration.rs
@@ -1,5 +1,5 @@
 use crate::engine::Engine;
-use crate::reef::{ReefAccessor, ReefId, Reefs};
+use crate::reef::{ReefId, Reefs};
 use crate::relations::Relations;
 use crate::steps::typing::function::Return;
 use crate::types::ctx::TypeContext;
@@ -21,6 +21,9 @@ pub struct ReefTypes<'a> {
     pub typing: &'a Typing,
 }
 
+/// A proxy that let the user access to any reef's engine, relations and types data.
+/// If the given reef identifier is the `current_reef`, the types data stored in `current` is returned instead
+/// of the data stored by the `reefs`.
 pub struct UniversalReefAccessor<'a, 'e> {
     reefs: &'a Reefs<'e>,
     current_reef: ReefId,
@@ -54,6 +57,8 @@ impl Exploration {
         self.returns.clear();
     }
 
+    /// returns an universal accessor that will return the exploration's types data
+    /// if the accessed reef's identifier is equal to given `current_reef`
     pub(crate) fn universal_accessor<'a, 'e>(
         &'e self,
         current_reef: ReefId,

--- a/analyzer/src/steps/typing/exploration.rs
+++ b/analyzer/src/steps/typing/exploration.rs
@@ -14,7 +14,7 @@ pub(super) struct Exploration {
     pub(super) returns: Vec<Return>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct ReefTypes<'a> {
     pub context: &'a TypeContext,
     pub engine: &'a TypedEngine,
@@ -24,6 +24,7 @@ pub struct ReefTypes<'a> {
 /// A proxy that let the user access to any reef's engine, relations and types data.
 /// If the given reef identifier is the `current_reef`, the types data stored in `current` is returned instead
 /// of the data stored by the `reefs`.
+#[derive(Clone, Copy)]
 pub struct UniversalReefAccessor<'a, 'e> {
     reefs: &'a Reefs<'e>,
     current_reef: ReefId,
@@ -33,7 +34,7 @@ pub struct UniversalReefAccessor<'a, 'e> {
 impl<'a, 'e> UniversalReefAccessor<'a, 'e> {
     pub fn get_types(&self, id: ReefId) -> Option<ReefTypes<'a>> {
         if id == self.current_reef {
-            Some(self.current.clone())
+            Some(self.current)
         } else {
             self.reefs.get_reef(id).map(|reef| ReefTypes {
                 context: &reef.type_context,

--- a/analyzer/src/steps/typing/exploration.rs
+++ b/analyzer/src/steps/typing/exploration.rs
@@ -1,78 +1,141 @@
 use crate::engine::Engine;
-use crate::reef::{ReefId, Reefs};
-use crate::relations::Relations;
+use crate::environment::Environment;
+use crate::reef::{Externals, Reef, ReefId};
+use crate::relations::{Definition, Relations, ResolvedSymbol, SourceId, SymbolRef};
 use crate::steps::typing::function::Return;
-use crate::types::ctx::TypeContext;
-use crate::types::engine::TypedEngine;
+use crate::types::ctx::{TypeContext, TypedVariable};
+use crate::types::engine::{CodeEntry, TypedEngine};
+use crate::types::ty::{MethodType, Type, TypeRef};
 use crate::types::Typing;
 
 /// The support for type analysis.
-pub(super) struct Exploration {
+pub(super) struct Exploration<'a> {
     pub(super) type_engine: TypedEngine,
     pub(super) typing: Typing,
     pub(super) ctx: TypeContext,
     pub(super) returns: Vec<Return>,
+    pub(super) externals: &'a Externals<'a>,
 }
 
-#[derive(Clone, Copy)]
-pub struct ReefTypes<'a> {
-    pub context: &'a TypeContext,
-    pub engine: &'a TypedEngine,
-    pub typing: &'a Typing,
+#[derive(Debug, Clone, Copy)]
+pub(super) struct Links<'a> {
+    pub(super) source: SourceId,
+    pub(super) engine: &'a Engine<'a>,
+    pub(super) relations: &'a Relations,
 }
 
-/// A proxy that let the user access to any reef's engine, relations and types data.
-/// If the given reef identifier is the `current_reef`, the types data stored in `current` is returned instead
-/// of the data stored by the `reefs`.
-#[derive(Clone, Copy)]
-pub struct UniversalReefAccessor<'a, 'e> {
-    reefs: &'a Reefs<'e>,
-    current_reef: ReefId,
-    current: ReefTypes<'e>,
-}
-
-impl<'a, 'e> UniversalReefAccessor<'a, 'e> {
-    pub fn get_types(&self, id: ReefId) -> Option<ReefTypes<'a>> {
-        if id == self.current_reef {
-            Some(self.current)
-        } else {
-            self.reefs.get_reef(id).map(|reef| ReefTypes {
-                context: &reef.type_context,
-                engine: &reef.typed_engine,
-                typing: &reef.typing,
-            })
-        }
+impl<'a> Links<'a> {
+    pub(super) fn env(self) -> &'a Environment {
+        self.engine.get_environment(self.source).unwrap()
     }
 
-    pub fn get_engine(&self, id: ReefId) -> Option<&'a Engine<'e>> {
-        self.reefs.get_reef(id).map(|r| &r.engine)
-    }
-
-    pub fn get_relations(&self, id: ReefId) -> Option<&'a Relations> {
-        self.reefs.get_reef(id).map(|r| &r.relations)
+    pub(super) fn with_source(self, source: SourceId) -> Self {
+        Self { source, ..self }
     }
 }
 
-impl Exploration {
+impl Exploration<'_> {
     pub(super) fn prepare(&mut self) {
         self.returns.clear();
     }
 
-    /// returns an universal accessor that will return the exploration's types data
-    /// if the accessed reef's identifier is equal to given `current_reef`
-    pub(crate) fn universal_accessor<'a, 'e>(
-        &'e self,
-        current_reef: ReefId,
-        reefs: &'a Reefs<'e>,
-    ) -> UniversalReefAccessor<'a, 'e> {
-        UniversalReefAccessor {
-            reefs,
-            current_reef,
-            current: ReefTypes {
-                context: &self.ctx,
-                engine: &self.type_engine,
-                typing: &self.typing,
-            },
+    pub(super) fn get_type(&self, id: TypeRef) -> Option<&Type> {
+        let typing = if id.reef == self.externals.current {
+            &self.typing
+        } else {
+            &self.get_external_type_reef(id.reef).typing
+        };
+        typing.get_type(id.type_id)
+    }
+
+    pub(super) fn get_method_exact(
+        &self,
+        id: TypeRef,
+        name: &str,
+        params: &[TypeRef],
+        return_ty: TypeRef,
+    ) -> Option<&MethodType> {
+        let typed_engine = if id.reef == self.externals.current {
+            &self.type_engine
+        } else {
+            &self.get_external_type_reef(id.reef).typed_engine
+        };
+        typed_engine.get_method_exact(id.type_id, name, params, return_ty)
+    }
+
+    pub(super) fn get_var(
+        &self,
+        source: SourceId, /* FIXME */
+        symbol: SymbolRef,
+        relations: &Relations,
+    ) -> Option<TypedVariable> {
+        let reef_id = match symbol {
+            SymbolRef::Local(_) => return self.ctx.get(relations, source, symbol),
+            SymbolRef::External(ext) => {
+                let call_symbol = relations[ext]
+                    .state
+                    .expect_resolved("Unresolved symbol during typechecking");
+                call_symbol.reef
+            }
+        };
+        let ctx = if reef_id == self.externals.current {
+            &self.ctx
+        } else {
+            &self
+                .externals
+                .get_reef(reef_id)
+                .expect("Unknown external reef found on symbol")
+                .type_context
+        };
+        ctx.get(relations, source, symbol)
+    }
+
+    pub(super) fn get_methods(&self, id: TypeRef, name: &str) -> Option<&Vec<MethodType>> {
+        let typed_engine = if id.reef == self.externals.current {
+            &self.type_engine
+        } else {
+            &self.get_external_type_reef(id.reef).typed_engine
+        };
+        typed_engine.get_methods(id.type_id, name)
+    }
+
+    pub(super) fn get_external_env<'a>(
+        &'a self,
+        from_env: &'a Environment,
+        to_symbol: ResolvedSymbol,
+    ) -> Option<&'a Environment> {
+        if to_symbol.reef == self.externals.current {
+            Some(from_env)
+        } else {
+            self.externals
+                .get_reef(to_symbol.reef)
+                .unwrap()
+                .engine
+                .get_environment(to_symbol.source)
         }
+    }
+
+    pub(super) fn get_types(&self, reef: ReefId) -> Option<&Typing> {
+        if reef == self.externals.current {
+            Some(&self.typing)
+        } else {
+            self.externals.get_reef(reef).map(|r| &r.typing)
+        }
+    }
+
+    pub(super) fn get_entry(&self, reef: ReefId, definition: Definition) -> Option<CodeEntry> {
+        if reef == self.externals.current {
+            self.type_engine.get(definition)
+        } else {
+            self.get_external_type_reef(reef)
+                .typed_engine
+                .get(definition)
+        }
+    }
+
+    fn get_external_type_reef(&self, id: ReefId) -> &Reef {
+        self.externals
+            .get_reef(id)
+            .expect("Unknown external reef found on type")
     }
 }

--- a/analyzer/src/types.rs
+++ b/analyzer/src/types.rs
@@ -1,9 +1,13 @@
+use crate::environment::symbols::SymbolInfo;
+use crate::reef::{ReefId, LANG_REEF};
+use crate::relations::{SourceId, SymbolRef};
+use crate::steps::typing::exploration::UniversalReefAccessor;
+use crate::types::ty::{Type, TypeId, TypeRef};
+use ast::r#use::InclusionPathItem;
+use context::source::SourceSegmentHolder;
 use std::collections::HashMap;
 
-use crate::types::hir::TypeId;
-use crate::types::ty::Type;
-
-mod builtin;
+pub(crate) mod builtin;
 pub mod ctx;
 pub mod engine;
 pub mod hir;
@@ -17,78 +21,13 @@ pub struct Typing {
     types: Vec<Type>,
 
     /// A list of implicit conversions from one type to another.
-    implicits: HashMap<TypeId, TypeId>,
+    implicits: HashMap<TypeId, TypeRef>,
 }
 
 impl Typing {
-    /// Constructs a new typing context that already contains the built-in types.
-    pub fn with_lang() -> Self {
-        Self {
-            types: vec![
-                Type::Error,
-                Type::Nothing,
-                Type::Unit,
-                Type::Bool,
-                Type::ExitCode,
-                Type::Int,
-                Type::Float,
-                Type::String,
-            ],
-            implicits: HashMap::from([(EXIT_CODE, BOOL), (INT, FLOAT)]),
-        }
+    pub(crate) fn set_implicit_conversion(&mut self, from: TypeId, to: TypeRef) {
+        self.implicits.insert(from, to);
     }
-
-    /// Unifies two type identifiers, returning the type that the right hand side was unified to.
-    ///
-    /// Unification is successful when the assignation type is a superset of the rvalue type, i.e
-    /// when the assignation type is a parent conceptually or technically of the rvalue type.
-    /// It is not reflexive, i.e. `unify(a, b)` is not the same as `unify(b, a)`.
-    ///
-    /// A conversion may be not as simple as a reinterpretation of the value, and may require
-    /// a conversion function to be called. Use [`crate::steps::typing::convert_expression`] to
-    /// generate the conversion code for a typed expression.
-    pub(crate) fn convert_description(
-        &mut self,
-        assign_to: TypeId,
-        rvalue: TypeId,
-    ) -> Result<TypeId, UnificationError> {
-        if assign_to.is_err() || rvalue.is_err() {
-            return Ok(assign_to); // An error is compatible with everything, as it is a placeholder.
-        }
-        let lhs = &self.types[assign_to.0];
-        let rhs = &self.types[rvalue.0];
-        if lhs == rhs {
-            return Ok(assign_to);
-        }
-
-        // apply the `A U Nothing => A` rule
-        if *rhs == Type::Nothing {
-            return Ok(assign_to);
-        }
-
-        if let Some(implicit) = self.implicits.get(&rvalue) {
-            if lhs == &self.types[implicit.0] {
-                return Ok(assign_to);
-            }
-        }
-        Err(UnificationError())
-    }
-
-    /// Unifies multiple type identifiers in any direction.
-    pub fn convert_many<I: IntoIterator<Item = TypeId>>(
-        &mut self,
-        types: I,
-    ) -> Result<TypeId, UnificationError> {
-        let mut types = types
-            .into_iter()
-            .filter(|ty| ty.is_ok() && !ty.is_nothing());
-        let first = types.next().unwrap_or(NOTHING);
-        types.try_fold(first, |acc, ty| {
-            self.convert_description(acc, ty)
-                .or_else(|_| self.convert_description(ty, acc))
-        })
-    }
-
     pub(crate) fn add_type(&mut self, ty: Type) -> TypeId {
         let type_id = TypeId(self.types.len());
         self.types.push(ty);
@@ -100,14 +39,142 @@ impl Typing {
     }
 }
 
-pub const ERROR: TypeId = TypeId(0);
-pub const NOTHING: TypeId = TypeId(1);
-pub const UNIT: TypeId = TypeId(2);
-pub const BOOL: TypeId = TypeId(3);
-pub const EXIT_CODE: TypeId = TypeId(4);
-pub const INT: TypeId = TypeId(5);
-pub const FLOAT: TypeId = TypeId(6);
-pub const STRING: TypeId = TypeId(7);
+pub const ERROR: TypeRef = TypeRef::new(LANG_REEF, TypeId(0));
+pub const NOTHING: TypeRef = TypeRef::new(LANG_REEF, TypeId(1));
+pub const UNIT: TypeRef = TypeRef::new(LANG_REEF, TypeId(2));
+pub const BOOL: TypeRef = TypeRef::new(LANG_REEF, TypeId(3));
+pub const EXIT_CODE: TypeRef = TypeRef::new(LANG_REEF, TypeId(4));
+pub const INT: TypeRef = TypeRef::new(LANG_REEF, TypeId(5));
+pub const FLOAT: TypeRef = TypeRef::new(LANG_REEF, TypeId(6));
+pub const STRING: TypeRef = TypeRef::new(LANG_REEF, TypeId(7));
+
+/// Unifies two type identifiers, returning the type that the right hand side was unified to.
+///
+/// Unification is successful when the assignation type is a superset of the rvalue type, i.e
+/// when the assignation type is a parent conceptually or technically of the rvalue type.
+/// It is not reflexive, i.e. `unify(a, b)` is not the same as `unify(b, a)`.
+///
+/// A conversion may be not as simple as a reinterpretation of the value, and may require
+/// a conversion function to be called. Use [`crate::steps::typing::convert_expression`] to
+/// generate the conversion code for a typed expression.
+pub fn convert_description(
+    reefs: &UniversalReefAccessor,
+    assign_to: TypeRef,
+    rvalue: TypeRef,
+) -> Result<TypeRef, UnificationError> {
+    if assign_to.is_err() || rvalue.is_err() {
+        // An error is compatible with everything, as it is a placeholder.
+        return Ok(assign_to);
+    }
+
+    if rvalue == assign_to {
+        // if both references are the same then no need to lookup, it's the same type
+        return Ok(assign_to);
+    }
+
+    let lhs =
+        get_type(assign_to, reefs).unwrap_or_else(|| panic!("cannot find type {assign_to:?}`"));
+    let rhs = get_type(rvalue, reefs).unwrap_or_else(|| panic!("cannot find type {rvalue:?}`"));
+    if lhs == rhs {
+        return Ok(assign_to);
+    }
+
+    // apply the `A U Nothing => A` rule
+    if *rhs == Type::Nothing {
+        return Ok(assign_to);
+    }
+
+    let rvalue_typing = reefs.get_types(rvalue.reef).unwrap().typing;
+
+    if let Some(implicit) = rvalue_typing.implicits.get(&rvalue.type_id) {
+        let implicit =
+            get_type(*implicit, reefs).unwrap_or_else(|| panic!("cannot find type {implicit:?}`"));
+        if lhs == implicit {
+            return Ok(assign_to);
+        }
+    }
+    Err(UnificationError())
+}
+
+/// Unifies multiple type identifiers in any direction.
+pub fn convert_many<I: IntoIterator<Item = TypeRef>>(
+    reefs: &UniversalReefAccessor,
+    types: I,
+) -> Result<TypeRef, UnificationError> {
+    let mut types = types
+        .into_iter()
+        .filter(|ty| ty.is_ok() && !ty.is_nothing());
+
+    let first = types.next().unwrap_or(NOTHING);
+    types.try_fold(first, |acc, ty| {
+        convert_description(reefs, acc, ty).or_else(|_| convert_description(reefs, ty, acc))
+    })
+}
+
+pub fn get_type<'a>(type_ref: TypeRef, ura: &'a UniversalReefAccessor) -> Option<&'a Type> {
+    ura.get_types(type_ref.reef)
+        .and_then(|types| types.typing.get_type(type_ref.type_id))
+}
+
+/// Finds the type reference from an annotation.
+pub(crate) fn resolve_type(
+    reefs: &UniversalReefAccessor,
+    reef_id: ReefId,
+    env_id: SourceId,
+    type_annotation: &ast::r#type::Type,
+) -> TypeRef {
+    match type_annotation {
+        ast::r#type::Type::Parametrized(param) => {
+            if param.path.len() > 1 || !param.params.is_empty() {
+                unimplemented!();
+            }
+            if let InclusionPathItem::Symbol(_, _) = param
+                .path
+                .first()
+                .expect("Type annotation should not be empty")
+            {
+                let engine = reefs.get_engine(reef_id).unwrap();
+                let relations = reefs.get_relations(reef_id).unwrap();
+
+                let env = engine.get_environment(env_id).unwrap();
+                let type_symbol_ref = env.get_raw_symbol(type_annotation.segment()).unwrap();
+                let type_symbol = match type_symbol_ref {
+                    SymbolRef::Local(l) => env.symbols.get(l).unwrap(),
+                    SymbolRef::External(r) => {
+                        let resolved_symbol = relations[r]
+                            .state
+                            .expect_resolved("unresolved type symbol during typechecking");
+
+                        if resolved_symbol.reef == LANG_REEF {
+                            let primitive_id = TypeId(resolved_symbol.object_id.0);
+                            return TypeRef::new(LANG_REEF, primitive_id);
+                        }
+
+                        let type_env = reefs
+                            .get_engine(resolved_symbol.reef)
+                            .unwrap()
+                            .get_environment(resolved_symbol.source)
+                            .unwrap();
+                        type_env.symbols.get(resolved_symbol.object_id).unwrap()
+                    }
+                };
+
+                if let SymbolInfo::Type(type_ref) = type_symbol.ty {
+                    type_ref
+                } else {
+                    panic!(
+                        "type {type_annotation} refers to a {} symbol ",
+                        type_symbol.ty
+                    )
+                }
+            } else {
+                unimplemented!("type's path cannot start with `reef` yet")
+            }
+        }
+        ast::r#type::Type::Callable(_) => unimplemented!(),
+        ast::r#type::Type::ByName(_) => unimplemented!(),
+    }
+}
 
 /// An error that occurs when two types are not compatible.
 #[derive(Debug, PartialEq)]

--- a/analyzer/src/types.rs
+++ b/analyzer/src/types.rs
@@ -1,11 +1,6 @@
 use std::collections::HashMap;
 
-use context::source::SourceSegmentHolder;
-
-use crate::environment::symbols::SymbolInfo;
-use crate::reef::{LANG_REEF, ReefId};
-use crate::relations::{SourceId, SymbolRef};
-use crate::steps::typing::exploration::UniversalReefAccessor;
+use crate::reef::LANG_REEF;
 use crate::types::ty::{Type, TypeId, TypeRef};
 
 pub(crate) mod builtin;
@@ -16,13 +11,13 @@ pub mod operator;
 pub mod ty;
 
 /// Holds all the known types.
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Typing {
     /// The actual types.
     types: Vec<Type>,
 
     /// A list of implicit conversions from one type to another.
-    implicits: HashMap<TypeId, TypeRef>,
+    pub(crate) implicits: HashMap<TypeId, TypeRef>,
 }
 
 impl Typing {
@@ -48,125 +43,6 @@ pub const EXITCODE: TypeRef = TypeRef::new(LANG_REEF, TypeId(4));
 pub const INT: TypeRef = TypeRef::new(LANG_REEF, TypeId(5));
 pub const FLOAT: TypeRef = TypeRef::new(LANG_REEF, TypeId(6));
 pub const STRING: TypeRef = TypeRef::new(LANG_REEF, TypeId(7));
-
-/// Unifies two type identifiers, returning the type that the right hand side was unified to.
-///
-/// Unification is successful when the assignation type is a superset of the rvalue type, i.e
-/// when the assignation type is a parent conceptually or technically of the rvalue type.
-/// It is not reflexive, i.e. `unify(a, b)` is not the same as `unify(b, a)`.
-///
-/// A conversion may be not as simple as a reinterpretation of the value, and may require
-/// a conversion function to be called. Use [`crate::steps::typing::convert_expression`] to
-/// generate the conversion code for a typed expression.
-pub fn convert_description(
-    ura: &UniversalReefAccessor,
-    assign_to: TypeRef,
-    rvalue: TypeRef,
-) -> Result<TypeRef, UnificationError> {
-    if assign_to.is_err() || rvalue.is_err() {
-        // An error is compatible with everything, as it is a placeholder.
-        return Ok(assign_to);
-    }
-
-    if rvalue == assign_to {
-        // if both references are the same then no need to lookup, it's the same type
-        return Ok(assign_to);
-    }
-
-    let lhs = get_type(assign_to, ura).unwrap_or_else(|| panic!("cannot find type {assign_to:?}`"));
-    let rhs = get_type(rvalue, ura).unwrap_or_else(|| panic!("cannot find type {rvalue:?}`"));
-    if lhs == rhs {
-        return Ok(assign_to);
-    }
-
-    // apply the `A U Nothing => A` rule
-    if *rhs == Type::Nothing {
-        return Ok(assign_to);
-    }
-
-    let rvalue_typing = ura.get_types(rvalue.reef).unwrap().typing;
-
-    if let Some(implicit) = rvalue_typing.implicits.get(&rvalue.type_id) {
-        let implicit =
-            get_type(*implicit, ura).unwrap_or_else(|| panic!("cannot find type {implicit:?}`"));
-        if lhs == implicit {
-            return Ok(assign_to);
-        }
-    }
-    Err(UnificationError())
-}
-
-/// Unifies multiple type identifiers in any direction.
-pub fn convert_many<I: IntoIterator<Item = TypeRef>>(
-    ura: &UniversalReefAccessor,
-    types: I,
-) -> Result<TypeRef, UnificationError> {
-    let mut types = types
-        .into_iter()
-        .filter(|ty| ty.is_ok() && !ty.is_nothing());
-
-    let first = types.next().unwrap_or(NOTHING);
-    types.try_fold(first, |acc, ty| {
-        convert_description(ura, acc, ty).or_else(|_| convert_description(ura, ty, acc))
-    })
-}
-
-pub fn get_type<'a>(type_ref: TypeRef, ura: &'a UniversalReefAccessor) -> Option<&'a Type> {
-    ura.get_types(type_ref.reef)
-        .and_then(|types| types.typing.get_type(type_ref.type_id))
-}
-
-/// Finds the type reference from an annotation.
-pub(crate) fn resolve_type(
-    ura: &UniversalReefAccessor,
-    reef_id: ReefId,
-    env_id: SourceId,
-    type_annotation: &ast::r#type::Type,
-) -> TypeRef {
-    match type_annotation {
-        ast::r#type::Type::Parametrized(param) => {
-            if !param.params.is_empty() {
-                unimplemented!();
-            }
-            let engine = ura.get_engine(reef_id).unwrap();
-            let relations = ura.get_relations(reef_id).unwrap();
-
-            let env = engine.get_environment(env_id).unwrap();
-            let type_symbol_ref = env.get_raw_symbol(type_annotation.segment()).unwrap();
-            let type_symbol = match type_symbol_ref {
-                SymbolRef::Local(l) => env.symbols.get(l).unwrap(),
-                SymbolRef::External(r) => {
-                    let resolved_symbol = relations[r]
-                        .state
-                        .expect_resolved("unresolved type symbol during typechecking");
-
-                    if resolved_symbol.reef == LANG_REEF {
-                        let primitive_id = TypeId(resolved_symbol.object_id.0);
-                        return TypeRef::new(LANG_REEF, primitive_id);
-                    }
-
-                    let type_env = ura
-                        .get_engine(resolved_symbol.reef)
-                        .unwrap()
-                        .get_environment(resolved_symbol.source)
-                        .unwrap();
-                    type_env.symbols.get(resolved_symbol.object_id).unwrap()
-                }
-            };
-
-            if let SymbolInfo::Type(type_ref) = type_symbol.ty {
-                type_ref
-            } else {
-                panic!(
-                    "type {type_annotation} refers to a {} symbol ",
-                    type_symbol.ty
-                )
-            }
-        }
-        ast::r#type::Type::Callable(_) => unimplemented!(),
-        ast::r#type::Type::ByName(_) => unimplemented!(),
-    }
-}
 
 /// An error that occurs when two types are not compatible.
 #[derive(Debug, PartialEq)]

--- a/analyzer/src/types/builtin.rs
+++ b/analyzer/src/types/builtin.rs
@@ -1,10 +1,13 @@
 use ast::operation::BinaryOperator;
 
-use crate::relations::NativeId;
+use crate::engine::Engine;
+use crate::reef::Reef;
+use crate::relations::{NativeId, Relations};
+use crate::types::ctx::TypeContext;
 use crate::types::engine::TypedEngine;
 use crate::types::operator::name_operator_method;
-use crate::types::ty::MethodType;
-use crate::types::{BOOL, EXIT_CODE, FLOAT, INT, STRING};
+use crate::types::ty::{MethodType, Type};
+use crate::types::{Typing, BOOL, EXIT_CODE, FLOAT, INT, NOTHING, STRING, UNIT};
 
 const ARITHMETIC_OPERATORS: &[BinaryOperator] = &[
     BinaryOperator::Plus,
@@ -37,35 +40,39 @@ impl VariableGenerator {
 }
 
 /// Adds the native methods to the engine.
-pub fn lang(engine: &mut TypedEngine) {
+fn fill_lang_typed_engine(engine: &mut TypedEngine) {
     let mut gen = VariableGenerator::default();
     engine.add_method(
-        EXIT_CODE,
+        EXIT_CODE.type_id,
         "to_bool",
         MethodType::native(vec![], BOOL, gen.next()),
     );
     for op in ARITHMETIC_OPERATORS {
         engine.add_method(
-            INT,
+            INT.type_id,
             name_operator_method(*op),
             MethodType::native(vec![INT], INT, gen.next()),
         );
         engine.add_method(
-            FLOAT,
+            FLOAT.type_id,
             name_operator_method(*op),
             MethodType::native(vec![FLOAT], FLOAT, gen.next()),
         );
     }
     engine.add_method(
-        INT,
+        INT.type_id,
         name_operator_method(BinaryOperator::Modulo),
         MethodType::native(vec![INT], INT, gen.next()),
     );
-    engine.add_method(BOOL, "not", MethodType::native(vec![], BOOL, gen.next()));
+    engine.add_method(
+        BOOL.type_id,
+        "not",
+        MethodType::native(vec![], BOOL, gen.next()),
+    );
     for ty in [BOOL, STRING] {
         for op in EQUALITY_OPERATORS {
             engine.add_method(
-                ty,
+                ty.type_id,
                 name_operator_method(*op),
                 MethodType::native(vec![ty], BOOL, gen.next()),
             );
@@ -74,7 +81,7 @@ pub fn lang(engine: &mut TypedEngine) {
     for ty in [INT, FLOAT] {
         for op in COMPARISON_OPERATORS {
             engine.add_method(
-                ty,
+                ty.type_id,
                 name_operator_method(*op),
                 MethodType::native(vec![ty], BOOL, gen.next()),
             );
@@ -82,20 +89,68 @@ pub fn lang(engine: &mut TypedEngine) {
     }
     for stringify in [BOOL, EXIT_CODE, INT, FLOAT] {
         engine.add_method(
-            stringify,
+            stringify.type_id,
             "to_string",
             MethodType::native(vec![], STRING, gen.next()),
         );
     }
     engine.add_method(
-        INT,
+        INT.type_id,
         "to_float",
         MethodType::native(vec![], FLOAT, gen.next()),
     );
-    engine.add_method(STRING, "len", MethodType::native(vec![], INT, gen.next()));
     engine.add_method(
-        STRING,
+        STRING.type_id,
+        "len",
+        MethodType::native(vec![], INT, gen.next()),
+    );
+    engine.add_method(
+        STRING.type_id,
         name_operator_method(BinaryOperator::Plus),
         MethodType::native(vec![STRING], STRING, gen.next()),
     );
+}
+
+fn fill_lang_types(typing: &mut Typing) {
+    for primitive in [
+        Type::Error,
+        Type::Nothing,
+        Type::Unit,
+        Type::Bool,
+        Type::ExitCode,
+        Type::Int,
+        Type::Float,
+        Type::String,
+    ] {
+        typing.add_type(primitive);
+    }
+    typing.set_implicit_conversion(EXIT_CODE.type_id, BOOL);
+    typing.set_implicit_conversion(INT.type_id, FLOAT);
+}
+
+fn fill_lang_bindings(ctx: &mut TypeContext) {
+    ctx.bind_name("Nothing".to_string(), NOTHING.type_id);
+    ctx.bind_name("Unit".to_string(), UNIT.type_id);
+    ctx.bind_name("Bool".to_string(), BOOL.type_id);
+    ctx.bind_name("Exitcode".to_string(), EXIT_CODE.type_id);
+    ctx.bind_name("Int".to_string(), INT.type_id);
+    ctx.bind_name("Float".to_string(), FLOAT.type_id);
+    ctx.bind_name("String".to_string(), STRING.type_id);
+}
+
+pub fn lang_reef() -> Reef<'static> {
+    let mut reef = Reef {
+        name: "lang".to_string(),
+        engine: Engine::default(),
+        relations: Relations::default(),
+        typed_engine: TypedEngine::default(),
+        typing: Typing::default(),
+        type_context: TypeContext::default(),
+    };
+
+    fill_lang_types(&mut reef.typing);
+    fill_lang_bindings(&mut reef.type_context);
+    fill_lang_typed_engine(&mut reef.typed_engine);
+
+    reef
 }

--- a/analyzer/src/types/builtin.rs
+++ b/analyzer/src/types/builtin.rs
@@ -7,7 +7,7 @@ use crate::types::ctx::TypeContext;
 use crate::types::engine::TypedEngine;
 use crate::types::operator::name_operator_method;
 use crate::types::ty::{MethodType, Type};
-use crate::types::{Typing, BOOL, EXIT_CODE, FLOAT, INT, NOTHING, STRING, UNIT};
+use crate::types::{Typing, BOOL, EXITCODE, FLOAT, INT, NOTHING, STRING, UNIT};
 
 const ARITHMETIC_OPERATORS: &[BinaryOperator] = &[
     BinaryOperator::Plus,
@@ -43,7 +43,7 @@ impl VariableGenerator {
 fn fill_lang_typed_engine(engine: &mut TypedEngine) {
     let mut gen = VariableGenerator::default();
     engine.add_method(
-        EXIT_CODE.type_id,
+        EXITCODE.type_id,
         "to_bool",
         MethodType::native(vec![], BOOL, gen.next()),
     );
@@ -87,7 +87,7 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine) {
             );
         }
     }
-    for stringify in [BOOL, EXIT_CODE, INT, FLOAT] {
+    for stringify in [BOOL, EXITCODE, INT, FLOAT] {
         engine.add_method(
             stringify.type_id,
             "to_string",
@@ -124,7 +124,7 @@ fn fill_lang_types(typing: &mut Typing) {
     ] {
         typing.add_type(primitive);
     }
-    typing.set_implicit_conversion(EXIT_CODE.type_id, BOOL);
+    typing.set_implicit_conversion(EXITCODE.type_id, BOOL);
     typing.set_implicit_conversion(INT.type_id, FLOAT);
 }
 
@@ -132,7 +132,7 @@ fn fill_lang_bindings(ctx: &mut TypeContext) {
     ctx.bind_name("Nothing".to_string(), NOTHING.type_id);
     ctx.bind_name("Unit".to_string(), UNIT.type_id);
     ctx.bind_name("Bool".to_string(), BOOL.type_id);
-    ctx.bind_name("Exitcode".to_string(), EXIT_CODE.type_id);
+    ctx.bind_name("Exitcode".to_string(), EXITCODE.type_id);
     ctx.bind_name("Int".to_string(), INT.type_id);
     ctx.bind_name("Float".to_string(), FLOAT.type_id);
     ctx.bind_name("String".to_string(), STRING.type_id);

--- a/analyzer/src/types/ctx.rs
+++ b/analyzer/src/types/ctx.rs
@@ -8,6 +8,7 @@ use crate::types::{BOOL, EXIT_CODE, FLOAT, INT, NOTHING, STRING, UNIT};
 /// Holds the symbol to type mapping.
 ///
 /// The actual type definition is in the [`crate::types::Typing`] struct.
+#[derive(Default)]
 pub struct TypeContext {
     names: HashMap<String, TypeId>,
     locals: HashMap<SourceId, Vec<TypedVariable>>,

--- a/analyzer/src/types/ctx.rs
+++ b/analyzer/src/types/ctx.rs
@@ -55,7 +55,7 @@ impl TypeContext {
         self.names.insert(name, tpe);
     }
 
-    pub fn get_type(&self, name: &str) -> Option<TypeId> {
+    pub fn get_type_id(&self, name: &str) -> Option<TypeId> {
         self.names.get(name).copied()
     }
 }

--- a/analyzer/src/types/ctx.rs
+++ b/analyzer/src/types/ctx.rs
@@ -1,9 +1,7 @@
-use ast::r#use::InclusionPathItem;
 use std::collections::HashMap;
 
-use crate::relations::{LocalId, Relations, SourceId, Symbol};
-use crate::types::hir::TypeId;
-use crate::types::{BOOL, EXIT_CODE, FLOAT, INT, NOTHING, STRING, UNIT};
+use crate::relations::{LocalId, Relations, SourceId, SymbolRef};
+use crate::types::ty::{TypeId, TypeRef};
 
 /// Holds the symbol to type mapping.
 ///
@@ -15,32 +13,17 @@ pub struct TypeContext {
 }
 
 impl TypeContext {
-    /// Constructs a new typing context that already contains the built-in type names.
-    pub(crate) fn with_lang() -> Self {
-        Self {
-            names: HashMap::from([
-                ("Nothing".to_owned(), NOTHING),
-                ("Bool".to_owned(), BOOL),
-                ("ExitCode".to_owned(), EXIT_CODE),
-                ("Unit".to_owned(), UNIT),
-                ("Int".to_owned(), INT),
-                ("Float".to_owned(), FLOAT),
-                ("String".to_owned(), STRING),
-            ]),
-            locals: HashMap::new(),
-        }
-    }
-
     /// Returns the type id of a symbol.
     pub(crate) fn get(
         &self,
         relations: &Relations,
         source: SourceId,
-        symbol: Symbol,
+        symbol: SymbolRef,
     ) -> Option<TypedVariable> {
         match symbol {
-            Symbol::Local(index) => self.locals.get(&source).unwrap().get(index.0).copied(),
-            Symbol::External(index) => {
+            SymbolRef::Local(index) => self.locals.get(&source).unwrap().get(index.0).copied(),
+
+            SymbolRef::External(index) => {
                 let resolved = relations[index].state.expect_resolved("Unresolved symbol");
                 self.locals
                     .get(&resolved.source)
@@ -54,8 +37,8 @@ impl TypeContext {
     /// Defines the type of a currently explored symbol.
     ///
     /// This must be in sync with the symbol in the environment.
-    pub(crate) fn push_local_type(&mut self, source: SourceId, type_id: TypeId) -> LocalId {
-        self.push_local(source, TypedVariable::immutable(type_id))
+    pub(crate) fn push_local_typed(&mut self, source: SourceId, type_ref: TypeRef) -> LocalId {
+        self.push_local(source, TypedVariable::immutable(type_ref))
     }
 
     /// Defines the identity of a currently explored symbol.
@@ -68,26 +51,12 @@ impl TypeContext {
         LocalId(index)
     }
 
-    /// Finds the type from an annotation.
-    pub(crate) fn resolve(&self, type_annotation: &ast::r#type::Type) -> Option<TypeId> {
-        match type_annotation {
-            ast::r#type::Type::Parametrized(param) => {
-                if param.path.len() > 1 || !param.params.is_empty() {
-                    unimplemented!();
-                }
-                if let InclusionPathItem::Symbol(sym, _) = param
-                    .path
-                    .first()
-                    .expect("Type annotation should not be empty")
-                {
-                    self.names.get(*sym).copied()
-                } else {
-                    unimplemented!("type's path cannot start with `reef` yet")
-                }
-            }
-            ast::r#type::Type::Callable(_) => unimplemented!(),
-            ast::r#type::Type::ByName(_) => unimplemented!(),
-        }
+    pub(crate) fn bind_name(&mut self, name: String, tpe: TypeId) {
+        self.names.insert(name, tpe);
+    }
+
+    pub fn get_type(&self, name: &str) -> Option<TypeId> {
+        self.names.get(name).copied()
     }
 }
 
@@ -97,23 +66,23 @@ impl TypeContext {
 /// but it also holds if the variable can be reassigned.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct TypedVariable {
-    pub(crate) type_id: TypeId,
+    pub(crate) type_ref: TypeRef,
     pub(crate) can_reassign: bool,
 }
 
 impl TypedVariable {
     /// Constructs a new mutable variable identity.
-    pub(crate) fn assignable(type_id: TypeId) -> Self {
+    pub(crate) fn assignable(type_ref: TypeRef) -> Self {
         Self {
-            type_id,
+            type_ref,
             can_reassign: true,
         }
     }
 
     /// Constructs a new immutable variable identity.
-    pub(crate) fn immutable(type_id: TypeId) -> Self {
+    pub(crate) fn immutable(type_ref: TypeRef) -> Self {
         Self {
-            type_id,
+            type_ref,
             can_reassign: false,
         }
     }

--- a/analyzer/src/types/hir.rs
+++ b/analyzer/src/types/hir.rs
@@ -2,12 +2,8 @@ use ast::call::{RedirFd, RedirOp};
 use ast::value::LiteralValue;
 use context::source::{SourceSegment, SourceSegmentHolder};
 
-use crate::relations::{Definition, LocalId, ObjectId, ResolvedSymbol};
-use crate::types::{ERROR, NOTHING};
-
-/// A type identifier in a [`Typing`] instance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct TypeId(pub ObjectId);
+use crate::relations::{Definition, LocalId, ResolvedSymbol};
+use crate::types::ty::TypeRef;
 
 #[derive(Clone, Copy, Debug, PartialEq, Hash, Eq)]
 pub enum Var {
@@ -15,29 +11,11 @@ pub enum Var {
     External(ResolvedSymbol),
 }
 
-impl TypeId {
-    pub fn is_nothing(self) -> bool {
-        self == NOTHING
-    }
-
-    pub fn is_something(self) -> bool {
-        self != NOTHING
-    }
-
-    pub fn is_ok(self) -> bool {
-        self != ERROR
-    }
-
-    pub fn is_err(self) -> bool {
-        self == ERROR
-    }
-}
-
 /// A type checked expression attached to a source segment.
 #[derive(Clone, Debug, PartialEq)]
 pub struct TypedExpr {
     pub kind: ExprKind,
-    pub ty: TypeId,
+    pub ty: TypeRef,
     pub segment: SourceSegment,
 }
 
@@ -69,7 +47,7 @@ pub struct Conditional {
 #[derive(Clone, Debug, PartialEq)]
 pub struct Convert {
     pub inner: Box<TypedExpr>,
-    pub into: TypeId,
+    pub into: TypeRef,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/analyzer/tests/collect_debug.rs
+++ b/analyzer/tests/collect_debug.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use pretty_assertions::assert_eq;
+use analyzer::analyze;
 
 use analyzer::environment::symbols::{Symbol, SymbolLocation, SymbolRegistry};
 use analyzer::importer::StaticImporter;
@@ -31,15 +32,19 @@ fn collect_sample() {
         [
             (root_name.clone(), source),
             (
-                lib_name,
-                Source::new("val LOG_FILE = 'debug.log'; val n", "lib"),
+                lib_name.clone(),
+                Source::new("val LOG_FILE = 'debug.log'; val n = 1", "lib"),
             ),
         ],
         parse_trusted,
     );
 
     let mut reefs = Reefs::default();
-    let mut context = ReefContext::declare_new(&mut reefs, "test");
+    // define the lib reef
+    let lib_context = ReefContext::declare_new(&mut reefs, "test");
+    analyze(lib_name, &mut importer, lib_context);
+
+    let mut context = ReefContext::declare_new(&mut reefs, "lib");
 
     let diagnostics = SymbolCollector::collect_symbols(
         &mut imports,
@@ -49,6 +54,7 @@ fn collect_sample() {
         &mut importer,
     );
     assert_eq!(diagnostics, vec![]);
+
     let diagnostics =
         SymbolResolver::resolve_symbols(&mut imports, &mut context, &mut to_visit, &mut visited);
     assert_eq!(diagnostics, vec![]);

--- a/analyzer/tests/collect_debug.rs
+++ b/analyzer/tests/collect_debug.rs
@@ -80,7 +80,7 @@ fn collect_sample() {
             Symbol::scoped("i".to_owned(), -2),
         ]
     );
-    let exported = factorial_env.symbols.exported_vars().collect::<Vec<_>>();
+    let exported = factorial_env.symbols.exported_symbols().collect::<Vec<_>>();
     assert_eq!(exported, vec![]);
 
     let n_parameter = factorial_env
@@ -107,7 +107,7 @@ fn collect_sample() {
         .get_environment(SourceId(2))
         .expect("Unable to get debug() environment");
     assert_eq!(debug_env.fqn, root_name.child("debug"));
-    let usages = debug_env.symbols.external_vars().collect::<Vec<_>>();
+    let usages = debug_env.symbols.external_symbols().collect::<Vec<_>>();
     assert_eq!(
         usages,
         vec![(
@@ -133,7 +133,7 @@ fn collect_sample() {
         .expect("Unable to get callback environment");
     assert_eq!(callback_env.fqn, root_name.child("main").child("callback"));
 
-    let mut globals = callback_env.symbols.external_vars().collect::<Vec<_>>();
+    let mut globals = callback_env.symbols.external_symbols().collect::<Vec<_>>();
     globals.sort_by_key(|(loc, _)| &loc.name);
     assert_eq!(
         globals,
@@ -194,7 +194,7 @@ fn collect_sample() {
         .get_environment(SourceId(5))
         .expect("Unable to get lambda environment");
 
-    let variables = lambda_env.symbols.external_vars().collect::<Vec<_>>();
+    let variables = lambda_env.symbols.external_symbols().collect::<Vec<_>>();
     assert_eq!(
         variables,
         vec![(&SymbolLocation::unspecified(Name::new("n")), RelationId(5))]

--- a/cli/lang_tests/flow/closure.msh
+++ b/cli/lang_tests/flow/closure.msh
@@ -6,7 +6,7 @@
 //     baz
 {
     var captured = 'bar'
-    fun foo(arg: String) -> ExitCode = {
+    fun foo(arg: String) -> Exitcode = {
         echo $captured
         captured = $arg
         echo $captured

--- a/cli/lang_tests/import/foo_consumer.msh
+++ b/cli/lang_tests/import/foo_consumer.msh
@@ -5,7 +5,7 @@
 //    this is foo!
 //    bar 514
 
-use foo_lib::{foo, bar, baz}
+use reef::foo_lib::{foo, bar, baz}
 
 echo foo()
 {

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -143,10 +143,13 @@ pub fn use_pipeline<'a>(
     let mut bytes = Vec::new();
     let contents = importer.list_content_ids();
     let lines = CachedSourceLocationLineProvider::compute(&contents, importer);
+    let reef = analyzer.context.current_reef();
+
     compile(
-        &analyzer.engine,
+        &reef.typed_engine,
         engine,
-        &analyzer.context.current_reef().relations,
+        &reef.relations,
+        analyzer.context.reef_id,
         starting_page,
         &mut bytes,
         Some(&lines),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,9 +1,9 @@
-use analyzer::reef::{ReefContext, Reefs};
 use clap::Parser;
 use miette::{IntoDiagnostic, MietteHandlerOpts, WrapErr};
 use std::ffi::OsStr;
 
 use analyzer::name::Name;
+use analyzer::reef::Externals;
 use analyzer::relations::SourceId;
 
 use crate::cli::{use_pipeline, Cli};
@@ -53,10 +53,11 @@ fn main() -> Result<PipelineStatus, miette::Error> {
         });
         importer.add_redirection(name.clone(), source.clone());
 
-        let mut reefs = Reefs::default();
-        let context = ReefContext::declare_new(&mut reefs, "test");
-        let mut pipeline = Pipeline::new(context);
-        pipeline.analyzer.process(name.clone(), &mut importer);
+        let externals = Externals::default();
+        let mut pipeline = Pipeline::new();
+        pipeline
+            .analyzer
+            .process(name.clone(), &mut importer, &externals);
         let diagnostics = pipeline.analyzer.take_diagnostics();
         return Ok(use_pipeline(
             &name,

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -6,6 +6,7 @@ use std::process::{ExitCode, Termination};
 
 use analyzer::importer::{ASTImporter, ImportResult, Imported};
 use analyzer::name::Name;
+use analyzer::reef::ReefContext;
 use analyzer::Analyzer;
 use ast::group::Block;
 use ast::Expr;
@@ -15,15 +16,17 @@ use parser::parse;
 use vm::VM;
 
 /// Holds the state of the analyzer and the virtual machine.
-#[derive(Default)]
-pub struct Pipeline<'a> {
-    pub analyzer: Analyzer<'a>,
+pub struct Pipeline<'a, 'e> {
+    pub analyzer: Analyzer<'a, 'e>,
     pub vm: VM,
 }
 
-impl Pipeline<'_> {
-    pub fn new() -> Self {
-        Self::default()
+impl<'a, 'e> Pipeline<'a, 'e> {
+    pub fn new(context: ReefContext<'a, 'e>) -> Self {
+        Self {
+            analyzer: Analyzer::new(context),
+            vm: VM::default(),
+        }
     }
 }
 

--- a/cli/src/pipeline.rs
+++ b/cli/src/pipeline.rs
@@ -6,7 +6,6 @@ use std::process::{ExitCode, Termination};
 
 use analyzer::importer::{ASTImporter, ImportResult, Imported};
 use analyzer::name::Name;
-use analyzer::reef::ReefContext;
 use analyzer::Analyzer;
 use ast::group::Block;
 use ast::Expr;
@@ -16,17 +15,15 @@ use parser::parse;
 use vm::VM;
 
 /// Holds the state of the analyzer and the virtual machine.
-pub struct Pipeline<'a, 'e> {
-    pub analyzer: Analyzer<'a, 'e>,
+#[derive(Default)]
+pub struct Pipeline<'a> {
+    pub analyzer: Analyzer<'a>,
     pub vm: VM,
 }
 
-impl<'a, 'e> Pipeline<'a, 'e> {
-    pub fn new(context: ReefContext<'a, 'e>) -> Self {
-        Self {
-            analyzer: Analyzer::new(context),
-            vm: VM::default(),
-        }
+impl<'a> Pipeline<'a> {
+    pub fn new() -> Self {
+        Self::default()
     }
 }
 

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 
 use analyzer::importer::ImportResult;
 use analyzer::name::Name;
-use analyzer::reef::{ReefContext, Reefs};
+use analyzer::reef::Externals;
 use analyzer::relations::SourceId;
 use analyzer::Inject;
 use context::source::OwnedSource;
@@ -17,11 +17,8 @@ use crate::report::print_flush;
 /// Indefinitely prompts a new expression from stdin and executes it.
 pub fn prompt(mut importer: FileImporter, config: &Cli) -> PipelineStatus {
     // Init a new pipeline that will be used to execute each expression.
-    let mut reefs = Reefs::default();
-
-    let reef_context = ReefContext::declare_new(&mut reefs, "repl");
-
-    let mut pipeline = Pipeline::new(reef_context);
+    let externals = Externals::default();
+    let mut pipeline = Pipeline::new();
     let mut status = PipelineStatus::Success;
 
     // Keep track of the previous attributed source, so that we can inject
@@ -42,6 +39,7 @@ pub fn prompt(mut importer: FileImporter, config: &Cli) -> PipelineStatus {
                     attached: starting_source,
                 },
                 &mut importer,
+                &externals,
             );
 
             // Reuse the same diagnotics by moving them, requiring to keep track

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 
 use analyzer::importer::ImportResult;
 use analyzer::name::Name;
+use analyzer::reef::{ReefContext, Reefs};
 use analyzer::relations::SourceId;
 use analyzer::Inject;
 use context::source::OwnedSource;
@@ -16,7 +17,12 @@ use crate::report::print_flush;
 /// Indefinitely prompts a new expression from stdin and executes it.
 pub fn prompt(mut importer: FileImporter, config: &Cli) -> PipelineStatus {
     // Init a new pipeline that will be used to execute each expression.
-    let mut pipeline = Pipeline::new();
+    let mut reefs = Reefs::default();
+
+    let reef_context = ReefContext::declare_new(&mut reefs, "repl");
+    let reef_id = reef_context.reef_id;
+
+    let mut pipeline = Pipeline::new(reef_context);
     let mut status = PipelineStatus::Success;
 
     // Keep track of the previous attributed source, so that we can inject
@@ -35,6 +41,7 @@ pub fn prompt(mut importer: FileImporter, config: &Cli) -> PipelineStatus {
                     name: name.clone(),
                     imported,
                     attached: starting_source,
+                    reef: reef_id,
                 },
                 &mut importer,
             );

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -20,7 +20,6 @@ pub fn prompt(mut importer: FileImporter, config: &Cli) -> PipelineStatus {
     let mut reefs = Reefs::default();
 
     let reef_context = ReefContext::declare_new(&mut reefs, "repl");
-    let reef_id = reef_context.reef_id;
 
     let mut pipeline = Pipeline::new(reef_context);
     let mut status = PipelineStatus::Success;
@@ -41,7 +40,6 @@ pub fn prompt(mut importer: FileImporter, config: &Cli) -> PipelineStatus {
                     name: name.clone(),
                     imported,
                     attached: starting_source,
-                    reef: reef_id,
                 },
                 &mut importer,
             );

--- a/compiler/src/emit.rs
+++ b/compiler/src/emit.rs
@@ -1,7 +1,8 @@
 use analyzer::engine::Engine;
 use analyzer::environment::Environment;
 use analyzer::relations::{Definition, SourceId};
-use analyzer::types::hir::{Declaration, ExprKind, TypeId, TypedExpr, Var};
+use analyzer::types::hir::{Declaration, ExprKind, TypedExpr, Var};
+use analyzer::types::ty::TypeRef;
 use ast::value::LiteralValue;
 
 use crate::bytecode::{Instructions, Opcode, Placeholder};
@@ -92,7 +93,7 @@ fn emit_literal(literal: &LiteralValue, instructions: &mut Instructions, cp: &mu
 fn emit_ref(
     var: Var,
     ctx: EmitterContext,
-    ref_type: TypeId,
+    ref_type: TypeRef,
     instructions: &mut Instructions,
     cp: &mut ConstantPool,
     locals: &LocalsLayout,
@@ -121,8 +122,8 @@ fn emit_declaration(
 ) {
     let variable = ctx
         .environment
-        .variables
-        .get_var(declaration.identifier)
+        .symbols
+        .get(declaration.identifier)
         .expect("The declared variable should be in the current environment.");
 
     if let Some(value) = &declaration.value {

--- a/compiler/src/emit/identifier.rs
+++ b/compiler/src/emit/identifier.rs
@@ -25,8 +25,8 @@ pub(super) fn expose_variable(ctx: EmitterContext, var: Var, cp: &mut ConstantPo
         Var::Local(id) => {
             let variable = ctx
                 .environment
-                .variables
-                .get_var(id)
+                .symbols
+                .get(id)
                 .expect("The declared variable should be in the current environment.");
             if variable.is_exported() && ctx.environment.is_script {
                 let name = &variable.name;
@@ -45,8 +45,8 @@ pub(super) fn expose_variable(ctx: EmitterContext, var: Var, cp: &mut ConstantPo
                 .get_environment(resolved.source)
                 .expect("Resolved relation targets an unknown environment");
             let variable = environment
-                .variables
-                .get_var(resolved.object_id)
+                .symbols
+                .get(resolved.object_id)
                 .expect("Resolved relation targets an unknown variable");
             let is_exported_dynsym = variable.is_exported() && environment.is_script;
             if is_exported_dynsym {

--- a/compiler/src/emit/invoke.rs
+++ b/compiler/src/emit/invoke.rs
@@ -1,7 +1,8 @@
 use libc::{O_APPEND, O_CREAT, O_RDONLY, O_RDWR, O_WRONLY};
 
 use analyzer::relations::Definition;
-use analyzer::types::hir::{ExprKind, FunctionCall, Redir, Redirect, TypeId, TypedExpr, Var};
+use analyzer::types::hir::{ExprKind, FunctionCall, Redir, Redirect, TypedExpr, Var};
+use analyzer::types::ty::TypeRef;
 use ast::call::{RedirFd, RedirOp};
 
 use crate::bytecode::{Instructions, Opcode};
@@ -116,7 +117,7 @@ fn emit_process_call_self(
 
 pub fn emit_function_invocation(
     function_call: &FunctionCall,
-    return_type: TypeId,
+    return_type: TypeRef,
     instructions: &mut Instructions,
     ctx: EmitterContext,
     cp: &mut ConstantPool,

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -357,7 +357,7 @@ mod tests {
 
     use analyzer::importer::StaticImporter;
     use analyzer::name::Name;
-    use analyzer::reef::{ReefContext, Reefs};
+    use analyzer::reef::{Externals, ReefId};
     use analyzer::relations::{LocalId, ResolvedSymbol, SourceId};
     use context::source::Source;
     use parser::parse_trusted;
@@ -385,16 +385,18 @@ mod tests {
            }
         }\
         ";
-        let mut reefs = Reefs::default();
-        let context = ReefContext::declare_new(&mut reefs, "test");
-        let reef_id = context.reef_id;
+        let externals = Externals::default();
+        let reef_id = ReefId(1);
         let analyzer = analyzer::analyze(
             Name::new("test"),
             &mut StaticImporter::new([(Name::new("test"), Source::unknown(src))], parse_trusted),
-            context,
+            &externals,
         );
-        let reef = analyzer.context.current_reef();
-        let captures = resolve_captures(&reef.engine, &reef.relations, reef_id);
+        let captures = resolve_captures(
+            &analyzer.resolution.engine,
+            &analyzer.resolution.relations,
+            reef_id,
+        );
 
         assert_eq!(
             captures,

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -192,7 +192,7 @@ fn resolve_captures(engine: &Engine, relations: &Relations, compiled_reef: ReefI
         // add this function's external referenced variables
         externals.extend(
             env.symbols
-                .external_vars()
+                .external_symbols()
                 .map(|(_, relation)| {
                     relations[relation]
                         .state

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -3,8 +3,9 @@ use std::io;
 use std::io::Write;
 
 use analyzer::engine::Engine;
-use analyzer::environment::variables::TypeInfo;
+use analyzer::environment::symbols::SymbolInfo;
 use analyzer::name::Name;
+use analyzer::reef::ReefId;
 use analyzer::relations::{LocalId, Relations, ResolvedSymbol, SourceId};
 use analyzer::types::engine::{Chunk, TypedEngine};
 use context::source::ContentId;
@@ -34,11 +35,12 @@ pub fn compile(
     typed_engine: &TypedEngine,
     link_engine: &Engine,
     relations: &Relations,
+    reef_id: ReefId,
     starting_page: SourceId,
     writer: &mut impl Write,
     line_provider: Option<&dyn SourceLineProvider>,
 ) -> Result<(), io::Error> {
-    let captures = resolve_captures(link_engine, relations);
+    let captures = resolve_captures(link_engine, relations, reef_id);
     let mut bytecode = Bytecode::default();
     let mut cp = ConstantPool::default();
 
@@ -159,12 +161,13 @@ fn compile_line_mapping_attribute(
 ///
 /// This function will resolve all direct captures of the chunk and the captures of its inner chunks.
 /// All resolved captures are set into the given `captures` vector.
-fn resolve_captures(engine: &Engine, relations: &Relations) -> Captures {
+fn resolve_captures(engine: &Engine, relations: &Relations, compiled_reef: ReefId) -> Captures {
     let mut externals = HashSet::new();
     let mut captures = vec![None; engine.len()];
 
     fn resolve(
         chunk_id: SourceId,
+        compiled_reef: ReefId,
         engine: &Engine,
         relations: &Relations,
         captures: &mut Captures,
@@ -174,14 +177,21 @@ fn resolve_captures(engine: &Engine, relations: &Relations) -> Captures {
 
         // recursively resolve all inner functions
         for func_id in env.iter_direct_inner_environments() {
-            resolve(func_id, engine, relations, captures, externals);
+            resolve(
+                func_id,
+                compiled_reef,
+                engine,
+                relations,
+                captures,
+                externals,
+            );
             // filter out external symbols that refers to the current chunk
             externals.retain(|symbol| symbol.source != chunk_id);
         }
 
         // add this function's external referenced variables
         externals.extend(
-            env.variables
+            env.symbols
                 .external_vars()
                 .map(|(_, relation)| {
                     relations[relation]
@@ -189,10 +199,12 @@ fn resolve_captures(engine: &Engine, relations: &Relations) -> Captures {
                         .expect_resolved("unresolved relation during compilation")
                 })
                 .filter(|symbol| {
-                    // filter out functions
-                    let env = engine.get_environment(symbol.source).unwrap();
-                    let var = env.variables.get_var(symbol.object_id).unwrap();
-                    var.ty == TypeInfo::Variable && !(env.is_script && var.is_exported())
+                    symbol.reef == compiled_reef && {
+                        // filter out functions
+                        let env = engine.get_environment(symbol.source).unwrap();
+                        let var = env.symbols.get(symbol.object_id).unwrap();
+                        var.ty == SymbolInfo::Variable && !(env.is_script && var.is_exported())
+                    }
                 }),
         );
 
@@ -210,7 +222,14 @@ fn resolve_captures(engine: &Engine, relations: &Relations) -> Captures {
 
     // Resolve captures of all environments, starting from the roots of each module
     for (engine_id, _) in engine.environments().filter(|(_, chunk)| chunk.is_script) {
-        resolve(engine_id, engine, relations, &mut captures, &mut externals);
+        resolve(
+            engine_id,
+            compiled_reef,
+            engine,
+            relations,
+            &mut captures,
+            &mut externals,
+        );
     }
     captures
 }
@@ -254,8 +273,7 @@ fn compile_chunk_code(
     let instruction_count = bytecode.emit_u32_placeholder();
 
     let mut instructions = Instructions::wrap(bytecode);
-    let mut locals =
-        LocalsLayout::new(ctx.environment.variables.all_vars().len() + chunk_captures.len());
+    let mut locals = LocalsLayout::new(ctx.environment.symbols.all().len() + chunk_captures.len());
 
     // set space for explicit parameters
     for (id, param) in chunk.parameters.iter().enumerate() {
@@ -376,7 +394,7 @@ mod tests {
             context,
         );
         let reef = analyzer.context.current_reef();
-        let captures = resolve_captures(&reef.engine, &reef.relations);
+        let captures = resolve_captures(&reef.engine, &reef.relations, reef_id);
 
         assert_eq!(
             captures,

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -339,6 +339,7 @@ mod tests {
 
     use analyzer::importer::StaticImporter;
     use analyzer::name::Name;
+    use analyzer::reef::{ReefContext, Reefs};
     use analyzer::relations::{LocalId, ResolvedSymbol, SourceId};
     use context::source::Source;
     use parser::parse_trusted;
@@ -366,12 +367,16 @@ mod tests {
            }
         }\
         ";
+        let mut reefs = Reefs::default();
+        let context = ReefContext::declare_new(&mut reefs, "test");
+        let reef_id = context.reef_id;
         let analyzer = analyzer::analyze(
             Name::new("test"),
             &mut StaticImporter::new([(Name::new("test"), Source::unknown(src))], parse_trusted),
+            context,
         );
-        let result = analyzer.resolution;
-        let captures = resolve_captures(&result.engine, &result.relations);
+        let reef = analyzer.context.current_reef();
+        let captures = resolve_captures(&reef.engine, &reef.relations);
 
         assert_eq!(
             captures,
@@ -380,25 +385,25 @@ mod tests {
                 Some(vec![]), //foo
                 Some(vec![
                     //foo1
-                    ResolvedSymbol::new(SourceId(1), LocalId(0)),
-                    ResolvedSymbol::new(SourceId(1), LocalId(1)),
+                    ResolvedSymbol::new(reef_id, SourceId(1), LocalId(0)),
+                    ResolvedSymbol::new(reef_id, SourceId(1), LocalId(1)),
                 ]),
                 Some(vec![
                     //foo2
-                    ResolvedSymbol::new(SourceId(1), LocalId(0)),
-                    ResolvedSymbol::new(SourceId(2), LocalId(0)),
+                    ResolvedSymbol::new(reef_id, SourceId(1), LocalId(0)),
+                    ResolvedSymbol::new(reef_id, SourceId(2), LocalId(0)),
                 ]),
                 Some(vec![
                     //bar
-                    ResolvedSymbol::new(SourceId(1), LocalId(0)),
+                    ResolvedSymbol::new(reef_id, SourceId(1), LocalId(0)),
                 ]),
                 Some(vec![
                     //bar1
-                    ResolvedSymbol::new(SourceId(1), LocalId(0)),
+                    ResolvedSymbol::new(reef_id, SourceId(1), LocalId(0)),
                 ]),
                 Some(vec![
                     //bar2
-                    ResolvedSymbol::new(SourceId(1), LocalId(0)),
+                    ResolvedSymbol::new(reef_id, SourceId(1), LocalId(0)),
                 ]),
             ]
         )

--- a/compiler/src/type.rs
+++ b/compiler/src/type.rs
@@ -1,11 +1,11 @@
 use analyzer::types::ty::TypeRef;
-use analyzer::types::{BOOL, ERROR, EXIT_CODE, FLOAT, INT, NOTHING, UNIT};
+use analyzer::types::{BOOL, ERROR, EXITCODE, FLOAT, INT, NOTHING, UNIT};
 
 /// returns the size of a given type identifier
 pub fn get_type_stack_size(tpe: TypeRef) -> ValueStackSize {
     match tpe {
         NOTHING | UNIT => ValueStackSize::Zero,
-        BOOL | EXIT_CODE => ValueStackSize::Byte,
+        BOOL | EXITCODE => ValueStackSize::Byte,
         INT | FLOAT => ValueStackSize::QWord,
         ERROR => panic!("Received 'ERROR' type in compilation phase."),
         _ => ValueStackSize::QWord, //other types are object types which are references (q-words)

--- a/compiler/src/type.rs
+++ b/compiler/src/type.rs
@@ -1,8 +1,8 @@
-use analyzer::types::hir::TypeId;
+use analyzer::types::ty::TypeRef;
 use analyzer::types::{BOOL, ERROR, EXIT_CODE, FLOAT, INT, NOTHING, UNIT};
 
 /// returns the size of a given type identifier
-pub fn get_type_stack_size(tpe: TypeId) -> ValueStackSize {
+pub fn get_type_stack_size(tpe: TypeRef) -> ValueStackSize {
     match tpe {
         NOTHING | UNIT => ValueStackSize::Zero,
         BOOL | EXIT_CODE => ValueStackSize::Byte,
@@ -30,8 +30,8 @@ impl From<ValueStackSize> for u8 {
     }
 }
 
-impl From<TypeId> for ValueStackSize {
-    fn from(value: TypeId) -> Self {
+impl From<TypeRef> for ValueStackSize {
+    fn from(value: TypeRef) -> Self {
         get_type_stack_size(value)
     }
 }

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -196,7 +196,7 @@ impl<'a> CallAspect<'a> for Parser<'a> {
             })
             .transpose()?;
 
-        let type_parameters = self.parse_type_parameter_list()?.0;
+        let type_arguments = self.parse_type_parameter_list()?.0;
         let open_parenthesis = self.cursor.force(
             of_type(TokenType::RoundedLeftBracket),
             "Expected opening parenthesis.",
@@ -210,7 +210,7 @@ impl<'a> CallAspect<'a> for Parser<'a> {
             source: Box::new(expr),
             name: name.map(|n| n.value),
             arguments,
-            type_parameters,
+            type_parameters: type_arguments,
             segment,
         }))
     }

--- a/vm/benches/exec_benchmark.rs
+++ b/vm/benches/exec_benchmark.rs
@@ -1,7 +1,7 @@
 use analyzer::analyze;
 use analyzer::importer::{ASTImporter, ImportResult, Imported};
 use analyzer::name::Name;
-use analyzer::reef::{ReefAccessor, ReefContext, Reefs};
+use analyzer::reef::{ReefContext, Reefs};
 use analyzer::relations::SourceId;
 use ast::Expr;
 use compiler::compile;

--- a/vm/benches/exec_benchmark.rs
+++ b/vm/benches/exec_benchmark.rs
@@ -1,6 +1,7 @@
 use analyzer::analyze;
 use analyzer::importer::{ASTImporter, ImportResult, Imported};
 use analyzer::name::Name;
+use analyzer::reef::{ReefContext, Reefs};
 use analyzer::relations::SourceId;
 use ast::Expr;
 use compiler::compile;
@@ -26,13 +27,14 @@ impl<'a> ASTImporter<'a> for SingleImporter<'a> {
 fn prepare_bytecode(code: &str) -> Vec<u8> {
     let mut bytes = Vec::new();
     let expr = parse_trusted(Source::new(code, "test"));
-    let mut analyzer = analyze(Name::new("test"), &mut SingleImporter(Some(expr)));
+    let mut reefs = Reefs::default();
+    let context = ReefContext::declare_new(&mut reefs, "bench");
+    let mut analyzer = analyze(Name::new("test"), &mut SingleImporter(Some(expr)), context);
     assert_eq!(analyzer.take_diagnostics(), &[]);
-    let resolve = analyzer.resolution;
     compile(
         &analyzer.engine,
-        &resolve.engine,
-        &resolve.relations,
+        &analyzer.context.current_reef().engine,
+        &analyzer.context.current_reef().relations,
         SourceId(0),
         &mut bytes,
         None,

--- a/vm/benches/exec_benchmark.rs
+++ b/vm/benches/exec_benchmark.rs
@@ -1,7 +1,7 @@
 use analyzer::analyze;
 use analyzer::importer::{ASTImporter, ImportResult, Imported};
 use analyzer::name::Name;
-use analyzer::reef::{ReefContext, Reefs};
+use analyzer::reef::{ReefAccessor, ReefContext, Reefs};
 use analyzer::relations::SourceId;
 use ast::Expr;
 use compiler::compile;
@@ -29,12 +29,17 @@ fn prepare_bytecode(code: &str) -> Vec<u8> {
     let expr = parse_trusted(Source::new(code, "test"));
     let mut reefs = Reefs::default();
     let context = ReefContext::declare_new(&mut reefs, "bench");
+
+    let reef_id = context.reef_id;
     let mut analyzer = analyze(Name::new("test"), &mut SingleImporter(Some(expr)), context);
     assert_eq!(analyzer.take_diagnostics(), &[]);
+
+    let reef = reefs.get_reef(reef_id).unwrap();
     compile(
-        &analyzer.engine,
-        &analyzer.context.current_reef().engine,
-        &analyzer.context.current_reef().relations,
+        &reef.typed_engine,
+        &reef.engine,
+        &reef.relations,
+        reef_id,
         SourceId(0),
         &mut bytes,
         None,

--- a/vm/benches/exec_benchmark.rs
+++ b/vm/benches/exec_benchmark.rs
@@ -1,7 +1,7 @@
 use analyzer::analyze;
 use analyzer::importer::{ASTImporter, ImportResult, Imported};
 use analyzer::name::Name;
-use analyzer::reef::{ReefContext, Reefs};
+use analyzer::reef::{Externals, ReefId};
 use analyzer::relations::SourceId;
 use ast::Expr;
 use compiler::compile;
@@ -27,19 +27,19 @@ impl<'a> ASTImporter<'a> for SingleImporter<'a> {
 fn prepare_bytecode(code: &str) -> Vec<u8> {
     let mut bytes = Vec::new();
     let expr = parse_trusted(Source::new(code, "test"));
-    let mut reefs = Reefs::default();
-    let context = ReefContext::declare_new(&mut reefs, "bench");
-
-    let reef_id = context.reef_id;
-    let mut analyzer = analyze(Name::new("test"), &mut SingleImporter(Some(expr)), context);
+    let externals = Externals::default();
+    let mut analyzer = analyze(
+        Name::new("test"),
+        &mut SingleImporter(Some(expr)),
+        &externals,
+    );
     assert_eq!(analyzer.take_diagnostics(), &[]);
 
-    let reef = reefs.get_reef(reef_id).unwrap();
     compile(
-        &reef.typed_engine,
-        &reef.engine,
-        &reef.relations,
-        reef_id,
+        &analyzer.engine,
+        &analyzer.resolution.engine,
+        &analyzer.resolution.relations,
+        ReefId(1),
         SourceId(0),
         &mut bytes,
         None,


### PR DESCRIPTION
This pull request follows the previous parser side pull request (#139) to implement reefs on the analyzer.

A reef is a structure that contains the analyzer's outputs over a set of input sources (`Engine`, `Relations`, `TypedEngine`, `Typing` and `TypeContext`).
A reef can also use symbols from other reefs, which needed the resolver, collector and `Relations` to take some significant changes that'll be enumerated later.

In order for this pull request to make sense, i also made types behave like regular symbols, and now the collection/resolution phases also works for types ! which also implied many changes on the typing phase.

## `Reef` / `Reefs`
the `Reef` structure contains all the symbols, types and relations of a reef, with a given name. 
Available reefs are stored into a `Reefs` structure, and reef's external relations are relative to it (for example, a reef pointing to the reef with id 4 is the reef with id 4 of its own `Reefs` container.)

## `ReefContext` / collection / resolution / typing phases

The ReefContext is a structure that mutably borrows a given `Reefs` structure, and reserves a reef in it. The reserved reef can then be mutably accessed using `ReefContext::current_reef_mut`. The `reefs` structure is protected by the context and is only exposed immutably.

Now that the analyzer's data is stored into a `Reef` structure, the `Engine` and `Relations` where removed from the `ResolutionResult` (used by collect/resolution phases).

But the fact that all the data is now contained in a `Reefs` structure does not really enjoys the borrow checker...  

In the collection / resolution phase this is not a real concern, and a smart use of `ReefContext::current_reef_mut` was sufficient to resolve the borrow issues.  
But in the `typing` phase, because some immutable access to the external reefs needed to be done even if the current reef's types structures are modified, the `Typing`, `TypeContext` and `TypedEngine` structures needed to still be owned by the `Exploration` structure.
This makes the access to a reef's type more complicated because the current reef's types cannot be accessed through the `Reefs` as they are written at the end of the typing phase from the `Exploration` structure. 

### URA
To overcome this issue, the `UniversaReefAccessor` is used by most of the typing phase functions, which is a proxy that takes the current exploration's types data (`Typing`, `TypeContext` and `TypedEngine`) and returns under the same interface the exploration's type data or any other reef's data if the given reef identifier is the current reef's identifier

## SymbolRegistry 
As types are now handled as regular symbols, but types can also take the same name of a variable or a function's name, the symbols now lives in a defined registry, which is either `Types` for types, or `Objects` for variables and functions.

## Other changes
Refactors :
- `environment::variables::Variables` is now `environment::symbols::Symbols`,
- The `relations::Symbol` enum became `relations::SymbolRef`
- The `Variable` structure in `environment::variables` became `Symbol`

The monstruous `ExitCode` type has been renamed with the fancy `Exitcode` name, yes this is arbitrary lol but we can discuss if you want for a better name, because i personally really dislike the way it's currently named.