### PR TITLE
Delimit strings in lexer and unescape

### DIFF
--- a/ast/src/match.rs
+++ b/ast/src/match.rs
@@ -1,6 +1,6 @@
 use dbg_pls::DebugPls;
 
-use context::source::SourceSegment;
+use context::source::{SourceSegment, SourceSegmentHolder};
 use src_macros::segment_holder;
 
 use crate::value::{Literal, TemplateString};
@@ -39,4 +39,15 @@ pub enum MatchPattern<'a> {
     VarRef(VarReference<'a>),
     Literal(Literal),
     Template(TemplateString<'a>),
+}
+
+impl SourceSegmentHolder for MatchPattern<'_> {
+    fn segment(&self) -> SourceSegment {
+        match self {
+            Self::Wildcard(segment) => segment.clone(),
+            Self::VarRef(var_ref) => var_ref.segment(),
+            Self::Literal(literal) => literal.segment(),
+            Self::Template(template) => template.segment(),
+        }
+    }
 }

--- a/lexer/src/lib.rs
+++ b/lexer/src/lib.rs
@@ -10,7 +10,7 @@ pub mod token;
 pub fn lex(input: &str) -> (Vec<Token>, Vec<UnmatchedDelimiter>) {
     let mut stream = TokenStream::new(input);
     let tokens = Vec::from_iter(&mut stream);
-    let mismatches = stream.mismatches;
+    let mismatches = stream.lexer.mismatches;
     (tokens, mismatches)
 }
 
@@ -18,9 +18,31 @@ pub fn lex(input: &str) -> (Vec<Token>, Vec<UnmatchedDelimiter>) {
 pub fn is_unterminated(input: &str) -> bool {
     let mut stream = TokenStream::new(input);
     for _ in stream.by_ref() {}
-    !stream.mismatches.is_empty()
+    !stream.lexer.mismatches.is_empty()
         && stream
+            .lexer
             .mismatches
             .into_iter()
             .all(|unmatched| unmatched.candidate.is_none())
+}
+
+pub fn unescape(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next().expect("Unterminated escape sequence") {
+                'n' => output.push('\n'),
+                'r' => output.push('\r'),
+                't' => output.push('\t'),
+                '\\' => output.push('\\'),
+                '"' => output.push('"'),
+                '\'' => output.push('\''),
+                _ => output.push(c),
+            }
+        } else {
+            output.push(c);
+        }
+    }
+    output
 }

--- a/lexer/src/literal.rs
+++ b/lexer/src/literal.rs
@@ -133,18 +133,4 @@ impl<'a> Lexer<'a> {
         }
         Token::new(TokenType::Space, &self.input[start_pos..pos])
     }
