### PR TITLE
Create shell strings and tweak common error messages

### DIFF
--- a/analyzer/src/environment/symbols.rs
+++ b/analyzer/src/environment/symbols.rs
@@ -106,7 +106,7 @@ impl SymbolLocation {
 
         let mut path_it = path.iter();
 
-        if current_reef {
+        if current_reef && path.len() > 1 {
             path_it.next();
         }
 

--- a/lexer/src/lexer.rs
+++ b/lexer/src/lexer.rs
@@ -86,6 +86,19 @@ impl<'a> Lexer<'a> {
                 ));
                 TokenType::StringStart
             }
+            '`' => {
+                if let Some(Token {
+                    token_type: TokenType::Backtick,
+                    ..
+                }) = self.open_delimiters.last()
+                {
+                    self.open_delimiters.pop();
+                } else {
+                    self.open_delimiters
+                        .push(Token::new(TokenType::Backtick, &self.input[pos..pos + 1]));
+                }
+                TokenType::Backtick
+            }
             '/' => {
                 if self.matches_next('/', &mut size) {
                     return self.skip_line();

--- a/lexer/src/literal.rs
+++ b/lexer/src/literal.rs
@@ -13,6 +13,7 @@ pub(crate) fn is_not_identifier_part(c: char) -> bool {
             | '@'
             | '\''
             | '"'
+            | '`'
             | '/'
             | '\\'
             | '+'
@@ -60,7 +61,6 @@ impl<'a> Lexer<'a> {
             "reef" => TokenType::Reef,
             "return" => TokenType::Return,
             "self" => TokenType::Slf,
-            "shell" => TokenType::Shell,
             "struct" => TokenType::Struct,
             "true" => TokenType::True,
             "use" => TokenType::Use,

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -35,6 +35,8 @@ pub enum TokenType {
     #[assoc(str = "val")]
     Val,
 
+    #[assoc(str = "`")]
+    Backtick,
     StringStart,
     StringEnd,
     StringContent,
@@ -78,8 +80,6 @@ pub enum TokenType {
     Match,
     #[assoc(str = "as")]
     As,
-    #[assoc(str = "shell")]
-    Shell,
 
     #[assoc(str = "self")]
     Slf,

--- a/parser/src/aspects/call.rs
+++ b/parser/src/aspects/call.rs
@@ -46,16 +46,7 @@ impl<'a> CallAspect<'a> for Parser<'a> {
     }
 
     fn programmatic_call(&mut self) -> ParseResult<Expr<'a>> {
-        let mut path = self.parse_inclusion_path()?;
-        let name = self.cursor.force_with(
-            of_type(TokenType::Identifier),
-            "Expected function name.",
-            ParseErrorKind::Expected("identifier".to_owned()),
-        )?;
-
-        let name_segment = self.cursor.relative_pos(name.value);
-        path.push(InclusionPathItem::Symbol(name.value, name_segment.clone()));
-
+        let path = self.parse_inclusion_path()?;
         let (type_parameters, _) = self.parse_optional_list(
             TokenType::SquaredLeftBracket,
             TokenType::SquaredRightBracket,
@@ -72,7 +63,7 @@ impl<'a> CallAspect<'a> for Parser<'a> {
         let start = path
             .first()
             .map(InclusionPathItem::segment)
-            .unwrap_or_else(|| name_segment);
+            .expect("Path should not be empty");
 
         let segment = start.start..args_segment.end;
 
@@ -285,21 +276,6 @@ mod tests {
                     literal(source.source, "y"),
                 ],
             }))
-        );
-    }
-
-    #[test]
-    fn echo_reef() {
-        let source = Source::unknown("echo reef()");
-        assert_eq!(
-            Parser::new(source)
-                .parse_next()
-                .expect_err("successful parse"),
-            ParseError {
-                message: "Expected function name.".to_string(),
-                position: find_in(source.source, "reef"),
-                kind: ParseErrorKind::Expected("identifier".to_string())
-            }
         );
     }
 

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -293,14 +293,9 @@ impl<'a> Parser<'a> {
                 self.call()
             }
             Dot => self.call(),
-            Shell => {
-                self.cursor.next_opt();
-                self.cursor.advance(spaces());
-                if self.cursor.peek().token_type == CurlyLeftBracket {
-                    self.block().map(Expr::Block)
-                } else {
-                    self.call()
-                }
+            Backtick => {
+                let callee = self.back_string_literal();
+                self.call_arguments(callee.map(Expr::TemplateString)?)
             }
             Not if self
                 .cursor

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -103,7 +103,7 @@ fn what_is_an_import() {
         report.errors,
         vec![
             ParseError {
-                message: "'break' is not a valid type identifier.".to_owned(),
+                message: "`break` is not a valid type identifier.".to_owned(),
                 position: content.find("break").map(|p| p..p + 5).unwrap(),
                 kind: ParseErrorKind::Unexpected
             },
@@ -157,12 +157,12 @@ fn tolerance_in_multiple_groups() {
             })],
             errors: vec![
                 ParseError {
-                    message: "'$' is not a valid generic type identifier.".to_owned(),
+                    message: "`$` is not a valid generic type identifier.".to_owned(),
                     position: content.find('$').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected
                 },
                 ParseError {
-                    message: "'+' is not a valid type identifier.".to_owned(),
+                    message: "`+` is not a valid type identifier.".to_owned(),
                     position: content.rfind('+').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected
                 }
@@ -207,7 +207,7 @@ fn do_not_accumulate_delimiters() {
     assert_eq!(
         report.errors,
         vec![ParseError {
-            message: "'/' is not a valid type identifier.".to_owned(),
+            message: "`/` is not a valid type identifier.".to_owned(),
             position: content.find('/').map(|p| p..p + 1).unwrap(),
             kind: ParseErrorKind::Unexpected
         }]
@@ -246,7 +246,7 @@ fn no_comma_or_two() {
                     kind: ParseErrorKind::Unpaired(content.find('\'').map(|p| p..p + 1).unwrap())
                 },
                 ParseError {
-                    message: "'@' is not a valid generic type identifier.".to_owned(),
+                    message: "`@` is not a valid generic type identifier.".to_owned(),
                     position: content.find('@').map(|p| p..p + 1).unwrap(),
                     kind: ParseErrorKind::Unexpected
                 },
@@ -262,6 +262,21 @@ fn no_comma_or_two() {
                 }
             ],
         }
+    );
+}
+
+#[test]
+fn single_colon() {
+    let content = "use std::foo:{bar, test}";
+    let source = Source::unknown(content);
+    let report = parse(source);
+    assert_eq!(
+        report.errors,
+        vec![ParseError {
+            message: "Expected `::`.".to_owned(),
+            position: content.rfind(':').map(|p| p..p + 1).unwrap(),
+            kind: ParseErrorKind::Unexpected
+        }]
     );
 }
 

--- a/parser/tests/err.rs
+++ b/parser/tests/err.rs
@@ -281,6 +281,21 @@ fn single_colon() {
 }
 
 #[test]
+fn colon_return_type() {
+    let content = "fun foo(): int = {}";
+    let source = Source::unknown(content);
+    let report = parse(source);
+    assert_eq!(
+        report.errors,
+        vec![ParseError {
+            message: "Return types are denoted using `->`.".to_owned(),
+            position: content.find(':').map(|p| p..p + 1).unwrap(),
+            kind: ParseErrorKind::Expected("`->`".to_owned())
+        }]
+    );
+}
+
+#[test]
 fn multiple_errors_in_parameters() {
     let content = "f(1 + , if true; $, (2 + 3)";
     let source = Source::unknown(content);

--- a/parser/tests/with_lexer.rs
+++ b/parser/tests/with_lexer.rs
@@ -62,7 +62,7 @@ fn with_lexer_var_reference_one() {
 
 #[test]
 fn with_lexer_var_reference_two() {
-    let source = Source::unknown("shell \"fake$cmd\" do $arg2");
+    let source = Source::unknown("`fake$cmd` do $arg2");
     let parsed = parse(source).expect("Failed to parse");
 
     assert_eq!(
@@ -77,7 +77,7 @@ fn with_lexer_var_reference_two() {
                             segment: find_in(source.source, "$cmd"),
                         }),
                     ],
-                    segment: find_in(source.source, "\"fake$cmd\""),
+                    segment: find_in(source.source, "`fake$cmd`"),
                 }),
                 literal(source.source, "do"),
                 Expr::VarReference(VarReference {
@@ -362,7 +362,7 @@ fn pipe_expressions() {
 
 #[test]
 fn pipe_to_command() {
-    let source = Source::unknown("shell { echo '1\n2' } | cat");
+    let source = Source::unknown("{ echo '1\n2' } | cat");
     let parsed = parse(source).expect("Failed to parse");
     assert_eq!(
         parsed,


### PR DESCRIPTION
The "magic" `shell` keyword created a strange parse context. Backticks are now used to delimit only the shell part.

The path parser has been simplified to include its last item. If a path only contain `reef`, the error is now caught later by the analyzer. Some hints have been added to help the user, such as indicate that paths are delimited by `::` instead of `:`.