### PR TITLE
Parse and analyze subscripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Moshell is a project in its early stages.
   - [x] Standard shell expressions
   - [x] Control flow
   - [x] Type hints
-  - [ ] Array indexing and ranges *(in progress)*
+  - [x] Array indexing and ranges
   - [x] User defined structures
   - [ ] User defined enums
 - [x] Static analysis
@@ -151,5 +151,3 @@ Moshell is a project in its early stages.
   - [ ] Display diagnostics *(partial)*
   - [x] Symbol reuse
   - [ ] Shell-like prompt
-
-

--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -516,6 +516,10 @@ impl<'a, 'b, 'e> SymbolCollector<'a, 'b, 'e> {
                 }
                 Iterable::Files(_) => {}
             },
+            Expr::Subscript(sub) => {
+                self.tree_walk(state, &sub.target, to_visit);
+                self.tree_walk(state, &sub.index, to_visit);
+            }
             Expr::Substitution(sub) => {
                 self.current_env().begin_scope();
                 for expr in &sub.underlying.expressions {

--- a/analyzer/src/steps/typing/assign.rs
+++ b/analyzer/src/steps/typing/assign.rs
@@ -1,0 +1,144 @@
+use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
+use crate::steps::typing::exploration::{Exploration, Links};
+use crate::steps::typing::function::{
+    find_exact_method, find_operand_implementation, list_operator_defined_for, BinaryMethodMatch,
+};
+use crate::steps::typing::{ascribe_types, TypingState};
+use crate::types::hir::{ExprKind, MethodCall, TypedExpr};
+use ast::range::Subscript;
+use ast::variable::Assign;
+use context::source::SourceSegmentHolder;
+
+pub(super) fn create_subscript(
+    sub: &Subscript,
+    exploration: &mut Exploration,
+    links: Links,
+    diagnostics: &mut Vec<Diagnostic>,
+    state: TypingState,
+) -> Result<BinaryMethodMatch, TypedExpr> {
+    let target = ascribe_types(exploration, links, diagnostics, &sub.target, state);
+    let index = ascribe_types(exploration, links, diagnostics, &sub.index, state);
+    if index.ty.is_err() || target.ty.is_err() {
+        return Err(target);
+    }
+
+    let index_ty = index.ty;
+    let target_ty = target.ty;
+    let methods = exploration
+        .get_methods(target.ty, "[]")
+        .map(|methods| methods.as_slice())
+        .unwrap_or(&[]);
+    let method = find_operand_implementation(exploration, target.ty.reef, methods, target, index);
+    match method {
+        Ok(method) => Ok(method),
+        Err(target) => {
+            diagnostics.push(if !methods.is_empty() {
+                Diagnostic::new(
+                    DiagnosticID::UnknownMethod,
+                    format!(
+                        "Cannot index into a value of type `{}`",
+                        exploration.get_type(target_ty)
+                    ),
+                )
+                .with_observation(Observation::here(
+                    links.source,
+                    exploration.externals.current,
+                    sub.index.segment(),
+                    format!(
+                        "`{}` indices are of type {}",
+                        exploration.get_type(target_ty),
+                        list_operator_defined_for(exploration, methods),
+                    ),
+                ))
+            } else {
+                Diagnostic::new(
+                    DiagnosticID::UnknownMethod,
+                    format!(
+                        "The type `{}` cannot be indexed by `{}`",
+                        exploration.get_type(target_ty),
+                        exploration.get_type(index_ty)
+                    ),
+                )
+                .with_observation(Observation::here(
+                    links.source,
+                    exploration.externals.current,
+                    sub.index.segment(),
+                    format!(
+                        "Indexing with `{}` is invalid",
+                        exploration.get_type(index_ty)
+                    ),
+                ))
+            });
+            Err(target)
+        }
+    }
+}
+
+pub(super) fn ascribe_assign_subscript(
+    assign: &Assign,
+    sub: &Subscript,
+    rhs: TypedExpr,
+    exploration: &mut Exploration,
+    links: Links,
+    diagnostics: &mut Vec<Diagnostic>,
+    state: TypingState,
+) -> TypedExpr {
+    // Require first that normal subscripting is available
+    let Ok(BinaryMethodMatch {
+        left: target,
+        right: index,
+        ..
+    }) = create_subscript(
+        sub,
+        exploration,
+        links,
+        diagnostics,
+        state.with_local_type(),
+    )
+    else {
+        return rhs.poison();
+    };
+
+    let rhs_segment = rhs.segment();
+    let rhs_ty = rhs.ty;
+    let methods = exploration
+        .get_methods(target.ty, "[]")
+        .map(|methods| methods.as_slice())
+        .unwrap_or(&[]);
+    let mut args = vec![index, rhs];
+    let method = find_exact_method(exploration, target.ty, methods, args.as_slice());
+    if let Some(method) = method {
+        let return_type = exploration.concretize(method.return_type, target.ty).id;
+        return TypedExpr {
+            kind: ExprKind::MethodCall(MethodCall {
+                callee: Box::new(target),
+                arguments: args,
+                definition: method.definition,
+            }),
+            ty: return_type,
+            segment: assign.segment(),
+        };
+    }
+    diagnostics.push(
+        Diagnostic::new(
+            DiagnosticID::TypeMismatch,
+            format!(
+                "Invalid assignment to `{}`",
+                exploration.get_type(target.ty)
+            ),
+        )
+        .with_observation(Observation::here(
+            links.source,
+            exploration.externals.current,
+            rhs_segment,
+            format!("Found `{}`", exploration.get_type(rhs_ty)),
+        ))
+        .with_observation(Observation::context(
+            links.source,
+            exploration.externals.current,
+            sub.segment(),
+            "Expected due to the type of this binding",
+        )),
+    );
+    args.pop().unwrap().poison()
+}

--- a/analyzer/src/steps/typing/function.rs
+++ b/analyzer/src/steps/typing/function.rs
@@ -11,7 +11,7 @@ use crate::steps::typing::coercion::{
     convert_description, convert_expression, convert_many, resolve_type_annotation,
 };
 use crate::steps::typing::exploration::{Exploration, Links};
-use crate::steps::typing::view::TypeInstance;
+use crate::steps::typing::view::{TypeInstance, TypeInstanceVec};
 use crate::types::engine::CodeEntry;
 use crate::types::hir::{ExprKind, TypedExpr};
 use crate::types::ty::{FunctionType, MethodType, Parameter, Type, TypeRef};
@@ -314,6 +314,24 @@ pub(super) fn find_operand_implementation(
         }
     }
     None
+}
+
+/// Creates a list of the type parameters of methods.
+pub(super) fn list_operator_defined_for<'a>(
+    exploration: &'a Exploration,
+    methods: &[MethodType],
+) -> TypeInstanceVec<'a> {
+    let types = methods
+        .iter()
+        .flat_map(|method| {
+            if let [param] = &method.parameters.as_slice() {
+                Some(param.ty)
+            } else {
+                None
+            }
+        })
+        .collect();
+    TypeInstanceVec::new(types, exploration)
 }
 
 /// Checks the type of a method expression.

