### PR TITLE
Introduce an optional type

### DIFF
--- a/analyzer/src/steps/typing/coercion.rs
+++ b/analyzer/src/steps/typing/coercion.rs
@@ -117,7 +117,10 @@ pub(super) fn resolve_type_annotation(
                 }
             };
 
-            let generics = &exploration.get_description(main_type).unwrap().generics;
+            let generics = &exploration
+                .get_description(main_type)
+                .map(|d| d.generics.as_slice())
+                .unwrap_or(&[]);
             if params.len() != generics.len() {
                 diagnostics.push(
                     Diagnostic::new(

--- a/analyzer/src/steps/typing/view.rs
+++ b/analyzer/src/steps/typing/view.rs
@@ -33,7 +33,7 @@ impl fmt::Display for TypeInstance<'_> {
             Type::Nothing => write!(f, "Nothing"),
             Type::Unit => write!(f, "Unit"),
             Type::Bool => write!(f, "Bool"),
-            Type::ExitCode => write!(f, "ExitCode"),
+            Type::ExitCode => write!(f, "Exitcode"),
             Type::Int => write!(f, "Int"),
             Type::Float => write!(f, "Float"),
             Type::String => write!(f, "String"),
@@ -46,6 +46,7 @@ impl fmt::Display for TypeInstance<'_> {
                 }
             ),
             Type::Vector => write!(f, "Vec"),
+            Type::Option => write!(f, "Option"),
             Type::Polytype => write!(f, "T"),
             Type::Instantiated(def, parameters) => {
                 write!(f, "{}[", TypeInstance::new(*def, self.exploration))?;

--- a/analyzer/src/types.rs
+++ b/analyzer/src/types.rs
@@ -49,7 +49,8 @@ pub const INT: TypeRef = TypeRef::new(LANG_REEF, TypeId(5));
 pub const FLOAT: TypeRef = TypeRef::new(LANG_REEF, TypeId(6));
 pub const STRING: TypeRef = TypeRef::new(LANG_REEF, TypeId(7));
 pub const GENERIC_VECTOR: TypeRef = TypeRef::new(LANG_REEF, TypeId(8));
-pub const POLYTYPE: TypeRef = TypeRef::new(LANG_REEF, TypeId(9));
+pub const GENERIC_OPTION: TypeRef = TypeRef::new(LANG_REEF, TypeId(9));
+pub const POLYTYPE: TypeRef = TypeRef::new(LANG_REEF, TypeId(10));
 
 /// An error that occurs when two types are not compatible.
 #[derive(Debug, PartialEq)]

--- a/analyzer/src/types/builtin.rs
+++ b/analyzer/src/types/builtin.rs
@@ -8,7 +8,8 @@ use crate::types::engine::TypedEngine;
 use crate::types::operator::name_operator_method;
 use crate::types::ty::{MethodType, Type, TypeId, TypeRef};
 use crate::types::{
-    Typing, BOOL, EXITCODE, FLOAT, GENERIC_VECTOR, INT, NOTHING, POLYTYPE, STRING, UNIT,
+    Typing, BOOL, EXITCODE, FLOAT, GENERIC_OPTION, GENERIC_VECTOR, INT, NOTHING, POLYTYPE, STRING,
+    UNIT,
 };
 
 const ARITHMETIC_OPERATORS: &[BinaryOperator] = &[
@@ -141,14 +142,14 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine) {
         "split",
         MethodType::native(
             vec![STRING],
-            TypeRef::new(LANG_REEF, TypeId(10)),
+            TypeRef::new(LANG_REEF, TypeId(11)),
             gen.next(),
         ),
     );
     engine.add_method(
         STRING.type_id,
         "bytes",
-        MethodType::native(vec![], TypeRef::new(LANG_REEF, TypeId(11)), gen.next()),
+        MethodType::native(vec![], TypeRef::new(LANG_REEF, TypeId(12)), gen.next()),
     );
 
     for operand in [BOOL, EXITCODE] {
@@ -167,6 +168,23 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine) {
             MethodType::native(vec![], operand, gen.next()),
         );
     }
+
+    engine.add_generic(GENERIC_OPTION.type_id, POLYTYPE);
+    engine.add_method(
+        GENERIC_OPTION.type_id,
+        "is_none",
+        MethodType::native(vec![], BOOL, gen.next()),
+    );
+    engine.add_method(
+        GENERIC_OPTION.type_id,
+        "is_some",
+        MethodType::native(vec![], BOOL, gen.next()),
+    );
+    engine.add_method(
+        GENERIC_OPTION.type_id,
+        "unwrap",
+        MethodType::native(vec![], POLYTYPE, gen.next()),
+    );
 }
 
 fn fill_lang_types(typing: &mut Typing) {
@@ -180,6 +198,7 @@ fn fill_lang_types(typing: &mut Typing) {
         Type::Float,
         Type::String,
         Type::Vector,
+        Type::Option,
         Type::Polytype,
         Type::Instantiated(GENERIC_VECTOR, vec![STRING]),
         Type::Instantiated(GENERIC_VECTOR, vec![INT]),
@@ -199,6 +218,7 @@ fn fill_lang_bindings(ctx: &mut TypeContext) {
     ctx.bind_name("Float".to_string(), FLOAT.type_id);
     ctx.bind_name("String".to_string(), STRING.type_id);
     ctx.bind_name("Vec".to_string(), GENERIC_VECTOR.type_id);
+    ctx.bind_name("Option".to_string(), GENERIC_OPTION.type_id);
 }
 
 pub fn lang_reef() -> Reef<'static> {

--- a/analyzer/src/types/ty.rs
+++ b/analyzer/src/types/ty.rs
@@ -81,6 +81,9 @@ pub enum Type {
     /// A vector type, that contains a list of elements of the same type.
     Vector,
 
+    /// A nullable type, that can be either `null` or a value of a given type.
+    Option,
+
     /// A generic type, that can be instantiated with concrete type parameters.
     Polytype,
 

--- a/cli/lang_tests/flow/option_parse.msh
+++ b/cli/lang_tests/flow/option_parse.msh
@@ -1,0 +1,27 @@
+// Run:
+//   status: error
+//   stdout:
+//     8
+//     11
+//     true false
+//     170
+//     ok
+//   stderr:
+//     panic: Cannot unwrap `None`.
+//         at option_parse.msh (line 27)
+
+use std::convert::{parse_int, parse_int_radix}
+
+var n = parse_int('+8')
+echo $n.unwrap()
+n = parse_int_radix('1011', 2)
+echo $n.unwrap()
+
+n = parse_int('15t')
+echo $n.is_none() $n.is_some()
+n = parse_int_radix('aA', 16);
+echo $n.unwrap()
+if parse_int('').is_none() {
+  echo 'ok'
+}
+parse_int('0x').unwrap() // panic

--- a/compiler/src/emit/native.rs
+++ b/compiler/src/emit/native.rs
@@ -38,11 +38,10 @@ pub(crate) fn emit_natives(
     let last_used = state.use_values(true);
     emit(callee, instructions, ctx, cp, locals, state);
 
-    let pushed_size = match native.0 {
+    match native.0 {
         0 => {
             // ExitCode -> Bool
             instructions.emit_bool_inversion();
-            ValueStackSize::Byte
         }
         1..=9 => {
             // Arithmetic expression
@@ -66,12 +65,10 @@ pub(crate) fn emit_natives(
                 9 => Opcode::IntMod,
                 _ => unreachable!("Not a numeric binary expression"),
             });
-            ValueStackSize::QWord
         }
         10 => {
             // !bool
             instructions.emit_bool_inversion();
-            ValueStackSize::Byte
         }
         11..=26 => {
             // Comparison expression
@@ -125,7 +122,6 @@ pub(crate) fn emit_natives(
                 26 => instructions.emit_code(Opcode::FloatGreaterOrEqual),
                 _ => unreachable!("Not a comparison expression"),
             }
-            ValueStackSize::Byte
         }
         27 => {
             // Bool -> String
@@ -143,23 +139,19 @@ pub(crate) fn emit_natives(
             instructions.patch_jump(jump_to_else);
             instructions.emit_push_constant_ref(false_string);
             instructions.patch_jump(jump_to_end);
-            ValueStackSize::QWord
         }
         28 => {
             // ExitCode -> String
             instructions.emit_code(Opcode::ConvertByteToInt);
             instructions.emit_invoke(cp.insert_string(INT_TO_STRING));
-            ValueStackSize::QWord
         }
         29 => {
             // Int -> String
             instructions.emit_invoke(cp.insert_string(INT_TO_STRING));
-            ValueStackSize::QWord
         }
         30 => {
             // Float -> String
             instructions.emit_invoke(cp.insert_string(FLOAT_TO_STRING));
-            ValueStackSize::QWord
         }
         33 => {
             // String + String -> String
@@ -173,7 +165,6 @@ pub(crate) fn emit_natives(
                 state,
             );
             instructions.emit_invoke(cp.insert_string(STRING_CONCAT));
-            ValueStackSize::QWord
         }
         34 => {
             // vector[Int] -> T
@@ -186,12 +177,6 @@ pub(crate) fn emit_natives(
                 state,
             );
             instructions.emit_invoke(cp.insert_string(VEC_INDEX));
-            if state.use_values
-                && is_boxable_primitive(ctx.get_type(receiver_ty).expect("Invalid type"))
-            {
-                instructions.emit_code(Opcode::Unbox);
-            }
-            ValueStackSize::QWord
         }
         35 => {
             // vector.push(T)
@@ -205,22 +190,14 @@ pub(crate) fn emit_natives(
                 instructions.emit_code(Opcode::BoxInt);
             }
             instructions.emit_invoke(cp.insert_string(VEC_PUSH));
-            ValueStackSize::Zero
         }
         36 => {
             // vector.pop() T
             instructions.emit_invoke(cp.insert_string(VEC_POP));
-            if state.use_values
-                && is_boxable_primitive(ctx.get_type(receiver_ty).expect("Invalid type"))
-            {
-                instructions.emit_code(Opcode::Unbox);
-            }
-            ValueStackSize::QWord
         }
         37 => {
             // vector.len()
             instructions.emit_invoke(cp.insert_string(VEC_LEN));
-            ValueStackSize::QWord
         }
         38 => {
             // string.split(delim)
@@ -234,12 +211,10 @@ pub(crate) fn emit_natives(
                 state,
             );
             instructions.emit_invoke(cp.insert_string(STRING_SPLIT));
-            ValueStackSize::QWord
         }
         39 => {
             // string.bytes()
             instructions.emit_invoke(cp.insert_string(STRING_BYTES));
-            ValueStackSize::QWord
         }
         40 | 42 => {
             // Bool && Bool -> Bool
@@ -260,7 +235,6 @@ pub(crate) fn emit_natives(
                 state,
             );
             instructions.patch_jump(end_jump);
-            ValueStackSize::Byte
         }
         41 | 43 => {
             // Bool || Bool -> Bool
@@ -283,25 +257,45 @@ pub(crate) fn emit_natives(
                 state,
             );
             instructions.patch_jump(end_jump);
-            ValueStackSize::Byte
         }
         44 => {
             // -Int -> Int
             instructions.emit_code(Opcode::IntNeg);
-            ValueStackSize::QWord
         }
         45 => {
             // -Float -> Float
             instructions.emit_code(Opcode::FloatNeg);
-            ValueStackSize::QWord
+        }
+        46 | 47 => {
+            // Option[T].is_some() -> bool
+            instructions.emit_push_int(0);
+            instructions.emit_code(Opcode::IntEqual);
+            if native.0 == 47 {
+                instructions.emit_bool_inversion();
+            }
+        }
+        48 => {
+            // Option[T].unwrap() -> T
+            instructions.emit_code(Opcode::Dup);
+            instructions.emit_push_int(0);
+            instructions.emit_code(Opcode::IntEqual);
+            let end_jump = instructions.emit_jump(Opcode::IfNotJump);
+            instructions.emit_push_constant_ref(cp.insert_string("Cannot unwrap `None`."));
+            instructions.emit_invoke(cp.insert_string("std::panic"));
+            instructions.patch_jump(end_jump);
         }
         id => todo!("Native function with id {id}"),
     };
+
+    let has_generic_return = matches!(native.0, 34 | 36 | 48);
+    if has_generic_return && !receiver_ty.is_obj() {
+        instructions.emit_code(Opcode::Unbox);
+    }
 
     // restore last state of use_values
     state.use_values(last_used);
 
     if !state.use_values {
-        instructions.emit_pop(pushed_size);
+        instructions.emit_pop(ValueStackSize::from(receiver_ty));
     }
 }

--- a/lib/std.msh
+++ b/lib/std.msh
@@ -13,18 +13,12 @@ fun panic(message: String) -> Nothing;
 fun exit(code: Exitcode) -> Nothing;
 
 /// @returns string value of given environment variable
-/// @panics if the environment variable isn't set
-fun env(name: String) -> String;
+fun env(name: String) -> Option[String];
 
 /// Set or override a given environment variable with given string value.
 /// @param name the targeted environment variable name.
 /// @param value the new value of targeted variable.
 fun set_env(name: String, value: String);
-
-/// Tests if given environment variable is defined.
-/// @returns true if the given environment variable has a defined value
-/// @param name the targeted environment variable name
-fun is_env_def(name: String) -> Bool;
 
 /// Reads a single line from the standard input.
 ///

--- a/lib/std/convert.msh
+++ b/lib/std/convert.msh
@@ -10,3 +10,14 @@ fun floor(f: Float) -> Int;
 
 /// @returns nearest int value
 fun round(f: Float) -> Int;
+
+/// Converts a string to an integer.
+fun parse_int(str: String) -> Option[Int] = parse_int_radix($str, 10);
+
+/// Parses a string in a given base to an integer.
+///
+/// The string is expected to be an optional `+` or `-` sign followed by digits.
+/// Leading and trailing characters represent an error.
+///
+/// @panics if `base` is not in the range 2..36
+fun parse_int_radix(str: String, base: Int) -> Option[Int];

--- a/vm/src/memory/gc.cpp
+++ b/vm/src/memory/gc.cpp
@@ -156,7 +156,9 @@ void gc::scan_thread(std::vector<const msh::obj *> &roots) {
             // this byte is marked as the first byte of an object reference
             if (operands_refs_offsets[frame_operands_first_byte + operand_index]) {
                 msh::obj *obj_ref = *(msh::obj **)(frame.operands.bytes + operand_index);
-                roots.push_back(obj_ref);
+                if (obj_ref != nullptr) { // might be not yet initialized
+                    roots.push_back(obj_ref);
+                }
                 operand_index += 8;
             } else {
                 operand_index++;


### PR DESCRIPTION
Add a nullable reference type.

The null pointer is checked at runtime when unwrapping. This `Option` type is used when parsing integers or accessing an environment variable via the API.

This can be extended in the future with pattern matching.