-
-    /// Returns `true` if the lexer is currently in a string.
-    pub(crate) fn is_in_string(&self) -> bool {
-        self.string_depth & 1 == 1
-    }
-
-    /// Toggles the string state.
-    pub(crate) fn toggle_in_string_state(&mut self) {
-        if self.is_in_string() {
-            self.string_depth -= 1;
-        } else {
-            self.string_depth += 1;
-        }
-    }
 }

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -35,6 +35,10 @@ pub enum TokenType {
     #[assoc(str = "val")]
     Val,
 
+    StringStart,
+    StringEnd,
+    StringContent,
+    StringLiteral,
     Identifier,
 
     IntLiteral,
@@ -100,10 +104,6 @@ pub enum TokenType {
     SemiColon,
     #[assoc(str = "=")]
     Equal,
-    #[assoc(str = "'")]
-    Quote,
-    #[assoc(str = "\"")]
-    DoubleQuote,
     #[assoc(str = "$")]
     Dollar,
     #[assoc(str = "&")]
@@ -257,8 +257,6 @@ impl TokenType {
                 | Bar
                 | Or
                 | And
-                | Quote
-                | DoubleQuote
                 | SquaredLeftBracket
                 | SquaredRightBracket
                 | RoundedLeftBracket
@@ -280,17 +278,13 @@ impl TokenType {
     ///is this lexeme a opening punctuation
     pub fn is_opening_ponctuation(self) -> bool {
         matches!(self, |SquaredLeftBracket| RoundedLeftBracket
-            | CurlyLeftBracket
-            | Quote
-            | DoubleQuote)
+            | CurlyLeftBracket)
     }
 
     ///is this lexeme a closing punctuation
     pub fn is_closing_ponctuation(self) -> bool {
         matches!(self, |SquaredRightBracket| RoundedRightBracket
-            | CurlyRightBracket
-            | Quote
-            | DoubleQuote)
+            | CurlyRightBracket)
     }
 
     /// Tests if this token ends an expression, where newlines are not allowed.
@@ -319,8 +313,6 @@ impl TokenType {
             SquaredLeftBracket => Some(SquaredRightBracket),
             RoundedLeftBracket => Some(RoundedRightBracket),
             CurlyLeftBracket => Some(CurlyRightBracket),
-            Quote => Some(Quote),
-            DoubleQuote => Some(DoubleQuote),
             _ => None,
         }
     }

--- a/lexer/tests/sample.rs
+++ b/lexer/tests/sample.rs
@@ -14,19 +14,7 @@ fn string_literal() {
     assert_eq!(
         tokens,
         vec![
-            Token::new(TokenType::Quote, "'"),
-            Token::new(TokenType::Identifier, "It"),
-            Token::new(TokenType::Identifier, "'"),
-            Token::new(TokenType::Identifier, "s"),
-            Token::new(TokenType::Space, " "),
-            Token::new(TokenType::Identifier, "http"),
-            Token::new(TokenType::Colon, ":"),
-            Token::new(TokenType::Identifier, "/"),
-            Token::new(TokenType::Identifier, "/localhost"),
-            Token::new(TokenType::Space, "  "),
-            Token::new(TokenType::Identifier, "/"),
-            Token::new(TokenType::Identifier, "/true"),
-            Token::new(TokenType::Quote, "'"),
+            Token::new(TokenType::StringLiteral, "It\\'s http://localhost  //true"),
             Token::new(TokenType::Space, " "),
             Token::new(TokenType::NewLine, "\n"),
             Token::new(TokenType::Identifier, "yes"),
@@ -66,7 +54,7 @@ fn string_literal_unterminated_due_to_comment() {
         vec![
             Token::new(TokenType::Identifier, "echo"),
             Token::new(TokenType::Space, " "),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringStart, "\""),
             Token::new(TokenType::Dollar, "$"),
             Token::new(TokenType::RoundedLeftBracket, "("),
         ]
@@ -81,10 +69,10 @@ fn string_literal_comment_after_arithmetic() {
         vec![
             Token::new(TokenType::Identifier, "echo"),
             Token::new(TokenType::Space, " "),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringStart, "\""),
             Token::new(TokenType::Dollar, "$"),
             Token::new(TokenType::RoundedLeftBracket, "("),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringStart, "\""),
             Token::new(TokenType::Dollar, "$"),
             Token::new(TokenType::RoundedLeftBracket, "("),
             Token::new(TokenType::RoundedLeftBracket, "("),
@@ -93,13 +81,11 @@ fn string_literal_comment_after_arithmetic() {
             Token::new(TokenType::IntLiteral, "1"),
             Token::new(TokenType::RoundedRightBracket, ")"),
             Token::new(TokenType::RoundedRightBracket, ")"),
-            Token::new(TokenType::Identifier, "/"),
-            Token::new(TokenType::Identifier, "/"),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringContent, "//"),
+            Token::new(TokenType::StringEnd, "\""),
             Token::new(TokenType::RoundedRightBracket, ")"),
-            Token::new(TokenType::Identifier, "/"),
-            Token::new(TokenType::Identifier, "/"),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringContent, "//"),
+            Token::new(TokenType::StringEnd, "\""),
         ]
     );
 }