--- a/analyzer/src/steps/typing/view.rs
+++ b/analyzer/src/steps/typing/view.rs
@@ -61,3 +61,39 @@ impl fmt::Display for TypeInstance<'_> {
         }
     }
 }
+
+pub struct TypeInstanceVec<'a> {
+    pub(super) ids: Vec<TypeRef>,
+    pub(super) exploration: &'a Exploration<'a>,
+}
+
+impl<'a> TypeInstanceVec<'a> {
+    pub(super) fn new(ids: Vec<TypeRef>, exploration: &'a Exploration) -> Self {
+        Self { ids, exploration }
+    }
+}
+
+impl fmt::Debug for TypeInstanceVec<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[")?;
+        for (i, id) in self.ids.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}", TypeInstance::new(*id, self.exploration))?;
+        }
+        write!(f, "]")
+    }
+}
+
+impl fmt::Display for TypeInstanceVec<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (i, id) in self.ids.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "`{}`", TypeInstance::new(*id, self.exploration))?;
+        }
+        Ok(())
+    }
+}

--- a/analyzer/src/types/builtin.rs
+++ b/analyzer/src/types/builtin.rs
@@ -118,7 +118,7 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine) {
     engine.add_generic(GENERIC_VECTOR.type_id, POLYTYPE);
     engine.add_method(
         GENERIC_VECTOR.type_id,
-        "get",
+        "[]",
         MethodType::native(vec![INT], POLYTYPE, gen.next()),
     );
     engine.add_method(

--- a/analyzer/src/types/builtin.rs
+++ b/analyzer/src/types/builtin.rs
@@ -185,6 +185,11 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine) {
         "unwrap",
         MethodType::native(vec![], POLYTYPE, gen.next()),
     );
+    engine.add_method(
+        GENERIC_VECTOR.type_id,
+        "[]",
+        MethodType::native(vec![INT, POLYTYPE], UNIT, gen.next()),
+    );
 }
 
 fn fill_lang_types(typing: &mut Typing) {

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -14,7 +14,7 @@ use crate::r#match::Match;
 use crate::r#struct::{StructDeclaration, StructImpl};
 use crate::r#type::CastedExpr;
 use crate::r#use::Use;
-use crate::range::Iterable;
+use crate::range::{Iterable, Subscript};
 use crate::substitution::Substitution;
 use crate::test::Test;
 use crate::value::{Literal, TemplateString};
@@ -81,6 +81,7 @@ pub enum Expr<'a> {
     VarReference(VarReference<'a>),
     VarDeclaration(VarDeclaration<'a>),
     Range(Iterable<'a>),
+    Subscript(Subscript<'a>),
 
     FunctionDeclaration(FunctionDeclaration<'a>),
 
@@ -126,6 +127,7 @@ impl SourceSegmentHolder for Expr<'_> {
             Expr::VarReference(var_reference) => var_reference.segment.clone(),
             Expr::VarDeclaration(var_declaration) => var_declaration.segment.clone(),
             Expr::Range(range) => range.segment(),
+            Expr::Subscript(subscript) => subscript.segment(),
             Expr::FunctionDeclaration(function_declaration) => function_declaration.segment.clone(),
             Expr::Parenthesis(parenthesis) => parenthesis.segment.clone(),
             Expr::Subshell(subshell) => subshell.segment.clone(),

--- a/ast/src/range.rs
+++ b/ast/src/range.rs
@@ -57,3 +57,10 @@ pub struct FilePattern {
     /// For now, this is just a string that is passed to the libc.
     pub pattern: String,
 }
+
+#[segment_holder]
+#[derive(Debug, Clone, PartialEq, DebugPls)]
+pub struct Subscript<'a> {
+    pub target: Box<Expr<'a>>,
+    pub index: Box<Expr<'a>>,
+}

--- a/cli/lang_tests/flow/str_bytes.msh
+++ b/cli/lang_tests/flow/str_bytes.msh
@@ -4,6 +4,7 @@
 //    The alphabet has 26 letters.
 //    The first letter has the ASCII code 97.
 //    The last letter has the ASCII code 122.
+//    At is 64.
 
 val letters = 'abcdefghijklmnopqrstuvwxy'.bytes()
 $letters.push(122)
@@ -12,3 +13,7 @@ var code = $letters[0]
 echo "The first letter has the ASCII code ${code}."
 code = $letters[25]
 echo "The last letter has the ASCII code ${code}."
+
+$letters[0] = 64
+code = $letters[0]
+echo "At is ${code}."

--- a/cli/lang_tests/flow/str_bytes.msh
+++ b/cli/lang_tests/flow/str_bytes.msh
@@ -8,7 +8,7 @@
 val letters = 'abcdefghijklmnopqrstuvwxy'.bytes()
 $letters.push(122)
 echo "The alphabet has ${letters.len()} letters."
-var code = $letters.get(0)
+var code = $letters[0]
 echo "The first letter has the ASCII code ${code}."
-code = $letters.get(25)
+code = $letters[25]
 echo "The last letter has the ASCII code ${code}."

--- a/cli/lang_tests/flow/str_split.msh
+++ b/cli/lang_tests/flow/str_split.msh
@@ -10,5 +10,5 @@ echo "The len is ${v.len()}."
 $v.push('and more')
 echo "The new len is ${v.len()}."
 
-val chars = $v.get(4)
+val chars = $v[4]
 echo $chars

--- a/compiler/src/emit/native.rs
+++ b/compiler/src/emit/native.rs
@@ -13,6 +13,7 @@ const STRING_CONCAT: &str = "lang::String::concat";
 const INT_TO_STRING: &str = "lang::Int::to_string";
 const FLOAT_TO_STRING: &str = "lang::Float::to_string";
 const VEC_INDEX: &str = "lang::Vec::[]";
+const VEC_INDEX_EQ: &str = "lang::Vec::[]=";
 const VEC_POP: &str = "lang::Vec::pop";
 const VEC_PUSH: &str = "lang::Vec::push";
 const VEC_LEN: &str = "lang::Vec::len";
@@ -283,6 +284,16 @@ pub(crate) fn emit_natives(
             instructions.emit_push_constant_ref(cp.insert_string("Cannot unwrap `None`."));
             instructions.emit_invoke(cp.insert_string("std::panic"));
             instructions.patch_jump(end_jump);
+        }
+        49 => {
+            // Vec[T][int] = T
+            for arg in args {
+                emit(arg, instructions, ctx, cp, locals, state);
+            }
+            if is_boxable_primitive(ctx.get_type(args[1].ty).expect("Invalid type")) {
+                instructions.emit_code(Opcode::BoxInt);
+            }
+            instructions.emit_invoke(cp.insert_string(VEC_INDEX_EQ));
         }
         id => todo!("Native function with id {id}"),
     };

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -308,6 +308,41 @@ impl TokenType {
         )
     }
 
+    /// Determines if this token creates a shell context when at the start of a statement.
+    pub fn belongs_to_shell(self) -> bool {
+        matches!(
+            self,
+            StringStart
+                | StringLiteral
+                | StringContent
+                | StringEnd
+                | NewLine
+                | SemiColon
+                | Dollar
+                | Ampersand
+                | At
+                | Comma
+                | Dot
+                | Bar
+                | And
+                | Or
+                | Not
+                | Less
+                | Greater
+                | Plus
+                | Minus
+                | Star
+                | Slash
+                | BackSlash
+                | Percent
+                | SquaredRightBracket
+                | RoundedRightBracket
+                | CurlyRightBracket
+                | Space
+                | EndOfFile
+        )
+    }
+
     pub fn closing_pair(self) -> Option<TokenType> {
         match self {
             SquaredLeftBracket => Some(SquaredRightBracket),

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -1,9 +1,5 @@
 use ast::call::{Call, MethodCall, ProgrammaticCall};
-use ast::lambda::LambdaDef;
-use ast::r#type::Type;
 use ast::r#use::InclusionPathItem;
-use ast::value::Literal;
-use ast::variable::TypedVariable;
 use ast::Expr;
 use context::source::{SourceSegment, SourceSegmentHolder};
 use lexer::token::{Token, TokenType};
@@ -20,13 +16,10 @@ use crate::moves::{
     any, blanks, eog, identifier_parenthesis, like, line_end, lookahead, of_type, of_types, spaces,
     MoveOperations,
 };
-use crate::parser::{ensure_empty, ParseResult, Parser};
+use crate::parser::{ParseResult, Parser};
 
 /// A parse aspect for command and function calls
 pub trait CallAspect<'a> {
-    /// Parses a raw call, a programmatic call or a lambda definition.
-    fn any_call(&mut self) -> ParseResult<Expr<'a>>;
-
     /// Attempts to parse the next raw call expression
     fn call(&mut self) -> ParseResult<Expr<'a>>;
 
@@ -47,119 +40,8 @@ pub trait CallAspect<'a> {
 }
 
 impl<'a> CallAspect<'a> for Parser<'a> {
-    fn any_call(&mut self) -> ParseResult<Expr<'a>> {
-        let mut path = self.parse_inclusion_path()?;
-
-        // Equivalent to #may_be_at_programmatic_call_start, with an additional check for lambda definitions.
-        if self
-            .cursor
-            .lookahead(
-                any().and_then(
-                    of_types(&[
-                        TokenType::RoundedLeftBracket,
-                        TokenType::SquaredLeftBracket,
-                        TokenType::ColonColon,
-                    ])
-                    .or(spaces().then(of_type(TokenType::FatArrow))),
-                ),
-            )
-            .is_none()
-        {
-            ensure_empty(
-                "Command calls cannot have inclusion path",
-                path,
-                InclusionPathItem::segment,
-            )?;
-            return self.call();
-        }
-        // We don't known if this is a programmatic call, a raw call or a lambda definition yet.
-
-        let identifier = self.cursor.next()?;
-        let name = identifier.value;
-        let name_segment = self.cursor.relative_pos(name);
-        let callee = Expr::Literal(Literal {
-            parsed: name.into(),
-            segment: name_segment.clone(),
-        });
-        let (type_parameters, _) = self.parse_optional_list(
-            TokenType::SquaredLeftBracket,
-            TokenType::SquaredRightBracket,
-            "Expected type argument.",
-            Parser::parse_type,
-        )?;
-
-        if let Some(open_parenthesis) = self.cursor.advance(of_type(TokenType::RoundedLeftBracket))
-        {
-            let (arguments, args_segment) =
-                self.parse_comma_separated_arguments(open_parenthesis)?;
-
-            let start = path
-                .first()
-                .map(InclusionPathItem::segment)
-                .unwrap_or_else(|| name_segment.clone());
-
-            path.push(InclusionPathItem::Symbol(name, name_segment));
-            Ok(Expr::ProgrammaticCall(ProgrammaticCall {
-                path,
-                arguments,
-                type_parameters,
-                segment: start.start..args_segment.end,
-            }))
-        } else if self
-            .cursor
-            .advance(spaces().then(of_type(TokenType::FatArrow)))
-            .is_some()
-        {
-            ensure_empty(
-                "Illegal expression before lambda parameter declaration",
-                path,
-                InclusionPathItem::segment,
-            )?;
-            ensure_empty(
-                "Illegal expression after lambda parameter declaration",
-                type_parameters,
-                Type::segment,
-            )?;
-            let body = Box::new(self.value()?);
-            let segment = name_segment.start..body.segment().end;
-            Ok(Expr::LambdaDef(LambdaDef {
-                args: vec![TypedVariable {
-                    name,
-                    ty: None,
-                    segment: self.cursor.relative_pos(name),
-                }],
-                body,
-                segment,
-            }))
-        } else {
-            ensure_empty(
-                "Command calls cannot have generic arguments",
-                type_parameters,
-                Type::segment,
-            )?;
-            ensure_empty(
-                "Command calls cannot have inclusion path",
-                path,
-                InclusionPathItem::segment,
-            )?;
-            self.call_arguments(callee)
-        }
-    }
-
     fn call(&mut self) -> ParseResult<Expr<'a>> {
         let callee = self.call_argument()?;
-        let (type_parameters, _) = self.parse_optional_list(
-            TokenType::SquaredLeftBracket,
-            TokenType::SquaredRightBracket,
-            "Expected type argument.",
-            Parser::parse_type,
-        )?;
-
-        ensure_empty(
-            "Command calls cannot have generic arguments",
-            type_parameters,
-            Type::segment,
-        )?;
         self.call_arguments(callee)
     }
 
@@ -418,57 +300,6 @@ mod tests {
                 position: find_in(source.source, "reef"),
                 kind: ParseErrorKind::Expected("identifier".to_string())
             }
-        );
-    }
-
-    #[test]
-    fn call_with_inclusion_path() {
-        let source = Source::unknown("a::b::c x y");
-        assert_eq!(
-            Parser::new(source).parse_next(),
-            Err(ParseError {
-                message: "Command calls cannot have inclusion path".to_string(),
-                position: find_in(source.source, "a::b"),
-                kind: ParseErrorKind::Unexpected,
-            })
-        );
-    }
-
-    #[test]
-    fn lambdef_with_inclusion_path() {
-        let source = Source::unknown("a::b => $b");
-        assert_eq!(
-            Parser::new(source).parse_next(),
-            Err(ParseError {
-                message: "Illegal expression before lambda parameter declaration".to_string(),
-                position: find_in(source.source, "a"),
-                kind: ParseErrorKind::Unexpected,
-            })
-        );
-    }
-
-    #[test]
-    fn lambdef_with_type_params() {
-        let source = Source::unknown("b[C] => $b");
-        assert_eq!(
-            Parser::new(source).parse_next(),
-            Err(ParseError {
-                message: "Illegal expression after lambda parameter declaration".to_string(),
-                position: find_in(source.source, "C"),
-                kind: ParseErrorKind::Unexpected,
-            })
-        );
-    }
-    #[test]
-    fn call_with_type_parameters() {
-        let source = Source::unknown("parse[Int] x y");
-        assert_eq!(
-            Parser::new(source).parse_next(),
-            Err(ParseError {
-                message: "Command calls cannot have generic arguments".to_string(),
-                position: find_in(source.source, "Int"),
-                kind: ParseErrorKind::Unexpected,
-            })
         );
     }
 

