### PR TITLE
Parse generic type declarations

### DIFF
--- a/ast/src/function.rs
+++ b/ast/src/function.rs
@@ -2,7 +2,7 @@ use dbg_pls::DebugPls;
 
 use src_macros::segment_holder;
 
-use crate::r#type::Type;
+use crate::r#type::{GenericType, Type};
 use crate::variable::TypedVariable;
 use crate::Expr;
 
@@ -16,7 +16,7 @@ pub struct Return<'a> {
 #[derive(Debug, Clone, PartialEq, DebugPls)]
 pub struct FunctionDeclaration<'a> {
     pub name: &'a str,
-    pub type_parameters: Vec<Type<'a>>,
+    pub type_parameters: Vec<GenericType<'a>>,
     pub parameters: Vec<FunctionParameter<'a>>,
     pub return_type: Option<Type<'a>>,
     pub body: Box<Expr<'a>>,

--- a/ast/src/function.rs
+++ b/ast/src/function.rs
@@ -2,7 +2,7 @@ use dbg_pls::DebugPls;
 
 use src_macros::segment_holder;
 
-use crate::r#type::{GenericType, Type};
+use crate::r#type::{Type, TypeParameter};
 use crate::variable::TypedVariable;
 use crate::Expr;
 
@@ -16,7 +16,7 @@ pub struct Return<'a> {
 #[derive(Debug, Clone, PartialEq, DebugPls)]
 pub struct FunctionDeclaration<'a> {
     pub name: &'a str,
-    pub type_parameters: Vec<GenericType<'a>>,
+    pub type_parameters: Vec<TypeParameter<'a>>,
     pub parameters: Vec<FunctionParameter<'a>>,
     pub return_type: Option<Type<'a>>,
     pub body: Box<Expr<'a>>,

--- a/ast/src/type.rs
+++ b/ast/src/type.rs
@@ -35,9 +35,9 @@ pub struct CastedExpr<'a> {
 
 #[segment_holder]
 #[derive(Debug, Clone, PartialEq, DebugPls)]
-pub struct GenericType<'a> {
+pub struct TypeParameter<'a> {
     pub name: &'a str,
-    pub params: Vec<GenericType<'a>>,
+    pub params: Vec<TypeParameter<'a>>,
 }
 
 #[segment_holder]

--- a/ast/src/type.rs
+++ b/ast/src/type.rs
@@ -35,6 +35,13 @@ pub struct CastedExpr<'a> {
 
 #[segment_holder]
 #[derive(Debug, Clone, PartialEq, DebugPls)]
+pub struct GenericType<'a> {
+    pub name: &'a str,
+    pub params: Vec<GenericType<'a>>,
+}
+
+#[segment_holder]
+#[derive(Debug, Clone, PartialEq, DebugPls)]
 pub struct ParametrizedType<'a> {
     /// inclusion path, with the type's name
     pub path: Vec<InclusionPathItem<'a>>,