@@ -116,9 +102,9 @@ fn utf8_compatible() {
             Token::new(TokenType::Space, " "),
             Token::new(TokenType::Equal, "="),
             Token::new(TokenType::Space, " "),
-            Token::new(TokenType::DoubleQuote, "\""),
-            Token::new(TokenType::Identifier, "épique"),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringStart, "\""),
+            Token::new(TokenType::StringContent, "épique"),
+            Token::new(TokenType::StringEnd, "\""),
         ]
     );
 }
@@ -167,24 +153,24 @@ fn literal_in_literal() {
         vec![
             Token::new(TokenType::Identifier, "echo"),
             Token::new(TokenType::Space, " "),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringStart, "\""),
             Token::new(TokenType::Dollar, "$"),
             Token::new(TokenType::RoundedLeftBracket, "("),
             Token::new(TokenType::Identifier, "ls"),
             Token::new(TokenType::Space, " "),
-            Token::new(TokenType::DoubleQuote, "\""),
-            Token::new(TokenType::Identifier, "tes"),
+            Token::new(TokenType::StringStart, "\""),
+            Token::new(TokenType::StringContent, "tes"),
             Token::new(TokenType::Dollar, "$"),
             Token::new(TokenType::RoundedLeftBracket, "("),
             Token::new(TokenType::Identifier, "echo"),
             Token::new(TokenType::Space, " "),
-            Token::new(TokenType::DoubleQuote, "\""),
-            Token::new(TokenType::Identifier, "t"),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringStart, "\""),
+            Token::new(TokenType::StringContent, "t"),
+            Token::new(TokenType::StringEnd, "\""),
             Token::new(TokenType::RoundedRightBracket, ")"),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringEnd, "\""),
             Token::new(TokenType::RoundedRightBracket, ")"),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringEnd, "\""),
         ]
     );
 }
@@ -195,17 +181,15 @@ fn var_in_literal() {
     assert_eq!(
         tokens,
         vec![
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringStart, "\""),
             Token::new(TokenType::Dollar, "$"),
             Token::new(TokenType::Identifier, "a"),
-            Token::new(TokenType::Space, " "),
-            Token::new(TokenType::Equal, "="),
-            Token::new(TokenType::Space, " "),
+            Token::new(TokenType::StringContent, " = "),
             Token::new(TokenType::Dollar, "$"),
             Token::new(TokenType::CurlyLeftBracket, "{"),
             Token::new(TokenType::Identifier, "b"),
             Token::new(TokenType::CurlyRightBracket, "}"),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringEnd, "\""),
         ]
     );
 }
@@ -218,9 +202,8 @@ fn quoted_arithmetic() {
         vec![
             Token::new(TokenType::Identifier, "echo"),
             Token::new(TokenType::Space, " "),
-            Token::new(TokenType::DoubleQuote, "\""),
-            Token::new(TokenType::Identifier, "Result"),
-            Token::new(TokenType::Space, " "),
+            Token::new(TokenType::StringStart, "\""),
+            Token::new(TokenType::StringContent, "Result "),
             Token::new(TokenType::Dollar, "$"),
             Token::new(TokenType::RoundedLeftBracket, "("),
             Token::new(TokenType::RoundedLeftBracket, "("),
@@ -231,7 +214,7 @@ fn quoted_arithmetic() {
             Token::new(TokenType::IntLiteral, "3"),
             Token::new(TokenType::RoundedRightBracket, ")"),
             Token::new(TokenType::RoundedRightBracket, ")"),
-            Token::new(TokenType::DoubleQuote, "\""),
+            Token::new(TokenType::StringEnd, "\""),
         ]
     );
 }