--- a/parser/src/cursor.rs
+++ b/parser/src/cursor.rs
@@ -191,8 +191,4 @@ impl<'a> ParserCursor<'a> {
         let end = context.to.as_ptr() as usize + context.to.len() - self.source.as_ptr() as usize;
         start..end
     }
-
-    pub fn get_source(&self) -> &'a str {
-        self.source
-    }
 }

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -1,9 +1,10 @@
+use ast::lambda::LambdaDef;
 use ast::operation::{BinaryOperation, BinaryOperator, UnaryOperation, UnaryOperator};
 use ast::r#type::CastedExpr;
 use ast::range::Iterable;
-use ast::variable::{Assign, AssignOperator};
+use ast::variable::{Assign, AssignOperator, TypedVariable};
 use ast::Expr;
-use context::source::{Source, SourceSegment, SourceSegmentHolder};
+use context::source::{Source, SourceSegmentHolder};
 use lexer::lex;
 use lexer::token::TokenType::*;
 use lexer::token::{Token, TokenType};
@@ -32,7 +33,7 @@ use crate::err::{
     determine_skip_sections, ErrorContext, ParseError, ParseErrorKind, ParseReport, SkipSections,
 };
 use crate::moves::{
-    any, blanks, line_end, next, of_type, of_types, repeat, spaces, Move, MoveOperations,
+    any, blanks, like, line_end, next, of_type, of_types, repeat, spaces, Move, MoveOperations,
 };
 
 pub(crate) type ParseResult<T> = Result<T, ParseError>;
