### PR TITLE
Preserve pointer information during native operations

### DIFF
--- a/cli/lang_tests/flow/preserve_pointer_info.msh
+++ b/cli/lang_tests/flow/preserve_pointer_info.msh
@@ -1,0 +1,11 @@
+// Run:
+//   status: success
+//   stdout:
+//     This-is-a-very-long-phrase-that-is-captured-by-the-shell-
+
+val res = $(echo "This is a very long phrase that is captured by the shell").split(' ')
+var i = 0
+while $i < $res.len() {
+    echo -n "${res[$i]}-"
+    $i += 1
+}

--- a/vm/src/interpreter.cpp
+++ b/vm/src/interpreter.cpp
@@ -745,9 +745,7 @@ frame_status run_frame(runtime_state &state, stack_frame &frame, CallStack &call
             break;
         }
         case OP_DUP: {
-            int64_t value = operands.pop_int();
-            operands.push_int(value);
-            operands.push_int(value);
+            operands.dup_qword();
             break;
         }
         case OP_DUP_BYTE: {
@@ -757,20 +755,11 @@ frame_status run_frame(runtime_state &state, stack_frame &frame, CallStack &call
             break;
         }
         case OP_SWAP: {
-            int64_t a = operands.pop_int();
-            int64_t b = operands.pop_int();
-            operands.push_int(a);
-            operands.push_int(b);
+            operands.swap_upper_qwords();
             break;
         }
         case OP_SWAP_2: {
-            int64_t a = operands.pop_int();
-            int64_t b = operands.pop_int();
-            int64_t c = operands.pop_int();
-
-            operands.push_int(b);
-            operands.push_int(a);
-            operands.push_int(c);
+            operands.swap_upper_three_qwords();
             break;
         }
         case OP_POP_BYTE: {

--- a/vm/src/memory/operand_stack.cpp
+++ b/vm/src/memory/operand_stack.cpp
@@ -1,8 +1,8 @@
 #include "operand_stack.h"
 #include <cstring>
 
-OperandStack::OperandStack(char *const buff, size_t &position, size_t stack_capacity, std::vector<bool> &operands_refs)
-    : bytes{buff},
+OperandStack::OperandStack(char *buff, size_t &position, size_t stack_capacity, std::vector<bool> &operands_refs)
+    : bytes{reinterpret_cast<std::byte *>(buff)},
       current_pos{position},
       stack_capacity{stack_capacity},
       operands_refs{operands_refs} {}
@@ -51,7 +51,7 @@ double OperandStack::pop_double() {
     return pop<double>();
 }
 
-const char *OperandStack::pop_bytes(size_t n) {
+const std::byte *OperandStack::pop_bytes(size_t n) {
     if (current_pos < n) {
         throw OperandStackUnderflowError("operand stack is empty");
     }
@@ -67,14 +67,42 @@ void OperandStack::transfer(OperandStack &callee_stack, size_t n) {
 #endif
     memcpy(this->bytes + current_pos, callee_stack.bytes + (callee_stack.size() - n), n);
     this->current_pos += n;
+    operands_refs.insert(operands_refs.end(), callee_stack.operands_refs.end() - n, callee_stack.operands_refs.end());
 }
 
-void OperandStack::push(const char *bytes, size_t size) {
-    if (current_pos + size > stack_capacity) {
+void OperandStack::memmove(size_t dest, size_t src, size_t size) {
+    if (dest + size > stack_capacity) {
         throw StackOverflowError("exceeded stack capacity via operand stack");
     }
-    // inform that all pushed bytes are not object references
-    operands_refs.resize(operands_refs.size() + size, false);
-    memcpy(this->bytes + current_pos, bytes, size);
-    current_pos += size;
+    memcpy(bytes + dest, bytes + src, size);
+    operands_refs.insert(operands_refs.begin() + dest, operands_refs.begin() + src, operands_refs.begin() + src + size);
+    current_pos = dest + size;
+}
+
+void OperandStack::dup_qword() {
+    if (current_pos + sizeof(int64_t) > stack_capacity) {
+        throw StackOverflowError("exceeded stack capacity via operand stack");
+    }
+    memcpy(this->bytes + current_pos, this->bytes + current_pos - sizeof(int64_t), sizeof(int64_t));
+    operands_refs.resize(operands_refs.size() + sizeof(int64_t));
+    operands_refs[operands_refs.size() - sizeof(int64_t)] = operands_refs[operands_refs.size() - sizeof(int64_t) * 2];
+    current_pos += sizeof(int64_t);
+}
+
+void OperandStack::swap_upper_qwords() {
+    if (current_pos < sizeof(int64_t) * 2) {
+        throw OperandStackUnderflowError("operand stack is empty");
+    }
+    std::swap(*(int64_t *)(bytes + current_pos - sizeof(int64_t)), *(int64_t *)(bytes + current_pos - sizeof(int64_t) * 2));
+    std::vector<bool>::swap(operands_refs[operands_refs.size() - sizeof(int64_t)], operands_refs[operands_refs.size() - sizeof(int64_t) * 2]);
+}
+
+void OperandStack::swap_upper_three_qwords() {
+    if (current_pos < sizeof(int64_t) * 3) {
+        throw OperandStackUnderflowError("operand stack is empty");
+    }
+    std::swap(*(int64_t *)(bytes + current_pos - sizeof(int64_t)), *(int64_t *)(bytes + current_pos - sizeof(int64_t) * 3));
+    std::swap(*(int64_t *)(bytes + current_pos - sizeof(int64_t) * 2), *(int64_t *)(bytes + current_pos - sizeof(int64_t) * 3));
+    std::vector<bool>::swap(operands_refs[operands_refs.size() - sizeof(int64_t)], operands_refs[operands_refs.size() - sizeof(int64_t) * 3]);
+    std::vector<bool>::swap(operands_refs[operands_refs.size() - sizeof(int64_t) * 2], operands_refs[operands_refs.size() - sizeof(int64_t) * 3]);
 }

--- a/vm/src/stdlib_natives.cpp
+++ b/vm/src/stdlib_natives.cpp
@@ -166,8 +166,9 @@ static void parse_int_radix(OperandStack &caller_stack, runtime_memory &mem) {
 }
 
 static void str_split(OperandStack &caller_stack, runtime_memory &mem) {
-    const std::string &delim = caller_stack.pop_reference().get<const std::string>();
-    const std::string &str = caller_stack.pop_reference().get<const std::string>();
+    msh::native_procedure<msh::obj *> procedure(caller_stack);
+    const std::string &delim = procedure.pop_reference().get<const std::string>();
+    const std::string &str = procedure.pop_reference().get<const std::string>();
 
     msh::obj &res_obj = mem.emplace(msh::obj_vector());
     caller_stack.push_reference(res_obj);
@@ -188,7 +189,8 @@ static void str_split(OperandStack &caller_stack, runtime_memory &mem) {
 }
 
 static void str_bytes(OperandStack &caller_stack, runtime_memory &mem) {
-    const std::string &str = caller_stack.pop_reference().get<const std::string>();
+    msh::native_procedure<msh::obj *> procedure(caller_stack);
+    const std::string &str = procedure.pop_reference().get<const std::string>();
     msh::obj_vector res;
     res.reserve(str.length());
 


### PR DESCRIPTION
The garbage collector identify pointers by checking if a value in the operand stack is marked in a parallel array. Because there may only one reference, it is very important to preserve the information if it is a pointer or not.

Native operations popped directly from the stack. If they were allocating new things, the GC could be executed without any indication that the reference is in fact on the native C stack. The operand stack is now wrapped in those cases, to just peek the information and to delay the pop later.

Some instructions like the swap operation treated pointers as simple integers, they weren't updating the reference positions.

Those cases are now fixed.