### PR TITLE
Create a Debian package

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,7 @@ Dockerfile
 .dockerignore
 .git
 .gitignore
+
+cmake-build-debug
+CMakeFiles
+completions

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,7 +22,7 @@ jobs:
           cargo zigbuild --release --bin cli --target x86_64-unknown-linux-gnu.2.28
           mkdir build-output
           zip -r build-output/lib.zip lib
-          mv target/x86_64-unknown-linux-gnu/release/cli build-output/moshell
+          mv target/x86_64-unknown-linux-gnu/release/moshell build-output/moshell
           date +"%D" > build-output/nightly-version
 
       - name: upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ CMakeFiles
 a.out
 moshell
 *.bin
+completions

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.72.0-slim AS builder
+FROM rust:1.72.1-slim AS builder
 
 WORKDIR /usr/src/moshell
 
@@ -8,14 +8,14 @@ RUN apt-get update \
 
 COPY . .
 
-RUN cargo build --release --bin cli && strip target/release/cli
+RUN cargo build --release --bin moshell && strip target/release/moshell
 
 FROM alpine:3.18 AS runtime
 
 ENV MOSHELL_STD=/usr/share/moshell
 
 RUN apk add --no-cache libgcc libstdc++ gcompat
-COPY --from=builder /usr/src/moshell/target/release/cli /bin/moshell
+COPY --from=builder /usr/src/moshell/target/release/moshell /bin/moshell
 COPY lib /usr/share/moshell
 
 ENTRYPOINT ["/bin/moshell"]

--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ cargo run --bin cli # Run the interactive prompt
 cargo run --bin cli -- -s <file> # Run a file
 ```
 
-You can also build a release binary :
+You can also build a release binary:
 ```sh
-cargo build --release --bin cli 
-./target/release/cli # Run the interactive prompt
-./target/release/cli -s <file> # Run a file
+cargo build --release
+./target/release/moshell # Run the interactive prompt
+./target/release/moshell -s <file> # Run a file
 ```
 
 You can export the `MOSHELL_STD` environment variable to specify a path to the standard library.

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "cli"
+description = "CLI-related functionality for Moshell"
 version = "0.1.0"
 edition = "2021"
+authors = ["Override-6", "syldium"]
+license = "GPL-3.0-only"
+repository = "https://github.com/moshell-lang/moshell"
+
+[[bin]]
+name = "moshell"
+path = "src/main.rs"
 
 [[test]]
 name = "lang_tests"
@@ -24,8 +32,23 @@ miette = { version = "5.9.0", features = ["fancy-no-backtrace"] }
 thiserror = "1.0.38"
 dbg-pls = { version = "0.4.1", features = ["pretty", "colors"] }
 clap = { version = "4.2.2", features = ["derive"] }
+clap_complete = "4.4.1"
 libc = "0.2.147"
 
 [dev-dependencies]
 lang_tester = "0.7.3"
 tempfile = "3.7.0"
+
+[package.metadata.deb]
+name = "moshell"
+maintainer = "syldium <syldium@mailo.com>"
+extended-description = """\
+A scripting language inspired by the shell, with \
+static analysis."""
+section = "devel"
+assets = [
+    ["target/release/moshell", "usr/bin/", "755"],
+    ["lib/std.msh", "usr/share/moshell/lib/", "644"],
+    ["lib/std/*", "usr/share/moshell/lib/std", "755"],
+    ["completions/bash/moshell", "/usr/share/bash-completion/completions/", "755"]
+]

--- a/cli/Makefile
+++ b/cli/Makefile
@@ -1,0 +1,10 @@
+deb: completions/bash/moshell
+	cargo deb -p cli --deb-version $(shell git log --date=format:%Y%m%d --pretty=0.0~git%cd.%h | head -n 1)
+
+completions/bash/moshell: | completions/bash
+	cargo run -- --completions bash > $@
+
+completions/bash:
+	mkdir -p $@
+
+.PHONY: deb

--- a/cli/lang_tests/run.rs
+++ b/cli/lang_tests/run.rs
@@ -24,7 +24,7 @@ fn main() {
                 .join("\n")
         })
         .test_cmds(move |p| {
-            let mut runtime = Command::new(env!("CARGO_BIN_EXE_cli"));
+            let mut runtime = Command::new(env!("CARGO_BIN_EXE_moshell"));
             let stdlib = current_dir().unwrap().with_file_name("lib");
             runtime
                 .env("MOSHELL_STD", stdlib)

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -3,6 +3,7 @@ use std::io::stderr;
 use std::path::PathBuf;
 
 use clap::Parser;
+use clap_complete::Shell;
 use dbg_pls::color;
 
 use analyzer::diagnostic::Diagnostic;
@@ -18,6 +19,7 @@ use crate::disassemble::display_bytecode;
 use crate::pipeline::{FileImportError, PipelineStatus, SourceHolder, SourcesCache};
 use crate::report::{display_diagnostic, display_parse_error};
 
+/// The Moshell scripting language.
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
@@ -36,6 +38,10 @@ pub struct Cli {
     /// Do not execute the code
     #[arg(long = "no-execute")]
     pub(crate) no_execute: bool,
+
+    /// Generate tab-completion scripts for your shell
+    #[arg(long = "completions")]
+    pub(crate) completions: Option<Shell>,
 }
 
 struct CachedSourceLocationLineProvider {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,12 +3,13 @@ use crate::pipeline::{ErrorReporter, PipelineStatus, SourcesCache};
 use crate::repl::repl;
 use crate::std::build_std;
 use ::std::ffi::OsStr;
+use ::std::io;
 use ::std::path::Path;
 use analyzer::name::Name;
 use analyzer::reef::Externals;
 use analyzer::relations::SourceId;
 use analyzer::Analyzer;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use miette::{Context, IntoDiagnostic, MietteHandlerOpts};
 use vm::VM;
 
@@ -35,6 +36,18 @@ fn main() -> Result<PipelineStatus, miette::Error> {
     }
 
     let cli = Cli::parse();
+
+    if let Some(generator) = cli.completions {
+        let mut cmd = Cli::command();
+        eprintln!("Generating completion file for {generator}...");
+        clap_complete::generate(
+            generator,
+            &mut cmd,
+            env!("CARGO_BIN_NAME"),
+            &mut io::stdout(),
+        );
+        return Ok(PipelineStatus::Success);
+    }
 
     miette::set_hook(Box::new(|_| {
         Box::new(MietteHandlerOpts::new().tab_width(2).build())


### PR DESCRIPTION
Use the [`cargo-deb`](https://github.com/kornelski/cargo-deb) helper, and expose a bash completion generator using `clap_generate`. It is versioned with the Git commit SHA.

This installs the standard library to `/usr/share/moshell/lib`, which is the last checked directory. User files are still preferred.