### PR TITLE
Make the REPL interactive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +141,9 @@ name = "bitflags"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bumpalo"
@@ -153,6 +171,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-targets",
+]
 
 [[package]]
 name = "ciborium"
@@ -247,6 +277,7 @@ dependencies = [
  "libc",
  "miette",
  "parser",
+ "reedline",
  "tempfile",
  "thiserror",
  "vm",
@@ -287,6 +318,12 @@ version = "0.1.0"
 dependencies = [
  "miette",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "crc32fast"
@@ -364,6 +401,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.0",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -479,6 +542,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +626,29 @@ name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "indexmap"
@@ -667,6 +764,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +831,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -811,6 +939,29 @@ name = "owo-colors"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "smallvec",
+ "windows-targets",
+]
 
 [[package]]
 name = "parser"
@@ -978,6 +1129,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "reedline"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "971ac45071721aae18927f3feb7e4c2b95cce387d96af185c5103166d332e55c"
+dependencies = [
+ "chrono",
+ "crossterm",
+ "fd-lock",
+ "itertools",
+ "nu-ansi-term",
+ "serde",
+ "strip-ansi-escapes",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "regex"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1189,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -1088,6 +1265,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
 name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,10 +1322,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3da32d3178b2690b515008539f0215a5991bb82fad567bb520c2b1d9c4cc70da"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.37",
+]
 
 [[package]]
 name = "stylish"
@@ -1371,6 +1612,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1395,6 +1642,26 @@ dependencies = [
  "criterion",
  "parser",
  "pretty_assertions",
+]
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d257817081c7dffcdbab24b9e62d2def62e2ff7d00b1c20062551e6cccc145ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1516,6 +1783,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "context",
  "dbg-pls",
  "directories",
+ "is_executable",
  "lang_tester",
  "lexer",
  "libc",
@@ -686,6 +687,15 @@ name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
+name = "is_executable"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9acdc6d67b75e626ad644734e8bc6df893d9cd2a834129065d3dd6158ea9c8"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "itertools"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
 name = "anstyle-parse"
@@ -277,6 +277,7 @@ dependencies = [
  "lexer",
  "libc",
  "miette",
+ "nu-ansi-term",
  "parser",
  "reedline",
  "tempfile",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,6 +36,7 @@ clap_complete = "4.4.1"
 libc = "0.2.147"
 reedline = "0.24.0"
 is_executable = "1.0.1"
+nu-ansi-term = "0.49.0"
 
 [dev-dependencies]
 lang_tester = "0.7.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -34,6 +34,7 @@ dbg-pls = { version = "0.4.1", features = ["pretty", "colors"] }
 clap = { version = "4.2.2", features = ["derive"] }
 clap_complete = "4.4.1"
 libc = "0.2.147"
+reedline = "0.24.0"
 
 [dev-dependencies]
 lang_tester = "0.7.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -35,6 +35,7 @@ clap = { version = "4.2.2", features = ["derive"] }
 clap_complete = "4.4.1"
 libc = "0.2.147"
 reedline = "0.24.0"
+is_executable = "1.0.1"
 
 [dev-dependencies]
 lang_tester = "0.7.3"

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -156,7 +156,7 @@ fn get_files(word: &str, pos: usize, predicate: fn(&Path) -> bool) -> Vec<Sugges
                 continue;
             }
             let mut entry_name = entry.file_name().to_string_lossy().into_owned();
-            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+            if entry.file_type().map_or(false, |t| t.is_dir()) {
                 entry_name.push(MAIN_SEPARATOR);
             }
             if entry_name.starts_with(partial) {

--- a/cli/src/complete.rs
+++ b/cli/src/complete.rs
@@ -1,0 +1,162 @@
+use ast::value::{Literal, LiteralValue};
+use ast::Expr;
+use context::source::Source;
+use parser::parse;
+use reedline::{Completer, Span, Suggestion};
+use std::env;
+use std::path::{Path, MAIN_SEPARATOR};
+
+/// A command completer.
+pub(crate) struct MoshellCompleter;
+
+impl Completer for MoshellCompleter {
+    fn complete(&mut self, line: &str, pos: usize) -> Vec<Suggestion> {
+        let (_, unmatched) = lexer::lex(&line[..pos]);
+        let mut fixed = String::from(&line[..pos]);
+        for unmatched in unmatched {
+            if unmatched.candidate.is_some() {
+                // Avoid completing a context that cannot be determined due to a mismatched token.
+                return Vec::new();
+            }
+            if let Some(opening) = unmatched.opening {
+                // Complete the missing token to not confuse the parser.
+                match line.as_bytes()[opening] {
+                    b'(' => fixed.push(')'),
+                    b'[' => fixed.push(']'),
+                    b'{' => fixed.push('}'),
+                    _ => {}
+                };
+            }
+        }
+
+        match get_last_word(&fixed) {
+            Some(CompletionCursor::Command(word)) => {
+                if word.starts_with('.') {
+                    get_files(&word, pos, |path| is_executable::is_executable(path))
+                } else {
+                    get_executables(&word, pos)
+                }
+            },
+            Some(CompletionCursor::Argument(word)) => get_files(&word, pos, |_| true),
+            None => Vec::new(),
+        }
+    }
+}
+
+/// The type of completion to output.
+#[derive(Debug, Clone)]
+enum CompletionCursor {
+    /// An executable command.
+    Command(String),
+
+    /// A file path argument.
+    Argument(String),
+}
+
+/// Get the last shell word in the given text.
+fn get_last_word(text: &str) -> Option<CompletionCursor> {
+    let mut report = parse(Source::unknown(text));
+    let mut expr = report.expr.pop()?;
+    let mut is_arg = false;
+    loop {
+        match expr {
+            Expr::Unary(unary) => {
+                expr = *unary.expr;
+            }
+            Expr::Binary(binary) => {
+                expr = *binary.right;
+            }
+            Expr::Block(mut block) => {
+                expr = block.expressions.pop()?;
+            }
+            Expr::FunctionDeclaration(function) => {
+                expr = *function.body?;
+            }
+            Expr::Call(mut call) => {
+                expr = call.arguments.pop()?;
+                is_arg = !call.arguments.is_empty();
+            }
+            Expr::TemplateString(mut template) => {
+                expr = template.parts.pop()?;
+            }
+            Expr::Literal(Literal {
+                parsed: LiteralValue::String(str),
+                segment,
+                ..
+            }) => {
+                if text.as_bytes()[segment.start] == b'\'' {
+                    return None;
+                }
+                return Some(if is_arg {
+                    CompletionCursor::Argument(str)
+                } else {
+                    CompletionCursor::Command(str)
+                });
+            }
+            _ => break None,
+        }
+    }
+}
+
+/// Lists all executables in the current path.
+fn get_executables(word: &str, pos: usize) -> Vec<Suggestion> {
+    let mut suggestions = Vec::new();
+    if let Some(path) = env::var_os("PATH") {
+        for path in env::split_paths(&path) {
+            if let Ok(dir) = path.read_dir() {
+                for entry in dir.filter_map(|e| e.ok()) {
+                    if let Some(name) = entry.file_name().to_str() {
+                        if name.starts_with(word) && is_executable::is_executable(entry.path()) {
+                            suggestions.push(Suggestion {
+                                value: name.to_owned(),
+                                description: None,
+                                extra: None,
+                                span: Span::new(pos - word.len(), pos),
+                                append_whitespace: true,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+    }
+    suggestions
+}
+
+/// Lists all files in the current path.
+fn get_files(word: &str, pos: usize, predicate: fn (&Path) -> bool) -> Vec<Suggestion> {
+    let mut suggestions = Vec::new();
+    let mut path = Path::new(word);
+    if !word.ends_with(MAIN_SEPARATOR) {
+        // Complete the last path component, so remove it from the path.
+        path = path.parent().unwrap();
+    }
+
+    if let Ok(dir) = path.read_dir() {
+        // Extract the filename
+        let partial = word
+            .rsplit_once(MAIN_SEPARATOR)
+            .map(|(_, p)| p)
+            .unwrap_or(word);
+
+        for entry in dir.filter_map(|e| e.ok()) {
+            if !predicate(&entry.path()) {
+                continue;
+            }
+            let mut entry_name = entry.file_name().to_string_lossy().into_owned();
+            if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                entry_name.push(MAIN_SEPARATOR);
+            }
+            if entry_name.starts_with(partial) {
+                suggestions.push(Suggestion {
+                    value: entry_name,
+                    description: None,
+                    extra: None,
+                    span: Span::new(pos - partial.len(), pos),
+                    append_whitespace: false,
+                });
+            }
+        }
+    }
+    suggestions
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,1 +1,7 @@
+use directories::ProjectDirs;
+
 pub mod pipeline;
+
+pub fn project_dir() -> Option<ProjectDirs> {
+    ProjectDirs::from("", "", "moshell")
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<PipelineStatus, miette::Error> {
         .into_diagnostic()
         .context("Could not locate working directory")?;
 
-    Ok(repl(current_dir, &cli, sources, externals, vm))
+    repl(current_dir, &cli, sources, externals, vm)
 }
 
 fn run(

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -14,6 +14,7 @@ use miette::{Context, IntoDiagnostic, MietteHandlerOpts};
 use vm::VM;
 
 mod cli;
+mod complete;
 mod disassemble;
 mod pipeline;
 mod repl;

--- a/cli/src/repl.rs
+++ b/cli/src/repl.rs
@@ -1,6 +1,9 @@
-use std::io;
-use std::io::BufRead;
-use std::io::Write;
+use miette::{Context, IntoDiagnostic};
+use reedline::{
+    FileBackedHistory, PromptEditMode, PromptHistorySearch, PromptHistorySearchStatus, Reedline,
+    Signal, ValidationResult,
+};
+use std::borrow::Cow;
 use std::path::PathBuf;
 
 use analyzer::importer::ImportResult;
@@ -8,22 +11,13 @@ use analyzer::name::Name;
 use analyzer::reef::Externals;
 use analyzer::relations::SourceId;
 use analyzer::{Analyzer, Inject};
+use cli::project_dir;
 use context::source::OwnedSource;
 use lexer::is_unterminated;
 use vm::VM;
 
 use crate::cli::{use_pipeline, Cli};
 use crate::pipeline::{ErrorReporter, PipelineStatus, SourcesCache};
-
-macro_rules! print_flush {
-    ( $($t:tt)* ) => {
-        {
-            let mut stdout = std::io::stdout();
-            write!(stdout, $($t)* ).unwrap();
-            stdout.flush().unwrap();
-        }
-    }
-}
 
 /// Indefinitely prompts a new expression from stdin and executes it.
 pub(crate) fn repl(
@@ -32,9 +26,11 @@ pub(crate) fn repl(
     mut sources: SourcesCache,
     externals: Externals,
     mut vm: VM,
-) -> PipelineStatus {
+) -> miette::Result<PipelineStatus> {
     let mut analyzer = Analyzer::new();
     sources.register(dir);
+
+    let mut editor = editor().context("Could not start REPL")?;
 
     let mut status = PipelineStatus::Success;
 
@@ -43,95 +39,133 @@ pub(crate) fn repl(
     let mut starting_source: Option<SourceId> = None;
     let name = Name::new("stdin");
 
-    // Loop over the user's input until they exit the REPL.
-    while let Some(source) = parse_input() {
-        // Inject the source directly into the importer, in order to know
-        // its attributed id. It will be used later to inject the next
-        // successfully parsed prompt.
-        let importer = sources.last_mut();
-        if let ImportResult::Success(imported) = importer.insert(source) {
-            let mut analysis = analyzer.inject(
-                Inject {
-                    name: name.clone(),
-                    imported,
-                    attached: starting_source,
-                },
-                importer,
-                &externals,
-            );
+    loop {
+        let line = editor.read_line(&Prompt);
 
-            // Reuse the same diagnotics by moving them, requiring to keep track
-            // if there was any error since they will be consumed before being
-            // able to cancel the analysis (the errors need the context that is
-            // dropped when the analysis is reverted).
-            let diagnostics = analysis.take_diagnostics();
-            let is_ready = diagnostics.is_empty();
+        match line {
+            Ok(Signal::Success(source)) => {
+                let source = OwnedSource::new(source, "stdin".to_owned());
+                let importer = sources.last_mut();
+                if let ImportResult::Success(imported) = importer.insert(source) {
+                    let mut analysis = analyzer.inject(
+                        Inject {
+                            name: name.clone(),
+                            imported,
+                            attached: starting_source,
+                        },
+                        importer,
+                        &externals,
+                    );
 
-            let errors = importer.take_errors();
+                    // Reuse the same diagnotics by moving them, requiring to keep track
+                    // if there was any error since they will be consumed before being
+                    // able to cancel the analysis (the errors need the context that is
+                    // dropped when the analysis is reverted).
+                    let diagnostics = analysis.take_diagnostics();
+                    let is_ready = diagnostics.is_empty();
 
-            status = status.compose(use_pipeline(
-                &name,
-                analysis.attributed_id(),
-                analysis.analyzer(),
-                &externals,
-                &mut vm,
-                diagnostics,
-                errors,
-                &sources,
-                config,
-            ));
+                    let errors = importer.take_errors();
 
-            // Remember the successfully injected source, or revert the analysis.
-            if is_ready {
-                starting_source = Some(analysis.attributed_id());
-            } else {
-                analysis.revert();
+                    status = status.compose(use_pipeline(
+                        &name,
+                        analysis.attributed_id(),
+                        analysis.analyzer(),
+                        &externals,
+                        &mut vm,
+                        diagnostics,
+                        errors,
+                        &sources,
+                        config,
+                    ));
+
+                    // Remember the successfully injected source, or revert the analysis.
+                    if is_ready {
+                        starting_source = Some(analysis.attributed_id());
+                    } else {
+                        analysis.revert();
+                    }
+                } else {
+                    // Probably hit some parse errors, so we skip any further analysis and
+                    // directly display the errors. There should be no actual diagnostics
+                    // in the pipeline, but we consume them anyway to reuse the same
+                    // end-of-pipeline logic.
+                    let diagnostics = analyzer.take_diagnostics();
+                    status = status.compose(use_pipeline(
+                        &name,
+                        SourceId(0), // this value has no importance
+                        &analyzer,
+                        &externals,
+                        &mut vm,
+                        diagnostics,
+                        importer.take_errors(),
+                        &sources,
+                        config,
+                    ));
+                }
             }
-        } else {
-            // Probably hit some parse errors, so we skip any further analysis and
-            // directly display the errors. There should be no actual diagnostics
-            // in the pipeline, but we consume them anyway to reuse the same
-            // end-of-pipeline logic.
-            let diagnostics = analyzer.take_diagnostics();
-            status = status.compose(use_pipeline(
-                &name,
-                SourceId(0), // this value has no importance
-                &analyzer,
-                &externals,
-                &mut vm,
-                diagnostics,
-                importer.take_errors(),
-                &sources,
-                config,
-            ));
+            Ok(Signal::CtrlC) => eprintln!("^C"),
+            Ok(Signal::CtrlD) => break Ok(status),
+            Err(err) => {
+                eprintln!("Error: {err:?}");
+                break Ok(status);
+            }
         }
     }
-    status
 }
 
-/// Parses stdin until the user's input forms a source code with no unclosed delimiters
-/// and return the source.
-fn parse_input() -> Option<OwnedSource> {
-    let stdin = io::stdin();
-    let lines = stdin.lock().lines();
-    let mut content = String::new();
-    print_flush!("=> ");
-    for line in lines {
-        let line = line.expect("couldn't read line from stdin");
-        content.push_str(&line);
-        if line.ends_with('\\') {
-            content.push('\n');
-            print_flush!("-> ");
-            continue;
-        }
-
-        if is_unterminated(&content) {
-            content.push('\n');
-            print_flush!("-> ");
-            continue;
-        }
-
-        return Some(OwnedSource::new(content, "stdin".to_owned()));
+fn editor() -> miette::Result<Reedline> {
+    let mut editor = Reedline::create().with_validator(Box::new(TerminatedValidator));
+    if let Some(project_dir) = project_dir() {
+        let history_path = project_dir.data_dir().join("history.txt");
+        let history = Box::new(
+            FileBackedHistory::with_file(4000, history_path.clone())
+                .into_diagnostic()
+                .with_context(|| {
+                    format!("Could not open history file: {}", history_path.display())
+                })?,
+        );
+        editor = editor.with_history(history);
     }
-    None
+    Ok(editor)
+}
+
+struct Prompt;
+
+impl reedline::Prompt for Prompt {
+    fn render_prompt_left(&self) -> Cow<str> {
+        Cow::Borrowed("=> ")
+    }
+
+    fn render_prompt_right(&self) -> Cow<str> {
+        Cow::Borrowed("")
+    }
+
+    fn render_prompt_indicator(&self, _: PromptEditMode) -> Cow<str> {
+        Cow::Borrowed("")
+    }
+
+    fn render_prompt_multiline_indicator(&self) -> Cow<str> {
+        Cow::Borrowed("... ")
+    }
+
+    fn render_prompt_history_search_indicator(
+        &self,
+        history_search: PromptHistorySearch,
+    ) -> Cow<str> {
+        match history_search.status {
+            PromptHistorySearchStatus::Passing => Cow::Borrowed("(reverse-i-search)`"),
+            PromptHistorySearchStatus::Failing => Cow::Borrowed("(failed reverse-i-search)`"),
+        }
+    }
+}
+
+struct TerminatedValidator;
+
+impl reedline::Validator for TerminatedValidator {
+    fn validate(&self, line: &str) -> ValidationResult {
+        match is_unterminated(line) {
+            true => ValidationResult::Incomplete,
+            false => ValidationResult::Complete,
+        }
+    }
 }

--- a/cli/src/std.rs
+++ b/cli/src/std.rs
@@ -4,7 +4,7 @@ use analyzer::analyze;
 use analyzer::name::Name;
 use analyzer::reef::{Externals, Reef};
 use analyzer::relations::SourceId;
-use directories::ProjectDirs;
+use cli::project_dir;
 use std::path::{Path, PathBuf};
 use vm::VM;
 
@@ -50,7 +50,7 @@ fn find_std() -> PathBuf {
         return dir;
     }
 
-    if let Some(proj_dirs) = ProjectDirs::from("", "", "moshell") {
+    if let Some(proj_dirs) = project_dir() {
         let lib = proj_dirs.data_dir().join("lib");
         if lib.exists() {
             return lib;


### PR DESCRIPTION
With the help of *reedline*, make the REPL more usable by having arrow keys, reverse search and completion for file names.

If the standard input is a terminal, switch to a dedicated *reedline* editor. It not, the code is simply read from stdin, so it can be used in external scripts. The command history is saved in the user files.

Command completion has been implemented by combining the parser output for the context handling, and the lexer output to put the completion cursor at the right spot.