### PR TITLE
Add macOS support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,12 +56,12 @@ jobs:
           mv target/release/moshell build-output/moshell
           date +"%D" > build-output/nightly-version
 
-      - name: upload artifact
-        uses: burnett01/rsync-deployments@6.0.0
-        with:
-          switches: -avzr --delete
-          path: build-output/
-          remote_path: /srv/moshell/releases/nightly/x86_64-apple-darwin
-          remote_host: moshell.dev
-          remote_user: maxime
-          remote_key: ${{ secrets.SSH_SERVER }}
+      - name: Upload artifact
+        run: |
+          brew install rsync
+          mkdir -m 700 -p ~/.ssh
+          echo "$REMOTE_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          rsync -e 'ssh -o StrictHostKeyChecking=no' -avzr --delete build-output/ maxime@moshell.dev:/srv/moshell/releases/nightly/x86_64-apple-darwin
+        env:
+         REMOTE_KEY: ${{ secrets.SSH_SERVER }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  distribute:
+  distribute-x86_64-linux-gnu:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,7 +32,36 @@ jobs:
         with:
           switches: -avzr --delete
           path: build-output/
-          remote_path: /srv/moshell/releases/nightly/
+          remote_path: /srv/moshell/releases/nightly/x86_64-linux-gnu
+          remote_host: moshell.dev
+          remote_user: maxime
+          remote_key: ${{ secrets.SSH_SERVER }}
+
+  distribute-x86_64-apple-darwin:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup toolchain and cache
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Remove C++ concepts
+        run: find vm/src \( -name '*.cpp' -o -name '*.h' \) -exec sed -i -e '/\s*requires/d' {} +
+
+      - name: build
+        run: |
+          cargo build --release
+          mkdir build-output
+          zip -r build-output/lib.zip lib
+          mv target/release/moshell build-output/moshell
+          date +"%D" > build-output/nightly-version
+
+      - name: upload artifact
+        uses: burnett01/rsync-deployments@6.0.0
+        with:
+          switches: -avzr --delete
+          path: build-output/
+          remote_path: /srv/moshell/releases/nightly/x86_64-apple-darwin
           remote_host: moshell.dev
           remote_user: maxime
           remote_key: ${{ secrets.SSH_SERVER }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,3 +39,18 @@ jobs:
     - name: Clippy Check
       run: cargo clippy --tests
       continue-on-error: true
+
+  build-macos:
+    if: github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup toolchain and cache
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+
+    - name: Remove C++ concepts
+      run: find vm/src \( -name '*.cpp' -o -name '*.h' \) -exec sed -i -e '/\s*requires/d' {} +
+
+    - name: Build
+      run: cargo build

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,19 @@
+#!/bin/sh
+# shellcheck shell=dash
+
 set -eu
 
-NIGHTLY_URL=https://moshell.dev/releases/nightly
+if ! [ "$(uname -m)" = "x86_64" ]; then
+  echo "Unsupported $(uname -m) architecture" >&2
+  exit 1
+fi
+case "$(uname -s)" in
+  Linux) target=x86_64-linux-gnu;;
+  Darwin) target=x86_64-apple-darwin;;
+  *) echo "Unsupported $(uname -s) OS" >&2; exit 1;;
+esac
+
+NIGHTLY_URL=https://moshell.dev/releases/nightly/$target
 
 BIN_PATH=~/.local/bin
 LIBS_PATH=~/.local/share/moshell

--- a/setup.sh
+++ b/setup.sh
@@ -8,15 +8,22 @@ if ! [ "$(uname -m)" = "x86_64" ]; then
   exit 1
 fi
 case "$(uname -s)" in
-  Linux) target=x86_64-linux-gnu;;
-  Darwin) target=x86_64-apple-darwin;;
-  *) echo "Unsupported $(uname -s) OS" >&2; exit 1;;
+  Linux)
+    TARGET=x86_64-linux-gnu
+    LIBS_PATH=~/.local/share/moshell
+    ;;
+  Darwin)
+    TARGET=x86_64-apple-darwin
+    LIBS_PATH=~/Library/Application\ Support/moshell
+    ;;
+  *)
+    echo "Unsupported $(uname -s) OS" >&2
+    exit 1
+    ;;
 esac
 
-NIGHTLY_URL=https://moshell.dev/releases/nightly/$target
-
+NIGHTLY_URL=https://moshell.dev/releases/nightly/$TARGET
 BIN_PATH=~/.local/bin
