### PR TITLE
Fix bounds handling for methods + Vec::pop patch

### DIFF
--- a/analyzer/src/relations.rs
+++ b/analyzer/src/relations.rs
@@ -37,10 +37,6 @@ pub struct SourceId(pub ObjectId);
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct LocalId(pub ObjectId);
 
-/// A native object identifier, that points to a native function in the [`Engine`].
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct NativeId(pub ObjectId);
-
 /// An indication where an object is located.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum SymbolRef {
@@ -49,26 +45,6 @@ pub enum SymbolRef {
 
     /// An external symbol, where the relation is contained in the [`Resolver`].
     External(RelationId),
-}
-
-/// An identifier in an engine.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Definition {
-    /// A block of code, defined by the user.
-    User(SourceId),
-
-    /// A native function, that is defined in the VM.
-    ///
-    /// It can also have a special treatment in the compiler, but it is abstracted away
-    /// during the analysis.
-    Native(NativeId),
-}
-
-impl Definition {
-    /// Builds an erroneous definition that is used for error propagation.
-    pub fn error() -> Self {
-        Self::Native(NativeId(ObjectId::MAX))
-    }
 }
 
 impl From<RelationId> for SymbolRef {

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -1091,6 +1091,13 @@ fn ascribe_method_call(
         .iter()
         .map(|expr| ascribe_types(exploration, links, diagnostics, expr, state))
         .collect::<Vec<_>>();
+
+    let return_hint = if let ExpressionValue::Expected(ty) = state.local_value {
+        Some(ty)
+    } else {
+        None
+    };
+
     match type_method(
         method,
         &callee,
@@ -1099,6 +1106,7 @@ fn ascribe_method_call(
         diagnostics,
         exploration,
         links.source,
+        return_hint,
     ) {
         Some(fun) => TypedExpr {
             kind: ExprKind::MethodCall(MethodCall {

--- a/analyzer/src/steps/typing/assign.rs
+++ b/analyzer/src/steps/typing/assign.rs
@@ -108,7 +108,21 @@ pub(super) fn ascribe_assign_subscript(
         .map(|methods| methods.as_slice())
         .unwrap_or(&[]);
     let mut args = vec![index, rhs];
-    let method = find_exact_method(exploration, target.ty, methods, args.as_slice(), &[]);
+
+    let return_hint = if let ExpressionValue::Expected(ty) = state.local_value {
+        Some(ty)
+    } else {
+        None
+    };
+
+    let method = find_exact_method(
+        target.ty,
+        methods,
+        args.as_slice(),
+        &[],
+        return_hint,
+        exploration,
+    );
     if let Some((method, _)) = method {
         let return_type = exploration.concretize(method.return_type, target.ty);
         return TypedExpr {

--- a/analyzer/src/steps/typing/bounds.rs
+++ b/analyzer/src/steps/typing/bounds.rs
@@ -5,7 +5,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 
 /// Binds a polytype to largest possible monotype
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct TypesBounds {
     bounds: HashMap<TypeRef, TypeRef>,
 }

--- a/analyzer/src/steps/typing/lower.rs
+++ b/analyzer/src/steps/typing/lower.rs
@@ -74,13 +74,14 @@ pub(super) fn call_convert_on(
     };
 
     // Else, we try to find the expected conversion method on the expression's type
-    if let Some(method) = exploration.get_method_exact(expr.ty, method_name, &[], into) {
+    if let Some((method, method_id)) = exploration.get_method_exact(expr.ty, method_name, &[], into)
+    {
         let segment = expr.segment.clone();
         return TypedExpr {
             kind: ExprKind::MethodCall(MethodCall {
                 callee: Box::new(expr),
                 arguments: vec![],
-                definition: method.definition,
+                function_id: method_id,
             }),
             ty: method.return_type,
             segment,

--- a/analyzer/src/types.rs
+++ b/analyzer/src/types.rs
@@ -10,9 +10,6 @@ pub mod hir;
 pub mod operator;
 pub mod ty;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct DefinitionId(pub(crate) TypeRef);
-
 /// Holds all the known types.
 #[derive(Default, Debug, Clone)]
 pub struct Typing {

--- a/analyzer/src/types/builtin.rs
+++ b/analyzer/src/types/builtin.rs
@@ -2,7 +2,7 @@ use ast::operation::BinaryOperator;
 
 use crate::engine::Engine;
 use crate::reef::{Reef, LANG_REEF};
-use crate::relations::{NativeId, Relations, SourceId};
+use crate::relations::{Relations, SourceId};
 use crate::types;
 use crate::types::ctx::TypeContext;
 use crate::types::engine::TypedEngine;
@@ -32,23 +32,8 @@ const EQUALITY_OPERATORS: &[BinaryOperator] =
 
 const LOGICAL_OPERATORS: &[BinaryOperator] = &[BinaryOperator::And, BinaryOperator::Or];
 
-/// A sequential generator for native object ids.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-struct VariableGenerator(usize);
-
-impl VariableGenerator {
-    /// Gets and increments the next native object id.
-    fn next(&mut self) -> NativeId {
-        let id = self.0;
-        self.0 += 1;
-        NativeId(id)
-    }
-}
-
 /// Adds the native methods to the engine.
 fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
-    let mut gen = VariableGenerator::default();
-
     // declare one generic parameter type, methods will reuse it
     let generic_param1 = TypeRef::new(
         LANG_REEF,
@@ -64,37 +49,33 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
     engine.add_method(
         EXITCODE.type_id,
         "to_bool",
-        MethodType::native(vec![], vec![], BOOL, gen.next()),
+        MethodType::new(vec![], vec![], BOOL),
     );
 
     for op in ARITHMETIC_OPERATORS {
         engine.add_method(
             INT.type_id,
             name_operator_method(*op),
-            MethodType::native(vec![], vec![INT], INT, gen.next()),
+            MethodType::new(vec![], vec![INT], INT),
         );
         engine.add_method(
             FLOAT.type_id,
             name_operator_method(*op),
-            MethodType::native(vec![], vec![FLOAT], FLOAT, gen.next()),
+            MethodType::new(vec![], vec![FLOAT], FLOAT),
         );
     }
     engine.add_method(
         INT.type_id,
         name_operator_method(BinaryOperator::Modulo),
-        MethodType::native(vec![], vec![INT], INT, gen.next()),
+        MethodType::new(vec![], vec![INT], INT),
     );
-    engine.add_method(
-        BOOL.type_id,
-        "not",
-        MethodType::native(vec![], vec![], BOOL, gen.next()),
-    );
+    engine.add_method(BOOL.type_id, "not", MethodType::new(vec![], vec![], BOOL));
     for ty in [BOOL, STRING] {
         for op in EQUALITY_OPERATORS {
             engine.add_method(
                 ty.type_id,
                 name_operator_method(*op),
-                MethodType::native(vec![], vec![ty], BOOL, gen.next()),
+                MethodType::new(vec![], vec![ty], BOOL),
             );
         }
     }
@@ -103,7 +84,7 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
             engine.add_method(
                 ty.type_id,
                 name_operator_method(*op),
-                MethodType::native(vec![], vec![ty], BOOL, gen.next()),
+                MethodType::new(vec![], vec![ty], BOOL),
             );
         }
     }
@@ -111,24 +92,20 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
         engine.add_method(
             stringify.type_id,
             "to_string",
-            MethodType::native(vec![], vec![], STRING, gen.next()),
+            MethodType::new(vec![], vec![], STRING),
         );
     }
     engine.add_method(
         INT.type_id,
         "to_float",
-        MethodType::native(vec![], vec![], FLOAT, gen.next()),
+        MethodType::new(vec![], vec![], FLOAT),
     );
 
-    engine.add_method(
-        STRING.type_id,
-        "len",
-        MethodType::native(vec![], vec![], INT, gen.next()),
-    );
+    engine.add_method(STRING.type_id, "len", MethodType::new(vec![], vec![], INT));
     engine.add_method(
         STRING.type_id,
         name_operator_method(BinaryOperator::Plus),
-        MethodType::native(vec![], vec![STRING], STRING, gen.next()),
+        MethodType::new(vec![], vec![STRING], STRING),
     );
 
     engine.add_generic(GENERIC_VECTOR.type_id, generic_param1);
@@ -136,49 +113,42 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
     engine.add_method(
         GENERIC_VECTOR.type_id,
         "[]",
-        MethodType::native(vec![], vec![INT], generic_param1, gen.next()),
+        MethodType::new(vec![], vec![INT], generic_param1),
     );
 
     engine.add_method(
         GENERIC_VECTOR.type_id,
         "push",
-        MethodType::native(vec![], vec![generic_param1], UNIT, gen.next()),
+        MethodType::new(vec![], vec![generic_param1], UNIT),
     );
 
     engine.add_method(
         GENERIC_VECTOR.type_id,
         "pop",
-        MethodType::native(
-            vec![],
-            vec![],
-            TypeRef::new(LANG_REEF, opt_type),
-            gen.next(),
-        ),
+        MethodType::new(vec![], vec![], TypeRef::new(LANG_REEF, opt_type)),
     );
     engine.add_method(
         GENERIC_VECTOR.type_id,
         "len",
-        MethodType::native(vec![], vec![], INT, gen.next()),
+        MethodType::new(vec![], vec![], INT),
     );
 
     engine.add_method(
         STRING.type_id,
         "split",
-        MethodType::native(
+        MethodType::new(
             vec![],
             vec![STRING],
             TypeRef::new(LANG_REEF, TypeId(10)), //Vec[String] instance
-            gen.next(),
         ),
     );
     engine.add_method(
         STRING.type_id,
         "bytes",
-        MethodType::native(
+        MethodType::new(
             vec![],
             vec![],
             TypeRef::new(LANG_REEF, TypeId(11)), // Vec[Int] instance
-            gen.next(),
         ),
     );
 
@@ -187,7 +157,7 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
             engine.add_method(
                 operand.type_id,
                 name_operator_method(*op),
-                MethodType::native(vec![], vec![operand], operand, gen.next()),
+                MethodType::new(vec![], vec![operand], operand),
             );
         }
     }
@@ -195,7 +165,7 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
         engine.add_method(
             operand.type_id,
             "neg",
-            MethodType::native(vec![], vec![], operand, gen.next()),
+            MethodType::new(vec![], vec![], operand),
         );
     }
 
@@ -203,33 +173,33 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
     engine.add_method(
         GENERIC_OPTION.type_id,
         "is_none",
-        MethodType::native(vec![], vec![], BOOL, gen.next()),
+        MethodType::new(vec![], vec![], BOOL),
     );
     engine.add_method(
         GENERIC_OPTION.type_id,
         "is_some",
-        MethodType::native(vec![], vec![], BOOL, gen.next()),
+        MethodType::new(vec![], vec![], BOOL),
     );
     engine.add_method(
         GENERIC_OPTION.type_id,
         "unwrap",
-        MethodType::native(vec![], vec![], generic_param1, gen.next()),
+        MethodType::new(vec![], vec![], generic_param1),
     );
     engine.add_method(
         GENERIC_VECTOR.type_id,
         "[]",
-        MethodType::native(vec![], vec![INT, generic_param1], UNIT, gen.next()),
+        MethodType::new(vec![], vec![INT, generic_param1], UNIT),
     );
 
     engine.add_method(
         INT.type_id,
         "to_exitcode",
-        MethodType::native(vec![], vec![], EXITCODE, gen.next()),
+        MethodType::new(vec![], vec![], EXITCODE),
     );
     engine.add_method(
         EXITCODE.type_id,
         "to_int",
-        MethodType::native(vec![], vec![], INT, gen.next()),
+        MethodType::new(vec![], vec![], INT),
     );
 }
 

--- a/analyzer/src/types/builtin.rs
+++ b/analyzer/src/types/builtin.rs
@@ -3,6 +3,7 @@ use ast::operation::BinaryOperator;
 use crate::engine::Engine;
 use crate::reef::{Reef, LANG_REEF};
 use crate::relations::{NativeId, Relations, SourceId};
+use crate::types;
 use crate::types::ctx::TypeContext;
 use crate::types::engine::TypedEngine;
 use crate::types::operator::name_operator_method;
@@ -48,10 +49,16 @@ impl VariableGenerator {
 fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
     let mut gen = VariableGenerator::default();
 
-    // declare one generic parameter type, functions will reuse it
+    // declare one generic parameter type, methods will reuse it
     let generic_param1 = TypeRef::new(
         LANG_REEF,
         typing.add_type(Type::Polytype, Some("A".to_string())),
+    );
+
+    // option containing generic parameter
+    let opt_type = typing.add_type(
+        Type::Instantiated(types::GENERIC_OPTION, vec![generic_param1]),
+        None,
     );
 
     engine.add_method(
@@ -129,18 +136,24 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
     engine.add_method(
         GENERIC_VECTOR.type_id,
         "[]",
-        MethodType::native(vec![generic_param1], vec![INT], generic_param1, gen.next()),
+        MethodType::native(vec![], vec![INT], generic_param1, gen.next()),
     );
 
     engine.add_method(
         GENERIC_VECTOR.type_id,
         "push",
-        MethodType::native(vec![generic_param1], vec![generic_param1], UNIT, gen.next()),
+        MethodType::native(vec![], vec![generic_param1], UNIT, gen.next()),
     );
+
     engine.add_method(
         GENERIC_VECTOR.type_id,
         "pop",
-        MethodType::native(vec![], vec![], generic_param1, gen.next()),
+        MethodType::native(
+            vec![],
+            vec![],
+            TypeRef::new(LANG_REEF, opt_type),
+            gen.next(),
+        ),
     );
     engine.add_method(
         GENERIC_VECTOR.type_id,
@@ -205,12 +218,7 @@ fn fill_lang_typed_engine(engine: &mut TypedEngine, typing: &mut Typing) {
     engine.add_method(
         GENERIC_VECTOR.type_id,
         "[]",
-        MethodType::native(
-            vec![generic_param1],
-            vec![INT, generic_param1],
-            UNIT,
-            gen.next(),
-        ),
+        MethodType::native(vec![], vec![INT, generic_param1], UNIT, gen.next()),
     );
 
     engine.add_method(

--- a/analyzer/src/types/engine.rs
+++ b/analyzer/src/types/engine.rs
@@ -2,10 +2,9 @@ use context::source::ContentId;
 
 use crate::engine::Engine;
 use crate::environment::Environment;
-use crate::relations::{Definition, SourceId};
+use crate::relations::{ObjectId, SourceId};
 use crate::types::hir::TypedExpr;
-use crate::types::ty::{FunctionType, MethodType, Parameter, TypeDescription, TypeId, TypeRef};
-use crate::types::UNIT;
+use crate::types::ty::{FunctionType, MethodType, TypeDescription, TypeId, TypeRef};
 
 /// A typed [`Engine`].
 ///
@@ -21,112 +20,13 @@ pub struct TypedEngine {
     /// Descriptions of types.
     descriptions: Vec<TypeDescription>,
 
-    /// Native code that powers the language.
-    ///
-    /// It powers primitives types, and is indexed by [`NativeId`]s.
-    natives: Vec<MethodLocation>,
+    /// All functions definitions. Indexed by a [`FunctionId`] identifier
+    functions: Vec<FunctionType>,
 }
 
-#[derive(Debug, Clone)]
-struct MethodLocation {
-    tpe: TypeId,
-    name: String,
-    index: usize,
-}
-
-impl Default for MethodLocation {
-    fn default() -> Self {
-        Self {
-            tpe: TypeId(usize::MAX),
-            name: String::default(),
-            index: 0,
-        }
-    }
-}
-
-pub enum CodeEntry<'a> {
-    User(&'a Chunk),
-    Native(&'a FunctionType),
-}
-
-impl CodeEntry<'_> {
-    pub fn parameters(&self) -> &[Parameter] {
-        match self {
-            CodeEntry::User(chunk) => chunk.parameters.as_slice(),
-            CodeEntry::Native(native) => native.parameters.as_slice(),
-        }
-    }
-
-    pub fn type_parameters(&self) -> &[TypeRef] {
-        match self {
-            CodeEntry::User(chunk) => &chunk.type_parameters,
-            CodeEntry::Native(native) => &native.type_parameters,
-        }
-    }
-
-    pub fn return_type(&self) -> TypeRef {
-        match self {
-            CodeEntry::User(chunk) => chunk.return_type,
-            CodeEntry::Native(native) => native.return_type,
-        }
-    }
-}
-
-/// A chunk of typed code.
-#[derive(Debug)]
-pub struct Chunk {
-    /// The expression that is evaluated when the chunk is called.
-    /// if this expression is set to None, the chunk is associated to a native function declaration
-    pub expression: Option<TypedExpr>,
-
-    /// List of type parameters declared in chunk's reef typing
-    pub type_parameters: Vec<TypeRef>,
-
-    /// The input parameters of the chunk.
-    ///
-    /// If the chunk is a script, there are no parameters.
-    pub parameters: Vec<Parameter>,
-
-    /// The return type of the chunk.
-    pub return_type: TypeRef,
-}
-
-impl Chunk {
-    /// Creates a new script chunk.
-    pub fn script(expression: TypedExpr) -> Self {
-        Self {
-            expression: Some(expression),
-            type_parameters: Vec::new(),
-            parameters: Vec::new(),
-            return_type: UNIT,
-        }
-    }
-
-    /// Creates a new function that is natively defined.
-    pub fn native(tparams: Vec<TypeRef>, parameters: Vec<Parameter>, return_type: TypeRef) -> Self {
-        Self {
-            expression: None,
-            type_parameters: tparams,
-            parameters,
-            return_type,
-        }
-    }
-
-    /// Creates a new function chunk.
-    pub fn function(
-        tparams: Vec<TypeRef>,
-        expression: TypedExpr,
-        parameters: Vec<Parameter>,
-        return_type: TypeRef,
-    ) -> Self {
-        Self {
-            expression: Some(expression),
-            type_parameters: tparams,
-            parameters,
-            return_type,
-        }
-    }
-}
+/// A function identifier, that points to a [`TypedEngine`]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct FunctionId(pub ObjectId);
 
 impl TypedEngine {
     /// Initializes a new typed engine with the given capacity.
@@ -137,20 +37,18 @@ impl TypedEngine {
         let mut engine = Self {
             entries: Vec::new(),
             descriptions: Vec::new(),
-            natives: Vec::new(),
+            functions: Vec::new(),
         };
         engine.entries.resize_with(capacity, || None);
         engine
     }
 
-    /// Returns the chunk with the given id.
-    pub fn get(&self, def: Definition) -> Option<CodeEntry> {
-        match def {
-            Definition::User(id) => self.get_user(id).map(CodeEntry::User),
-            Definition::Native(id) => self.natives.get(id.0).map(|loc| {
-                CodeEntry::Native(&self.descriptions[loc.tpe.0].methods[&loc.name][loc.index])
-            }),
-        }
+    pub fn get_function(&self, id: FunctionId) -> Option<&FunctionType> {
+        self.functions.get(id.0)
+    }
+
+    pub(crate) fn get_function_mut(&mut self, id: FunctionId) -> Option<&mut FunctionType> {
+        self.functions.get_mut(id.0)
     }
 
     /// Returns the chunk with the given source id.
@@ -174,7 +72,7 @@ impl TypedEngine {
     ///
     /// If the type is unknown or doesn't have any methods with the given name,
     /// [`None`] is returned.
-    pub fn get_methods(&self, type_id: TypeId, name: &str) -> Option<&Vec<MethodType>> {
+    pub fn get_methods(&self, type_id: TypeId, name: &str) -> Option<&Vec<FunctionId>> {
         self.descriptions.get(type_id.0)?.methods.get(name)
     }
 
@@ -190,45 +88,44 @@ impl TypedEngine {
         name: &str,
         args: &[TypeRef],
         return_type: TypeRef,
-    ) -> Option<&MethodType> {
+    ) -> Option<(&MethodType, FunctionId)> {
         self.get_methods(type_id, name).and_then(|methods| {
-            methods.iter().find(|method| {
-                method.parameters.iter().map(|p| &p.ty).eq(args)
-                    && method.return_type == return_type
-            })
+            methods
+                .iter()
+                .find(|function_id| {
+                    let method = &self.functions[function_id.0];
+                    method.return_type == return_type
+                        && method.parameters.iter().map(|p| &p.ty).eq(args)
+                })
+                .map(|function_id| (&self.functions[function_id.0], *function_id))
         })
     }
 
     /// Adds a new method to a type.
     ///
     /// The method may not conflict with any existing methods.
-    pub fn add_method(&mut self, type_id: TypeId, name: &str, method: MethodType) {
+    pub fn add_method(&mut self, type_id: TypeId, name: &str, method: MethodType) -> FunctionId {
         // Extend the vector of type descriptions if necessary.
         if type_id.0 >= self.descriptions.len() {
             self.descriptions
                 .resize_with(type_id.0 + 1, Default::default);
         }
 
-        let type_methods = self.descriptions[type_id.0]
+        let function_id = self.add_function(method);
+
+        self.descriptions[type_id.0]
             .methods
             .entry(name.to_owned())
-            .or_default();
+            .or_default()
+            .push(function_id);
 
-        let method_idx = type_methods.len();
+        function_id
+    }
 
-        if let Definition::Native(id) = method.definition {
-            // resize if needed
-            if id.0 >= self.natives.len() {
-                self.natives.resize_with(id.0 + 1, Default::default);
-            }
-            self.natives[id.0] = MethodLocation {
-                tpe: type_id,
-                name: name.to_owned(),
-                index: method_idx,
-            }
-        }
-
-        type_methods.push(method);
+    pub fn add_function(&mut self, function: FunctionType) -> FunctionId {
+        let function_id = FunctionId(self.functions.len());
+        self.functions.push(function);
+        function_id
     }
 
     /// Adds a new generic type parameter to a type.
@@ -269,6 +166,52 @@ impl TypedEngine {
             next: starting_page,
         }
     }
+}
+//
+// pub enum CodeEntry<'a> {
+//     User(&'a Chunk),
+//     Native(&'a FunctionType),
+// }
+//
+// impl CodeEntry<'_> {
+//     pub fn parameters(&self) -> &[Parameter] {
+//         match self {
+//             CodeEntry::User(chunk) => chunk.parameters.as_slice(),
+//             CodeEntry::Native(native) => native.parameters.as_slice(),
+//         }
+//     }
+//
+//     pub fn type_parameters(&self) -> &[TypeRef] {
+//         match self {
+//             CodeEntry::User(chunk) => &chunk.type_parameters,
+//             CodeEntry::Native(native) => &native.type_parameters,
+//         }
+//     }
+//
+//     pub fn return_type(&self) -> TypeRef {
+//         match self {
+//             CodeEntry::User(chunk) => chunk.return_type,
+//             CodeEntry::Native(native) => native.return_type,
+//         }
+//     }
+// }
+
+/// A chunk of typed code.
+#[derive(Debug)]
+pub struct Chunk {
+    /// The expression that is evaluated when the chunk is called.
+    /// if this expression is set to None, the chunk is associated to a native function declaration
+    pub expression: Option<TypedExpr>,
+
+    /// Associated chunk function, if any
+    pub kind: ChunkType,
+}
+
+#[derive(Debug, Copy, Clone)]
+//will add `impl`, `struct` chunks later.
+pub enum ChunkType {
+    Script(FunctionId),
+    Function(FunctionId),
 }
 
 /// A group of chunks that were defined in the same content.

--- a/analyzer/src/types/engine.rs
+++ b/analyzer/src/types/engine.rs
@@ -167,34 +167,6 @@ impl TypedEngine {
         }
     }
 }
-//
-// pub enum CodeEntry<'a> {
-//     User(&'a Chunk),
-//     Native(&'a FunctionType),
-// }
-//
-// impl CodeEntry<'_> {
-//     pub fn parameters(&self) -> &[Parameter] {
-//         match self {
-//             CodeEntry::User(chunk) => chunk.parameters.as_slice(),
-//             CodeEntry::Native(native) => native.parameters.as_slice(),
-//         }
-//     }
-//
-//     pub fn type_parameters(&self) -> &[TypeRef] {
-//         match self {
-//             CodeEntry::User(chunk) => &chunk.type_parameters,
-//             CodeEntry::Native(native) => &native.type_parameters,
-//         }
-//     }
-//
-//     pub fn return_type(&self) -> TypeRef {
-//         match self {
-//             CodeEntry::User(chunk) => chunk.return_type,
-//             CodeEntry::Native(native) => native.return_type,
-//         }
-//     }
-// }
 
 /// A chunk of typed code.
 #[derive(Debug)]

--- a/analyzer/src/types/hir.rs
+++ b/analyzer/src/types/hir.rs
@@ -3,7 +3,8 @@ use ast::call::{RedirFd, RedirOp};
 use ast::value::LiteralValue;
 use context::source::{SourceSegment, SourceSegmentHolder};
 
-use crate::relations::{Definition, LocalId, ResolvedSymbol};
+use crate::relations::{LocalId, ResolvedSymbol, SourceId};
+use crate::types::engine::FunctionId;
 use crate::types::ty::TypeRef;
 use crate::types::ERROR;
 
@@ -61,15 +62,16 @@ pub struct Loop {
 #[derive(Clone, Debug, PartialEq)]
 pub struct FunctionCall {
     pub arguments: Vec<TypedExpr>,
-    pub definition: Definition,
     pub reef: ReefId,
+    pub function_id: FunctionId,
+    pub source_id: Option<SourceId>,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct MethodCall {
     pub callee: Box<TypedExpr>,
     pub arguments: Vec<TypedExpr>,
-    pub definition: Definition,
+    pub function_id: FunctionId,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/cli/lang_tests/redir/mutate_before_process.msh
+++ b/cli/lang_tests/redir/mutate_before_process.msh
@@ -11,5 +11,5 @@ fun mutate() -> Int = {
     $n
 }
 
-echo Process: mutate() $b.pop()
-echo After: $n $b.pop()
+echo Process: mutate() $b.pop().unwrap()
+echo After: $n $b.pop().unwrap()

--- a/compiler/src/emit/native.rs
+++ b/compiler/src/emit/native.rs
@@ -1,4 +1,4 @@
-use analyzer::relations::NativeId;
+use analyzer::types::engine::FunctionId;
 use analyzer::types::hir::MethodCall;
 use analyzer::types::ty::TypeRef;
 
@@ -23,7 +23,7 @@ const STRING_BYTES: &str = "lang::String::bytes";
 /// Emits a primitive sequence of instructions.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn emit_natives(
-    native: NativeId,
+    native: FunctionId,
     MethodCall {
         callee,
         arguments: args,

--- a/vm/src/stdlib_natives.cpp
+++ b/vm/src/stdlib_natives.cpp
@@ -167,6 +167,10 @@ static void vec_len(OperandStack &caller_stack, runtime_memory &) {
 
 static void vec_pop(OperandStack &caller_stack, runtime_memory &) {
     msh::obj_vector &vec = caller_stack.pop_reference().get<msh::obj_vector>();
+    if (vec.empty()) {
+        caller_stack.push(nullptr);
+        return;
+    }
     msh::obj &last_element = *vec.back();
     vec.pop_back();
     caller_stack.push_reference(last_element);


### PR DESCRIPTION
This PR fixes previous hazardous behavior when applying type bounds to methods with parameters typed with type's generics.
This allowed the `Vec::pop` method to return an Option[A]