--- a/parser/src/aspects/if_else.rs
+++ b/parser/src/aspects/if_else.rs
@@ -248,7 +248,7 @@ mod tests {
                                         Expr::TemplateString(TemplateString {
                                             parts: vec![
                                                 literal(content, "+"),
-                                                literal(content, "\"%Y\"")
+                                                literal(content, "%Y")
                                             ],
                                             segment: find_in(content, "+\"%Y\"")
                                         })
@@ -265,11 +265,11 @@ mod tests {
                         segment: find_between(content, "[", "]"),
                     })),
                     success_branch: Box::new(Expr::TemplateString(TemplateString {
-                        parts: vec![literal(content, "\"bash\"")],
+                        parts: vec![literal(content, "bash")],
                         segment: find_in(content, "\"bash\"")
                     })),
                     fail_branch: Some(Box::new(Expr::TemplateString(TemplateString {
-                        parts: vec![literal(content, "\"moshell\"")],
+                        parts: vec![literal(content, "moshell")],
                         segment: find_in(content, "\"moshell\"")
                     }))),
                     segment: find_between(content, "if", "\"moshell\""),

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -233,12 +233,18 @@ fn do_not_accumulate_delimiters2() {
 fn no_comma_or_two() {
     let content = "fun test[@](a b,,c) = '";
     let source = Source::unknown(content);
-    let report = parse(source);
+    let mut report = parse(source);
+    report.expr.clear();
     assert_eq!(
         report,
         ParseReport {
             expr: vec![],
             errors: vec![
+                ParseError {
+                    message: "Unterminated string literal.".to_owned(),
+                    position: content.len()..content.len(),
+                    kind: ParseErrorKind::Unpaired(content.find('\'').map(|p| p..p + 1).unwrap())
+                },
                 ParseError {
                     message: "'@' is not a valid generic type identifier.".to_owned(),
                     position: content.find('@').map(|p| p..p + 1).unwrap(),
@@ -253,11 +259,6 @@ fn no_comma_or_two() {
                     message: "Expected parameter.".to_owned(),
                     position: content.rfind(',').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected
-                },
-                ParseError {
-                    message: "Unterminated string literal.".to_owned(),
-                    position: content.len()..content.len(),
-                    kind: ParseErrorKind::Unpaired(content.find('\'').map(|p| p..p + 1).unwrap())
                 }
             ],
         }

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -67,7 +67,7 @@ fn with_lexer_var_reference_two() {
             arguments: vec![
                 Expr::TemplateString(TemplateString {
                     parts: vec![
-                        literal(source.source, "\"fake"),
+                        literal(source.source, "fake"),
                         Expr::VarReference(VarReference {
                             name: "cmd",
                             segment: find_in(source.source, "$cmd"),
@@ -104,7 +104,7 @@ fn with_lexer_var_reference_three() {
                 literal(source.source, "echo"),
                 Expr::TemplateString(TemplateString {
                     parts: vec![
-                        literal(source.source, "\"hello "),
+                        literal(source.source, "hello "),
                         Expr::VarReference(VarReference {
                             name: "world",
                             segment: find_in(source.source, "$world"),
@@ -118,7 +118,7 @@ fn with_lexer_var_reference_three() {
                             name: "ready",
                             segment: find_in(source.source, "${ready}"),
                         }),
-                        literal(source.source, "!\""),
+                        literal(source.source, "!"),
                     ],
                     segment: find_between(source.source, "\"", "\""),
                 }),
@@ -303,7 +303,7 @@ fn with_lexer_substitution_in_substitution() {
                                             },
                                             kind: SubstitutionKind::Capture,
                                         }),
-                                        literal(source.source, "/test\""),
+                                        literal(source.source, "/test"),
                                     ],
                                     segment: find_in(source.source, "\"$(pwd)/test\""),
                                 }),


### PR DESCRIPTION
Unescape escaped characters, and fixes mismatched delimiters for the CLI by using a special lexer state for strings.

Sample test:
```kt
val msg = 'a\r\nb\')'
echo $msg
```