@@ -244,17 +245,31 @@ impl<'a> Parser<'a> {
             Identifier
                 if self
                     .cursor
-                    .lookahead(next().then(
-                        spaces().then(
-                            of_types(&[Plus, Minus, Star, Slash, Percent]).then(of_type(Equal)),
+                    .lookahead(
+                        next().then(
+                            spaces().then(
+                                of_types(&[Plus, Minus, Star, Slash, Percent])
+                                    .then(of_types(&[Equal, FatArrow])),
+                            ),
                         ),
-                    ))
+                    )
                     .is_some() =>
             {
                 let name = self.cursor.next()?.value;
                 self.cursor.advance(spaces());
-                let operator = AssignOperator::try_from(self.cursor.next()?.token_type)
-                    .expect("Invalid assign operator");
+                let Ok(operator) = AssignOperator::try_from(self.cursor.next()?.token_type) else {
+                    let body = Box::new(self.value()?);
+                    let segment = self.cursor.relative_pos(name).start..body.segment().end;
+                    return Ok(Expr::LambdaDef(LambdaDef {
+                        args: vec![TypedVariable {
+                            name,
+                            ty: None,
+                            segment: self.cursor.relative_pos(name),
+                        }],
+                        body,
+                        segment,
+                    }));
+                };
                 if operator != AssignOperator::Assign {
                     self.cursor.next_opt();
                 }
@@ -269,7 +284,14 @@ impl<'a> Parser<'a> {
             }
 
             Var | Val => self.var_declaration(),
-            Identifier | Reef => self.any_call(),
+            Identifier
+                if self
+                    .cursor
+                    .lookahead(next().then(like(TokenType::belongs_to_shell)))
+                    .is_some() =>
+            {
+                self.call()
+            }
             Dot => self.call(),
             Shell => {
                 self.cursor.next_opt();
@@ -277,7 +299,7 @@ impl<'a> Parser<'a> {
                 if self.cursor.peek().token_type == CurlyLeftBracket {
                     self.block().map(Expr::Block)
                 } else {
-                    self.any_call()
+                    self.call()
                 }
             }
             Not if self
@@ -539,17 +561,6 @@ impl<'a> Parser<'a> {
         self.cursor.mk_parse_error(message, context, kind)
     }
 
-    /// Executes an operation on the parser, and returns the result and whether there were no errors that
-    /// were reported and already handled.
-    pub(crate) fn observe_error_reports<E>(
-        &mut self,
-        transaction: impl FnOnce(&mut Self) -> ParseResult<E>,
-    ) -> ParseResult<(E, bool)> {
-        let old_len = self.errors.len();
-        let result = transaction(self);
-        Ok((result?, self.errors.len() == old_len))
-    }
-
     ///Skips spaces and verify that this parser is not parsing the end of an expression
     /// (unescaped newline or semicolon)
     pub(crate) fn repos(&mut self, message: &str) -> ParseResult<()> {
@@ -672,28 +683,5 @@ impl<'a> Parser<'a> {
                 break;
             }
         }
-    }
-}
-
-/// Ensures that the given elements are empty, returning Err(ParseError) with given message otherwise.
-/// The error's context segment will be the segment between first and last elements of given elements.
-pub(crate) fn ensure_empty<T>(
-    msg: &str,
-    elements: Vec<T>,
-    convert: impl Fn(&T) -> SourceSegment,
-) -> ParseResult<()> {
-    if let Some(first) = elements.first() {
-        let position = elements
-            .last()
-            .map(|last| convert(first).start..convert(last).end)
-            .unwrap_or_else(|| convert(first));
-
-        Err(ParseError {
-            message: msg.to_string(),
-            position,
-            kind: Unexpected,
-        })
-    } else {
-        Ok(())
     }
 }

--- a/vm/src/stdlib_natives.cpp
+++ b/vm/src/stdlib_natives.cpp
@@ -184,6 +184,17 @@ static void vec_index(OperandStack &caller_stack, runtime_memory &) {
     caller_stack.push_reference(*vec[index]);
 }
 
+static void vec_index_set(OperandStack &caller_stack, runtime_memory &) {
+    msh::obj &ref = caller_stack.pop_reference();
+    int64_t n = caller_stack.pop_int();
+    size_t index = static_cast<size_t>(n);
+    msh::obj_vector &vec = caller_stack.pop_reference().get<msh::obj_vector>();
+    if (index >= vec.size()) {
+        throw RuntimeException("Index " + std::to_string(n) + " is out of range, the length is " + std::to_string(vec.size()) + ".");
+    }
+    vec[index] = &ref;
+}
+
 static void gc(OperandStack &, runtime_memory &mem) {
     mem.run_gc();
 }
@@ -202,6 +213,7 @@ natives_functions_t load_natives() {
         {"lang::Vec::len", vec_len},
         {"lang::Vec::push", vec_push},
         {"lang::Vec::[]", vec_index},
+        {"lang::Vec::[]=", vec_index_set},
 
         {"std::panic", panic},
         {"std::exit", exit},


### PR DESCRIPTION
Replace `Vec[T].get(Int)` by a subscript operator, and add a way to assign to a vector via a subscript.

Subscripts are parsed like function calls, i.e. as suffix operators. They may happen before an equal sign, which create a special assignation that is not directly bound to a variable. The analyzer has been updated accordingly to treat those assignations as special method calls.

The typing phase tries to create useful diagnostics by indicating if the type is first subscriptable, and can display which types are valid indices.

Lastly, the parser no longer tries to treat function calls in a shell context. This is the opportunity to use operators from the programming context on it.

- Fixes #50 (The unpack operator will be implemented elsewhere)