--- a/parser/src/aspects/assign.rs
+++ b/parser/src/aspects/assign.rs
@@ -50,7 +50,7 @@ mod tests {
         assert_eq!(
             res,
             Err(ParseError {
-                message: "Expected value".to_string(),
+                message: "Expected expression".to_string(),
                 position: content.len()..content.len(),
                 kind: ParseErrorKind::Unexpected,
             })

--- a/parser/src/aspects/assign.rs
+++ b/parser/src/aspects/assign.rs
@@ -37,6 +37,7 @@ mod tests {
     use ast::variable::Assign;
     use ast::Expr;
     use context::source::{Source, SourceSegmentHolder};
+    use pretty_assertions::assert_eq;
 
     use crate::err::{ParseError, ParseErrorKind};
     use crate::parse;
@@ -50,7 +51,7 @@ mod tests {
         assert_eq!(
             res,
             Err(ParseError {
-                message: "Expected expression".to_string(),
+                message: "Expected value".to_string(),
                 position: content.len()..content.len(),
                 kind: ParseErrorKind::Unexpected,
             })

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -283,7 +283,7 @@ impl<'a> CallAspect<'a> for Parser<'a> {
 impl<'a> Parser<'a> {
     /// special pivot method for argument methods
     pub(crate) fn call_argument(&mut self) -> ParseResult<Expr<'a>> {
-        self.repos("Expected expression")?;
+        self.repos("Expected value")?;
 
         let pivot = self.cursor.peek().token_type;
         match pivot {

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -6,7 +6,6 @@ use ast::value::Literal;
 use ast::variable::TypedVariable;
 use ast::Expr;
 use context::source::{SourceSegment, SourceSegmentHolder};
-use lexer::token::TokenType::{RoundedLeftBracket, SquaredLeftBracket, SquaredRightBracket};
 use lexer::token::{Token, TokenType};
 
 use crate::aspects::expr_list::ExpressionListAspect;
@@ -81,10 +80,9 @@ impl<'a> CallAspect<'a> for Parser<'a> {
             parsed: name.into(),
             segment: name_segment.clone(),
         });
-        let (type_parameters, _) = self.parse_optional_or_nonempty_list(
-            SquaredLeftBracket,
-            SquaredRightBracket,
-            "empty type argument list",
+        let (type_parameters, _) = self.parse_optional_list(
+            TokenType::SquaredLeftBracket,
+            TokenType::SquaredRightBracket,
             Parser::parse_type,
         )?;
 
@@ -148,10 +146,9 @@ impl<'a> CallAspect<'a> for Parser<'a> {
 
     fn call(&mut self) -> ParseResult<Expr<'a>> {
         let callee = self.call_argument()?;
-        let (type_parameters, _) = self.parse_optional_or_nonempty_list(
-            SquaredLeftBracket,
-            SquaredRightBracket,
-            "empty type argument list",
+        let (type_parameters, _) = self.parse_optional_list(
+            TokenType::SquaredLeftBracket,
+            TokenType::SquaredRightBracket,
             Parser::parse_type,
         )?;
 
@@ -174,10 +171,9 @@ impl<'a> CallAspect<'a> for Parser<'a> {
         let name_segment = self.cursor.relative_pos(name.value);
         path.push(InclusionPathItem::Symbol(name.value, name_segment.clone()));
 
-        let (type_parameters, _) = self.parse_optional_or_nonempty_list(
-            SquaredLeftBracket,
-            SquaredRightBracket,
-            "empty type argument list",
+        let (type_parameters, _) = self.parse_optional_list(
+            TokenType::SquaredLeftBracket,
+            TokenType::SquaredRightBracket,
             Parser::parse_type,
         )?;
         let open_parenthesis = self.cursor.force(
@@ -215,16 +211,16 @@ impl<'a> CallAspect<'a> for Parser<'a> {
             })
             .transpose()?;
 
-        let (type_arguments, _) = self.parse_optional_or_nonempty_list(
-            SquaredLeftBracket,
-            SquaredRightBracket,
-            "empty type argument list",
+        let (type_arguments, _) = self.parse_optional_list(
+            TokenType::SquaredLeftBracket,
+            TokenType::SquaredRightBracket,
             Parser::parse_type,
         )?;
 
-        let open_parenthesis = self
-            .cursor
-            .force(of_type(RoundedLeftBracket), "Expected opening parenthesis.")?;
+        let open_parenthesis = self.cursor.force(
+            of_type(TokenType::RoundedLeftBracket),
+            "Expected opening parenthesis.",
+        )?;
         let (arguments, segment) = self.parse_comma_separated_arguments(open_parenthesis)?;
         let segment = dot
             .map(|d| self.cursor.relative_pos(d.value))

--- a/parser/src/aspects/expr_list.rs
+++ b/parser/src/aspects/expr_list.rs
@@ -38,7 +38,6 @@ pub(super) trait ExpressionListAspect<'a> {
     /// parses a list which is either nonexistent or explicit but nonempty.
     /// - if the current's token does not match `start`, an empty vec is returned.
     /// - else, an explicit list is parsed, that must end with `end` token.
-    ///   if the explicit list is empty, an error is returned with given error message.
     fn parse_optional_list<E, F>(
         &mut self,
         start: TokenType,

--- a/parser/src/aspects/function_declaration.rs
+++ b/parser/src/aspects/function_declaration.rs
@@ -1,3 +1,4 @@
+use crate::aspects::expr_list::ExpressionListAspect;
 use ast::function::{FunctionDeclaration, FunctionParameter, Return};
 use ast::r#type::Type;
 use context::source::SourceSegmentHolder;
@@ -36,7 +37,12 @@ impl<'a> FunctionDeclarationAspect<'a> for Parser<'a> {
         self.cursor.advance(blanks());
         let name = self.parse_fn_declaration_name()?;
         self.cursor.advance(blanks());
-        let tparams = self.parse_type_parameter_list()?.0;
+        let (tparams, _) = self.parse_optional_or_nonempty_list(
+            SquaredLeftBracket,
+            SquaredRightBracket,
+            "empty generic parameter list",
+            Parser::parse_generic_type,
+        )?;
         self.cursor.advance(blanks());
         let params = self.parse_fn_parameter_list()?;
         self.cursor.advance(blanks());
@@ -213,7 +219,7 @@ mod tests {
     use ast::call::Call;
     use ast::function::{FunctionDeclaration, FunctionParameter, Return};
     use ast::operation::{BinaryOperation, BinaryOperator};
-    use ast::r#type::{ParametrizedType, Type};
+    use ast::r#type::{GenericType, ParametrizedType, Type};
     use ast::r#use::InclusionPathItem;
     use ast::value::Literal;
     use ast::variable::{TypedVariable, VarReference};
@@ -465,16 +471,16 @@ mod tests {
             vec![Expr::FunctionDeclaration(FunctionDeclaration {
                 name: "test",
                 type_parameters: vec![
-                    Type::Parametrized(ParametrizedType {
-                        path: vec![InclusionPathItem::Symbol("X", find_in(source.source, "X"))],
+                    GenericType {
+                        name: "X",
                         params: Vec::new(),
                         segment: find_in(source.source, "X")
-                    }),
-                    Type::Parametrized(ParametrizedType {
-                        path: vec![InclusionPathItem::Symbol("Y", find_in(source.source, "Y"))],
+                    },
+                    GenericType {
+                        name: "Y",
                         params: Vec::new(),
                         segment: find_in(source.source, "Y")
-                    }),
+                    },
                 ],
                 parameters: vec![
                     FunctionParameter::Named(TypedVariable {
@@ -582,16 +588,16 @@ mod tests {
             vec![Expr::FunctionDeclaration(FunctionDeclaration {
                 name: "test",
                 type_parameters: vec![
-                    Type::Parametrized(ParametrizedType {
-                        path: vec![InclusionPathItem::Symbol("X", find_in(source.source, "X"))],
+                    GenericType {
+                        name: "X",
                         params: Vec::new(),
                         segment: find_in(source.source, "X")
-                    }),
-                    Type::Parametrized(ParametrizedType {
-                        path: vec![InclusionPathItem::Symbol("Y", find_in(source.source, "Y"))],
+                    },
+                    GenericType {
+                        name: "Y",
                         params: Vec::new(),
                         segment: find_in(source.source, "Y")
-                    }),
+                    },
                 ],
                 parameters: vec![
                     FunctionParameter::Named(TypedVariable {

--- a/parser/src/aspects/function_declaration.rs
+++ b/parser/src/aspects/function_declaration.rs
@@ -3,7 +3,6 @@ use ast::function::{FunctionDeclaration, FunctionParameter, Return};
 use ast::r#type::Type;
 use context::source::SourceSegmentHolder;
 use lexer::token::TokenType;
-use lexer::token::TokenType::*;
 
 use crate::aspects::r#type::TypeAspect;
 use crate::aspects::var_declaration::VarDeclarationAspect;
@@ -28,7 +27,7 @@ impl<'a> FunctionDeclarationAspect<'a> for Parser<'a> {
         let fun = self
             .cursor
             .force(
-                of_type(Fun),
+                of_type(TokenType::Fun),
                 "expected 'fun' keyword at start of function declaration.",
             )?
             .value;
@@ -37,11 +36,11 @@ impl<'a> FunctionDeclarationAspect<'a> for Parser<'a> {
         self.cursor.advance(blanks());
         let name = self.parse_fn_declaration_name()?;
         self.cursor.advance(blanks());
-        let (tparams, _) = self.parse_optional_or_nonempty_list(
-            SquaredLeftBracket,
-            SquaredRightBracket,
-            "empty generic parameter list",
-            Parser::parse_generic_type,
+
+        let (tparams, _) = self.parse_optional_list(
+            TokenType::SquaredLeftBracket,
+            TokenType::SquaredRightBracket,
+            Parser::parse_type_parameter,
         )?;
         self.cursor.advance(blanks());
         let params = self.parse_fn_parameter_list()?;
@@ -51,7 +50,7 @@ impl<'a> FunctionDeclarationAspect<'a> for Parser<'a> {
 
         let body = self
             .cursor
-            .force(blanks().then(of_type(Equal)), "expected '='")
+            .force(blanks().then(of_type(TokenType::Equal)), "expected '='")
             .and_then(|_| {
                 self.cursor.advance(blanks());
                 self.statement()
@@ -72,7 +71,7 @@ impl<'a> FunctionDeclarationAspect<'a> for Parser<'a> {
     fn parse_return(&mut self) -> ParseResult<Return<'a>> {
         let start = self
             .cursor
-            .force(of_type(Return), "'return' keyword expected here")?;
+            .force(of_type(TokenType::Return), "'return' keyword expected here")?;
         if self.cursor.advance(spaces()).is_none() || self.cursor.lookahead(eox()).is_some() {
             return Ok(Return {
                 expr: None,
@@ -90,7 +89,7 @@ impl<'a> FunctionDeclarationAspect<'a> for Parser<'a> {
 
 impl<'a> Parser<'a> {
     fn parse_fn_return_type(&mut self) -> ParseResult<Option<Type<'a>>> {
-        if self.cursor.advance(of_type(Arrow)).is_none() {
+        if self.cursor.advance(of_type(TokenType::Arrow)).is_none() {
             return Ok(None);
         }
         self.cursor.advance(blanks()); // consume blanks
@@ -103,28 +102,29 @@ impl<'a> Parser<'a> {
         let is_vararg = self
             .cursor
             .lookahead(
-                of_type(Vararg).or(repeat(
+                of_type(TokenType::Vararg).or(repeat(
                     // skip everything that could compose a type expression
                     of_types(&[
-                        Space,
-                        NewLine,
-                        Identifier,
-                        SquaredLeftBracket,
-                        SquaredRightBracket,
+                        TokenType::Space,
+                        TokenType::NewLine,
+                        TokenType::Identifier,
+                        TokenType::SquaredLeftBracket,
+                        TokenType::SquaredRightBracket,
                     ]),
                 )
-                .then(of_type(Vararg))),
+                .then(of_type(TokenType::Vararg))),
             )
             .is_some();
 
         if is_vararg {
             let param = self
                 .cursor
-                .lookahead(not(of_type(Vararg)))
+                .lookahead(not(of_type(TokenType::Vararg)))
                 .map(|_| self.parse_type())
                 .transpose()
                 .map(FunctionParameter::Variadic)?;
-            self.cursor.force(of_type(Vararg), "expected '...'")?;
+            self.cursor
+                .force(of_type(TokenType::Vararg), "expected '...'")?;
             return Ok(param);
         }
 
@@ -134,7 +134,7 @@ impl<'a> Parser<'a> {
     fn parse_fn_parameter_list(&mut self) -> ParseResult<Vec<FunctionParameter<'a>>> {
         let parenthesis = self
             .cursor
-            .advance(of_type(RoundedLeftBracket))
+            .advance(of_type(TokenType::RoundedLeftBracket))
             .ok_or_else(|| {
                 self.mk_parse_error(
                     "expected start of parameter list",
@@ -146,7 +146,7 @@ impl<'a> Parser<'a> {
         let mut params = Vec::new();
         loop {
             self.cursor.advance(blanks());
-            while let Some(comma) = self.cursor.advance(of_type(Comma)) {
+            while let Some(comma) = self.cursor.advance(of_type(TokenType::Comma)) {
                 self.report_error(self.mk_parse_error(
                     "Expected parameter.",
                     comma,
@@ -161,11 +161,11 @@ impl<'a> Parser<'a> {
             match param {
                 Ok(param) => params.push(param),
                 Err(err) => {
-                    self.recover_from(err, of_type(Comma));
+                    self.recover_from(err, of_type(TokenType::Comma));
                 }
             }
             if let Err(err) = self.cursor.force(
-                blanks().then(of_type(Comma).or(lookahead(eog()))),
+                blanks().then(of_type(TokenType::Comma).or(lookahead(eog()))),
                 "Expected ','",
             ) {
                 self.cursor.advance(blanks());
@@ -173,7 +173,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        self.expect_delimiter(parenthesis, RoundedRightBracket)?;
+        self.expect_delimiter(parenthesis, TokenType::RoundedRightBracket)?;
 
         Ok(params)
     }
@@ -187,9 +187,9 @@ impl<'a> Parser<'a> {
                     .cursor
                     .collect(repeat(
                         not(blank().or(eox()).or(of_types(&[
-                            CurlyLeftBracket,
-                            SquaredLeftBracket,
-                            RoundedLeftBracket,
+                            TokenType::CurlyLeftBracket,
+                            TokenType::SquaredLeftBracket,
+                            TokenType::RoundedLeftBracket,
                         ])))
                         .and_then(next()),
                     ))
@@ -219,7 +219,7 @@ mod tests {
     use ast::call::Call;
     use ast::function::{FunctionDeclaration, FunctionParameter, Return};
     use ast::operation::{BinaryOperation, BinaryOperator};
-    use ast::r#type::{GenericType, ParametrizedType, Type};
+    use ast::r#type::{ParametrizedType, Type, TypeParameter};
     use ast::r#use::InclusionPathItem;
     use ast::value::Literal;
     use ast::variable::{TypedVariable, VarReference};
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn function_declaration() {
-        let source = Source::unknown("fun test() = x");
+        let source = Source::unknown("fun test[]() = x");
         let ast = parse(source).expect("parse failed");
         assert_eq!(
             ast,
@@ -420,7 +420,7 @@ mod tests {
 
     #[test]
     fn function_declaration_params() {
-        let source = Source::unknown("fun test(  x : String  ,  y : Test   ) = x");
+        let source = Source::unknown("fun test[](  x : String  ,  y : Test   ) = x");
         let ast = parse(source).expect("parse failed");
         assert_eq!(
             ast,
@@ -471,12 +471,12 @@ mod tests {
             vec![Expr::FunctionDeclaration(FunctionDeclaration {
                 name: "test",
                 type_parameters: vec![
-                    GenericType {
+                    TypeParameter {
                         name: "X",
                         params: Vec::new(),
                         segment: find_in(source.source, "X")
                     },
-                    GenericType {
+                    TypeParameter {
                         name: "Y",
                         params: Vec::new(),
                         segment: find_in(source.source, "Y")
@@ -588,12 +588,12 @@ mod tests {
             vec![Expr::FunctionDeclaration(FunctionDeclaration {
                 name: "test",
                 type_parameters: vec![
-                    GenericType {
+                    TypeParameter {
                         name: "X",
                         params: Vec::new(),
                         segment: find_in(source.source, "X")
                     },
-                    GenericType {
+                    TypeParameter {
                         name: "Y",
                         params: Vec::new(),
                         segment: find_in(source.source, "Y")

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -273,7 +273,7 @@ impl<'a> Parser<'a> {
 
     /// Parses the left-hand side of the next value.
     fn lhs(&mut self) -> ParseResult<Expr<'a>> {
-        self.repos("Expected expression")?;
+        self.repos("Expected value")?;
         match self.cursor.peek().token_type {
             RoundedLeftBracket => self.lambda_or_parentheses(),
             CurlyLeftBracket => self.block().map(Expr::Block),

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -273,7 +273,7 @@ impl<'a> Parser<'a> {
 
     /// Parses the left-hand side of the next value.
     fn lhs(&mut self) -> ParseResult<Expr<'a>> {
-        self.repos("Expected value")?;
+        self.repos("Expected expression")?;
         match self.cursor.peek().token_type {
             RoundedLeftBracket => self.lambda_or_parentheses(),
             CurlyLeftBracket => self.block().map(Expr::Block),

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 use ast::call::{Call, ProgrammaticCall};
 use ast::function::{FunctionDeclaration, FunctionParameter};
 use ast::group::Block;
-use ast::r#type::{GenericType, ParametrizedType, Type};
+use ast::r#type::{ParametrizedType, Type, TypeParameter};
 use ast::r#use::InclusionPathItem;
 use ast::value::Literal;
 use ast::variable::{TypedVariable, VarDeclaration, VarKind, VarReference};
@@ -108,12 +108,12 @@ fn what_is_an_import() {
                 kind: ParseErrorKind::Unexpected
             },
             ParseError {
-                message: "Expected expression".to_owned(),
+                message: "Expected value".to_owned(),
                 position: content.find('%').map(|p| p + 1..p + 2).unwrap(),
                 kind: ParseErrorKind::Unexpected
             },
             ParseError {
-                message: "Expected expression".to_owned(),
+                message: "Expected value".to_owned(),
                 position: content.find(';').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }
@@ -131,11 +131,11 @@ fn tolerance_in_multiple_groups() {
         ParseReport {
             expr: vec![Expr::FunctionDeclaration(FunctionDeclaration {
                 name: "f",
-                type_parameters: vec![GenericType {
+                type_parameters: vec![TypeParameter {
                     name: "T",
                     params: Vec::new(),
                     segment: find_in(source.source, "T")
-                },],
+                }],
                 parameters: vec![FunctionParameter::Named(TypedVariable {
                     name: "x",
                     ty: Some(Type::Parametrized(ParametrizedType {
@@ -357,7 +357,7 @@ fn expected_value_found_eof() {
         ParseReport {
             expr: vec![],
             errors: vec![ParseError {
-                message: "Expected expression".to_string(),
+                message: "Expected value".to_string(),
                 position: content.find('=').map(|p| p + 1..p + 2).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
@@ -375,7 +375,7 @@ fn expected_value_found_semicolon() {
         ParseReport {
             expr: vec![],
             errors: vec![ParseError {
-                message: "Expected expression".to_string(),
+                message: "Expected value".to_string(),
                 position: content.find(';').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
@@ -481,7 +481,7 @@ fn double_comma_function() {
                     kind: ParseErrorKind::Unexpected
                 },
                 ParseError {
-                    message: "Expected expression".to_string(),
+                    message: "Expected value".to_string(),
                     position: content.len()..content.len(),
                     kind: ParseErrorKind::Unexpected
                 }

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -3,7 +3,7 @@ use pretty_assertions::assert_eq;
 use ast::call::{Call, ProgrammaticCall};
 use ast::function::{FunctionDeclaration, FunctionParameter};
 use ast::group::Block;
-use ast::r#type::{ParametrizedType, Type};
+use ast::r#type::{GenericType, ParametrizedType, Type};
 use ast::r#use::InclusionPathItem;
 use ast::value::Literal;
 use ast::variable::{TypedVariable, VarDeclaration, VarKind, VarReference};
@@ -108,12 +108,12 @@ fn what_is_an_import() {
                 kind: ParseErrorKind::Unexpected
             },
             ParseError {
-                message: "Expected value".to_owned(),
+                message: "Expected expression".to_owned(),
                 position: content.find('%').map(|p| p + 1..p + 2).unwrap(),
                 kind: ParseErrorKind::Unexpected
             },
             ParseError {
-                message: "Expected value".to_owned(),
+                message: "Expected expression".to_owned(),
                 position: content.find(';').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }
@@ -131,11 +131,11 @@ fn tolerance_in_multiple_groups() {
         ParseReport {
             expr: vec![Expr::FunctionDeclaration(FunctionDeclaration {
                 name: "f",
-                type_parameters: vec![Type::Parametrized(ParametrizedType {
-                    path: vec![InclusionPathItem::Symbol("T", find_in(source.source, "T"))],
-                    params: vec![],
-                    segment: find_in(&source.source, "T")
-                })],
+                type_parameters: vec![GenericType {
+                    name: "T",
+                    params: Vec::new(),
+                    segment: find_in(source.source, "T")
+                },],
                 parameters: vec![FunctionParameter::Named(TypedVariable {
                     name: "x",
                     ty: Some(Type::Parametrized(ParametrizedType {
@@ -157,7 +157,7 @@ fn tolerance_in_multiple_groups() {
             })],
             errors: vec![
                 ParseError {
-                    message: "'$' is not a valid type identifier.".to_owned(),
+                    message: "'$' is not a valid generic type identifier.".to_owned(),
                     position: content.find('$').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected
                 },
@@ -240,7 +240,7 @@ fn no_comma_or_two() {
             expr: vec![],
             errors: vec![
                 ParseError {
-                    message: "'@' is not a valid type identifier.".to_owned(),
+                    message: "'@' is not a valid generic type identifier.".to_owned(),
                     position: content.find('@').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected
                 },
@@ -315,14 +315,9 @@ fn do_not_self_lock() {
             })],
             errors: vec![
                 ParseError {
-                    message: "Expected value.".to_owned(),
+                    message: "Expected expression.".to_owned(),
                     position: content.find(',').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected
-                },
-                ParseError {
-                    message: "expected types".to_owned(),
-                    position: content.find(']').map(|p| p..p + 1).unwrap(),
-                    kind: ParseErrorKind::Expected("<types>".to_owned())
                 },
                 ParseError {
                     message: "Expected parameter.".to_owned(),
@@ -362,7 +357,7 @@ fn expected_value_found_eof() {
         ParseReport {
             expr: vec![],
             errors: vec![ParseError {
-                message: "Expected value".to_string(),
+                message: "Expected expression".to_string(),
                 position: content.find('=').map(|p| p + 1..p + 2).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
@@ -380,7 +375,7 @@ fn expected_value_found_semicolon() {
         ParseReport {
             expr: vec![],
             errors: vec![ParseError {
-                message: "Expected value".to_string(),
+                message: "Expected expression".to_string(),
                 position: content.find(';').map(|p| p..p + 1).unwrap(),
                 kind: ParseErrorKind::Unexpected
             }],
@@ -486,7 +481,7 @@ fn double_comma_function() {
                     kind: ParseErrorKind::Unexpected
                 },
                 ParseError {
-                    message: "Expected value".to_string(),
+                    message: "Expected expression".to_string(),
                     position: content.len()..content.len(),
                     kind: ParseErrorKind::Unexpected
                 }


### PR DESCRIPTION
This PR adds a new ast structure for generic types declarations (used in function declaration's type parameters).

Also did some fixes with `Parser::parse_explicit_list` that could report a missing expected expression but still try to parse it afterward.