### PR TITLE
Fix shifted sources ids

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 use crate::cli::{use_pipeline, Cli};
-use crate::pipeline::{ErrorReporter, FileImporter, PipelineStatus, SourcesCache};
+use crate::pipeline::{ErrorReporter, PipelineStatus, SourcesCache};
 use crate::repl::repl;
 use crate::std::build_std;
 use ::std::ffi::OsStr;
@@ -77,15 +77,15 @@ fn run(
         path
     };
 
-    let mut importer = FileImporter::new(folder_path);
+    sources.register(folder_path);
+    let importer = sources.last_mut();
     importer.add_redirection(name.clone(), source.to_path_buf());
 
     let mut analyzer = Analyzer::new();
-    analyzer.process(name.clone(), &mut importer, &externals);
+    analyzer.process(name.clone(), importer, &externals);
 
     let diagnostics = analyzer.take_diagnostics();
     let errors = importer.take_errors();
-    sources.set(externals.current, importer.take_sources());
 
     Ok(use_pipeline(
         &name,

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -20,8 +20,7 @@ mod report;
 mod std;
 
 fn main() -> Result<PipelineStatus, miette::Error> {
-    #[cfg(unix)]
-    {
+    if cfg!(unix) && !cfg!(miri) {
         // Override Rust's default `SIGPIPE` signal handler that ignores the signal.
         // `println!` will no longer panic since the process will be killed before
         // trying to write something. Restoring this Unix behavior is also important

--- a/cli/src/report.rs
+++ b/cli/src/report.rs
@@ -9,7 +9,7 @@ use analyzer::reef::{Externals, ReefId};
 use context::source::{ContentId, Source, SourceSegment};
 use parser::err::{ParseError, ParseErrorKind};
 
-use crate::pipeline::SourcesCache;
+use crate::pipeline::{SourceHolder, SourcesCache};
 
 macro_rules! print_flush {
     ( $($t:tt)* ) => {
@@ -113,7 +113,10 @@ pub fn display_diagnostic<W: Write>(
             .as_ref()
             .map_or(true, |s| s.id == content_id && s.reef == loc.reef)
         {
-            let source = sources.get(loc.reef, content_id).expect("Unknown source");
+            let source = sources
+                .get(loc.reef)
+                .and_then(|importer| importer.get_source(content_id))
+                .expect("Unknown source");
             let span = loc.segment.clone();
             diag = diag.and_label(LabeledSpan::new(obs.message, span.start, span.len()));
             displayed_source = Some(AttachedSource {

--- a/cli/src/std.rs
+++ b/cli/src/std.rs
@@ -1,5 +1,5 @@
 use crate::cli::{use_pipeline, Cli};
-use crate::pipeline::{ErrorReporter, FileImporter, PipelineStatus, SourcesCache};
+use crate::pipeline::{ErrorReporter, PipelineStatus, SourcesCache};
 use analyzer::analyze;
 use analyzer::name::Name;
 use analyzer::reef::{Externals, Reef};
@@ -10,13 +10,12 @@ use vm::VM;
 
 pub fn build_std(externals: &mut Externals, vm: &mut VM, sources: &mut SourcesCache, config: &Cli) {
     let std_file = find_std();
-    let mut importer = FileImporter::new(std_file);
+    sources.register(std_file);
+    let importer = sources.last_mut();
 
     let name = Name::new("std");
-    let mut analyzer = analyze(name.clone(), &mut importer, externals);
+    let mut analyzer = analyze(name.clone(), importer, externals);
     let diagnostics = analyzer.take_diagnostics();
-
-    sources.set(externals.current, importer.take_sources());
 
     let status = use_pipeline(
         &name,

--- a/compiler/src/emit/invoke.rs
+++ b/compiler/src/emit/invoke.rs
@@ -108,8 +108,6 @@ pub fn emit_process_call(
         // the stack if the value isn't used later in the code
         instructions.emit_pop(ValueStackSize::Byte);
     }
-
-
 }
 
 fn emit_process_call_self(


### PR DESCRIPTION
The REPL would previously forget all previous prompt sources.

Tested with `MIRIFLAGS="-Zmiri-disable-isolation" cargo +nightly miri run`.