-LIBS_PATH=~/.local/share/moshell
 
 NIGHTLY_VERSION=$(wget -qO- $NIGHTLY_URL/nightly-version)
 
@@ -26,28 +33,28 @@ if [ -e $BIN_PATH/moshell ] && [ "$(date -r $BIN_PATH/moshell +"%D")" = "$NIGHTL
   exit 0
 fi
 
-mkdir -p $BIN_PATH $LIBS_PATH
+mkdir -p "$BIN_PATH" "$LIBS_PATH"
 
 # setup binaries
 echo Setting up Moshell nightly version of "$NIGHTLY_VERSION"
 echo Downloading $NIGHTLY_URL/bin ...
-wget -qc $NIGHTLY_URL/moshell -P $BIN_PATH
-chmod +x $BIN_PATH/moshell
-[ -e $BIN_PATH/msh ] || ln -s $BIN_PATH/moshell $BIN_PATH/msh
+wget -qc $NIGHTLY_URL/moshell -P "$BIN_PATH"
+chmod +x "$BIN_PATH/moshell"
+[ -e "$BIN_PATH/msh" ] || ln -s "$BIN_PATH/moshell" "$BIN_PATH/msh"
 
 # setup standard library
 echo Downloading $NIGHTLY_URL/lib.zip ...
-wget -qc $NIGHTLY_URL/lib.zip -P $LIBS_PATH
+wget -qc $NIGHTLY_URL/lib.zip -P "$LIBS_PATH"
 echo Unzipping library
 rm -rf "$LIBS_PATH/lib"
-unzip -q $LIBS_PATH/lib.zip -d $LIBS_PATH && rm $LIBS_PATH/lib.zip
+unzip -q "$LIBS_PATH/lib.zip" -d "$LIBS_PATH" && rm "$LIBS_PATH/lib.zip"
 
 
 echo Moshell Nightly version "$NIGHTLY_VERSION" Successfully installed!
 echo "Binary : $BIN_PATH/moshell"
 echo "Stdlib : $LIBS_PATH/lib"
 
-if ! echo "$PATH" | grep -q $BIN_PATH; then
+if ! echo "$PATH" | grep -q "$BIN_PATH"; then
   echo
   echo $BIN_PATH not found in '$PATH' variable
   echo Do you want to add $BIN_PATH in your '$PATH' ? [Y/n]

--- a/vm/src/byte_reader.cpp
+++ b/vm/src/byte_reader.cpp
@@ -1,7 +1,7 @@
 #include "byte_reader.h"
 
-ByteReader::ByteReader(const char *bytes, size_t byte_count)
-    : bytes{reinterpret_cast<const std::byte *>(bytes)}, byte_count{byte_count}, pos{0} {}
+ByteReader::ByteReader(const std::byte *bytes, size_t byte_count)
+    : bytes{bytes}, byte_count{byte_count}, pos{0} {}
 
 size_t ByteReader::position() const {
     return pos;

--- a/vm/src/byte_reader.h
+++ b/vm/src/byte_reader.h
@@ -14,7 +14,7 @@ class ByteReader {
     size_t pos;
 
 public:
-    ByteReader(const char *bytes, size_t byte_count);
+    ByteReader(const std::byte *bytes, size_t byte_count);
 
     ByteReader(const ByteReader &other) = delete;
     ByteReader &operator=(const ByteReader &other) = delete;

--- a/vm/src/conversions.h
+++ b/vm/src/conversions.h
@@ -1,11 +1,21 @@
 #pragma once
 
-template <typename T>
-T ntohl(T net) {
-    T host = 0;
-    for (size_t i = 0; i < sizeof(T); i++) {
-        host <<= 8;
-        host |= (net >> (i * 8)) & 0xFF;
+#include <algorithm>
+
+namespace msh {
+    /**
+     * Read a value from a byte array in network byte order (big endian) and convert it to host byte order.
+     *
+     * @tparam T The type of the value to read.
+     * @param bytes The byte array to read from.
+     * @return The value read.
+     */
+    template <typename T>
+    T read_big_endian(const std::byte *bytes)
+        requires std::is_trivial_v<T>
+    {
+        T val;
+        std::reverse_copy(bytes, bytes + sizeof(T), reinterpret_cast<std::byte *>(&val));
+        return val;
     }
-    return host;
 }

--- a/vm/src/definitions/loader.cpp
+++ b/vm/src/definitions/loader.cpp
@@ -7,7 +7,7 @@
 #define MAPPINGS_ATTRIBUTE 1
 
 namespace msh {
-    void loader::load_raw_bytes(const char *bytes, size_t size, pager &pager, msh::heap &heap) {
+    void loader::load_raw_bytes(const std::byte *bytes, size_t size, pager &pager, msh::heap &heap) {
         ByteReader reader(bytes, size);
 
         ConstantPool tmp_pool = load_constant_pool(reader, heap);
@@ -72,7 +72,7 @@ namespace msh {
         return exported.at(name);
     }
 
-    const char *loader::get_instructions(size_t index) const {
+    const std::byte *loader::get_instructions(size_t index) const {
         return concatened_instructions.data() + index;
     }
 
@@ -85,7 +85,7 @@ namespace msh {
         uint8_t return_byte_count = reader.read<uint8_t>();
         uint32_t instruction_count = reader.read<uint32_t>();
 
-        const char *instructions = reader.read_n<char>(instruction_count);
+        const std::byte *instructions = reader.read_n<std::byte>(instruction_count);
         size_t effective_address = concatened_instructions.size();
         std::copy(instructions, instructions + instruction_count, std::back_inserter(concatened_instructions));
 

--- a/vm/src/definitions/loader.h
+++ b/vm/src/definitions/loader.h
@@ -57,7 +57,7 @@ namespace msh {
         /**
          * The instructions bytes that have been loaded and concatenated.
          */
-        std::vector<char> concatened_instructions;
+        std::vector<std::byte> concatened_instructions;
 
         /**
          * The unresolved symbols that have been found and need to be resolved.
@@ -75,7 +75,7 @@ namespace msh {
          * @param pager The pager where to initialize the memory.
          * @param heap The heap heap where to store the constant strings.
          */
-        void load_raw_bytes(const char *bytes, size_t size, pager &pager, msh::heap &heap);
+        void load_raw_bytes(const std::byte *bytes, size_t size, pager &pager, msh::heap &heap);
 
         /**
          * Gets the function definition for the given name.
@@ -117,7 +117,7 @@ namespace msh {
          * @param index The index of the instructions.
          * @return The instructions bytes.
          */
-        const char *get_instructions(size_t index) const;
+        const std::byte *get_instructions(size_t index) const;
 
         /**
          * Resolves all the unresolved symbols.

--- a/vm/src/memory/call_stack.cpp
+++ b/vm/src/memory/call_stack.cpp
@@ -157,10 +157,10 @@ call_stack_iterator &call_stack_iterator::operator++() {
     return *this;
 }
 
-bool call_stack_iterator::operator==(const call_stack_iterator &other) {
+bool call_stack_iterator::operator==(const call_stack_iterator &other) const {
     return other.call_stack == this->call_stack && other.pos == this->pos && other.frame_ord == this->frame_ord;
 }
 
-bool call_stack_iterator::operator!=(const call_stack_iterator &other) {
-    return other.call_stack != this->call_stack || other.pos != this->pos || other.frame_ord != this->frame_ord;
+bool call_stack_iterator::operator!=(const call_stack_iterator &other) const {
+    return !(*this == other);
 }

--- a/vm/src/memory/call_stack.h
+++ b/vm/src/memory/call_stack.h
@@ -113,7 +113,7 @@ public:
 
     call_stack_iterator(CallStack *call_stack, size_t pos, size_t frame_ord);
     call_stack_iterator &operator++();
-    bool operator==(const call_stack_iterator &other);
-    bool operator!=(const call_stack_iterator &other);
+    bool operator==(const call_stack_iterator &other) const;
+    bool operator!=(const call_stack_iterator &other) const;
     stack_frame operator*();
 };

--- a/vm/src/vm.cpp
+++ b/vm/src/vm.cpp
@@ -102,7 +102,7 @@ moshell_vm moshell_vm_init() {
 int moshell_vm_register(moshell_vm vm, const char *bytes, size_t byte_count) {
     vm_state &state = *static_cast<vm_state *>(vm.vm);
     try {
-        state.loader.load_raw_bytes(bytes, byte_count, state.pager, state.heap);
+        state.loader.load_raw_bytes(reinterpret_cast<const std::byte *>(bytes), byte_count, state.pager, state.heap);
         return 0;
     } catch (const std::exception &e) {
         std::cerr << e.what() << std::endl;


### PR DESCRIPTION
The nightly setup script now checks the operating system and the architecture. Binaries are now built for the Darwin target. It fixes the macro conflict reported in #166.

The binary for macOS is crafted with the system Apple Clang compiler, that doesn't support C++ 20 concepts, so they are removed before the build. It may be better to create a C macro that checks for the compiler.