### PR TITLE
Implement directory related primitives

### DIFF
--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -810,6 +810,21 @@ impl<'a, 'b, 'e> SymbolCollector<'a, 'b, 'e> {
                 }
                 true
             }
+            "cd" => {
+                let name = Name::from(vec!["std".to_owned(), command.to_owned()]);
+                let symbol = self.identify_symbol(
+                    *self.stack.last().unwrap(),
+                    env_id,
+                    SymbolLocation {
+                        name,
+                        is_current_reef_explicit: false,
+                    },
+                    call.arguments[0].segment().clone(),
+                    SymbolRegistry::Objects,
+                );
+                self.current_env().annotate(call, symbol);
+                true
+            }
             _ => false,
         }
     }

--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -8,7 +8,7 @@ use ast::r#type::Type;
 use ast::r#use::{Import as ImportExpr, InclusionPathItem};
 use ast::range;
 use ast::value::LiteralValue;
-use ast::variable::VarName;
+use ast::variable::{Tilde, VarName};
 use ast::Expr;
 use context::source::{ContentId, SourceSegment, SourceSegmentHolder};
 use range::Iterable;
@@ -548,6 +548,28 @@ impl<'a, 'b, 'e> SymbolCollector<'a, 'b, 'e> {
             Expr::Subscript(sub) => {
                 self.tree_walk(state, &sub.target, to_visit);
                 self.tree_walk(state, &sub.index, to_visit);
+            }
+            Expr::Tilde(tilde) => {
+                let function_name = match &tilde.structure {
+                    Tilde::HomeDir(Some(expr)) => {
+                        self.tree_walk(state, expr, to_visit);
+                        "home_dir"
+                    }
+                    Tilde::HomeDir(None) => "current_home_dir",
+                    Tilde::WorkingDir => "working_dir",
+                };
+                let name = Name::from(vec!["std".to_owned(), function_name.to_owned()]);
+                let symbol = self.identify_symbol(
+                    *self.stack.last().unwrap(),
+                    state.module,
+                    SymbolLocation {
+                        name,
+                        is_current_reef_explicit: false,
+                    },
+                    tilde.segment(),
+                    SymbolRegistry::Objects,
+                );
+                self.current_env().annotate(tilde, symbol);
             }
             Expr::Substitution(sub) => {
                 self.current_env().begin_scope();

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -18,7 +18,7 @@ use crate::range::{Iterable, Subscript};
 use crate::substitution::Substitution;
 use crate::test::Test;
 use crate::value::{Literal, TemplateString};
-use crate::variable::{Assign, Identifier, VarDeclaration, VarReference};
+use crate::variable::{Assign, Identifier, TildeExpansion, VarDeclaration, VarReference};
 
 pub mod call;
 pub mod control_flow;
@@ -83,6 +83,7 @@ pub enum Expr<'a> {
     Range(Iterable<'a>),
     Subscript(Subscript<'a>),
     FieldAccess(FieldAccess<'a>),
+    Tilde(TildeExpansion<'a>),
 
     FunctionDeclaration(FunctionDeclaration<'a>),
 
@@ -130,6 +131,7 @@ impl SourceSegmentHolder for Expr<'_> {
             Expr::VarDeclaration(var_declaration) => var_declaration.segment.clone(),
             Expr::Range(range) => range.segment(),
             Expr::Subscript(subscript) => subscript.segment(),
+            Expr::Tilde(tilde) => tilde.segment(),
             Expr::FunctionDeclaration(function_declaration) => function_declaration.segment.clone(),
             Expr::Parenthesis(parenthesis) => parenthesis.segment.clone(),
             Expr::Subshell(subshell) => subshell.segment.clone(),

--- a/ast/src/variable.rs
+++ b/ast/src/variable.rs
@@ -121,3 +121,16 @@ impl Assign<'_> {
         }
     }
 }
+
+/// An expansion of an expression related to directories.
+#[segment_holder]
+#[derive(Debug, Clone, PartialEq, DebugPls)]
+pub struct TildeExpansion<'a> {
+    pub structure: Tilde<'a>,
+}
+
+#[derive(Debug, Clone, PartialEq, DebugPls)]
+pub enum Tilde<'a> {
+    HomeDir(Option<Box<Expr<'a>>>),
+    WorkingDir,
+}

--- a/cli/lang_tests/flow/change_dir.msh
+++ b/cli/lang_tests/flow/change_dir.msh
@@ -1,0 +1,10 @@
+// Run:
+//   status: success
+//   stdout:
+//    content
+
+mkdir foo-bar-baz
+cd foo-bar-baz
+echo 'content' > foo.txt
+cd ..
+cat foo-bar-baz/foo.txt

--- a/lexer/src/lexer.rs
+++ b/lexer/src/lexer.rs
@@ -140,6 +140,7 @@ impl<'a> Lexer<'a> {
                 TokenType::CurlyRightBracket
             }
             '@' => TokenType::At,
+            '~' => TokenType::Tilde,
             '$' => {
                 self.state = LexerState::Variable;
                 TokenType::Dollar

--- a/lexer/src/literal.rs
+++ b/lexer/src/literal.rs
@@ -26,6 +26,7 @@ pub(crate) fn is_not_identifier_part(c: char) -> bool {
             | ')'
             | '{'
             | '}'
+            | '~'
             | '$'
             | ','
             | '.'

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -104,6 +104,8 @@ pub enum TokenType {
     SemiColon,
     #[assoc(str = "=")]
     Equal,
+    #[assoc(str = "~")]
+    Tilde,
     #[assoc(str = "$")]
     Dollar,
     #[assoc(str = "&")]

--- a/lexer/src/token.rs
+++ b/lexer/src/token.rs
@@ -225,11 +225,6 @@ impl TokenType {
         matches!(self, Not | Minus)
     }
 
-    ///is this lexeme a lexeme that cannot fusion with other glued tokens
-    pub fn is_identifier_bound(self) -> bool {
-        matches!(self, NewLine | SemiColon | Less | Bar | Greater | And | Or)
-    }
-
     /// Tests if this token marks the end of a call statement's arguments.
     pub fn is_call_bound(self) -> bool {
         matches!(

--- a/lib/std.msh
+++ b/lib/std.msh
@@ -44,3 +44,8 @@ fun some[A](v: A) -> Option[A];
 /// Instantiate a None option
 // TODO make Option's generic parameter (`A`) covariant to return an Option[Nothing]
 fun none[A]() -> Option[A];
+
+/// Changes the current working directory to a relative or an absolute path.
+///
+/// @panics if the operation fails.
+fun cd(path: String);

--- a/lib/std.msh
+++ b/lib/std.msh
@@ -47,5 +47,18 @@ fun none[A]() -> Option[A];
 
 /// Changes the current working directory to a relative or an absolute path.
 ///
-/// @panics if the operation fails.
+/// @panics if the path is not accessible or is not a directory.
 fun cd(path: String);
+
+/// Gets the current working directory.
+///
+/// @panics if the current working directory does not exist.
+fun working_dir() -> String;
+
+/// Gets the home directory of the user.
+fun home_dir(username: String) -> Option[String];
+
+/// Gets the home directory of the current user.
+///
+/// @panics if the current user does not have a home directory specified.
+fun current_home_dir() -> String;

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -292,7 +292,7 @@ impl<'a> Parser<'a> {
             {
                 self.call()
             }
-            Dot => self.call(),
+            Dot | Tilde => self.call(),
             Backtick => {
                 let callee = self.back_string_literal();
                 self.call_arguments(callee.map(Expr::TemplateString)?)

--- a/parser/tests/expr.rs
+++ b/parser/tests/expr.rs
@@ -731,10 +731,7 @@ fn classic_call_no_regression() {
                 literal(source.source, "1..=9"),
                 Expr::TemplateString(TemplateString {
                     parts: vec![
-                        Expr::Literal(Literal {
-                            parsed: true.into(),
-                            segment: find_in(source.source, "true")
-                        }),
+                        literal(source.source, "true"),
                         Expr::VarReference(VarReference {
                             name: VarName::User("a"),
                             segment: find_in(source.source, "$a")

--- a/vm/src/stdlib_natives.cpp
+++ b/vm/src/stdlib_natives.cpp
@@ -3,6 +3,8 @@
 #include "memory/heap.h"
 #include <charconv>
 #include <cmath>
+#include <cstring>
+#include <unistd.h>
 #include <iostream>
 
 static void int_to_string(OperandStack &caller_stack, runtime_memory &mem) {
@@ -79,6 +81,13 @@ static void some(OperandStack &, runtime_memory &) {
 
 static void none(OperandStack &caller_stack, runtime_memory &) {
     caller_stack.push(nullptr);
+}
+
+static void cd(OperandStack &caller_stack, runtime_memory &) {
+    const std::string &path = caller_stack.pop_reference().get<const std::string>();
+    if (chdir(path.c_str()) == -1) {
+        throw RuntimeException("Failed to change directory to " + path + ": " + strerror(errno) + ".");
+    }
 }
 
 static void floor(OperandStack &caller_stack, runtime_memory &) {
@@ -252,6 +261,7 @@ natives_functions_t load_natives() {
         {"std::new_vec", new_vec},
         {"std::some", some},
         {"std::none", none},
+        {"std::cd", cd},
 
         {"std::memory::gc", gc},
         {"std::memory::empty_operands", is_operands_empty},

--- a/vm/tests/flow.rs
+++ b/vm/tests/flow.rs
@@ -157,3 +157,14 @@ fn str_split() {
         Some("this is a string, hello strings ! ! ! babibel".into())
     )
 }
+
+#[test]
+fn working_directory_via_tilde() {
+    let mut runner = Runner::default();
+    runner.eval(
+        "use std::working_dir
+        use std::assert::assert
+        val wd = $(echo ~+)
+        assert(working_dir() == $wd)",
+    );
+}


### PR DESCRIPTION
This adds the shell procedure `cd` to change the current working directory. It also allows the user to obtain their home directory and the directories of other users.

`cd` is implemented as a regular command, converted during the analysis phase into a function call. This special treatment is required in the collector and the resolver, and may be dropped in the future if the language adds proper user-defined functions/procedures that can be called without parentheses.

Tilde expansions are also handy shortcuts to certain functions. They must be at the beginning of an unquoted argument. In order to implement the parser for them properly, the `argument` parser has been completely rewritten to have fewer edge cases and repetitions *(the parser benchmark shows a ~5% time reduction)*.