### PR TITLE
Accept paths in expressions

### DIFF
--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -646,8 +646,8 @@ fn ascribe_var_reference(
 fn ascribe_identifier(ident: &Identifier, links: Links, exploration: &Exploration) -> TypedExpr {
     ascribe_var_reference(
         &VarReference {
-            name: VarName::User(ident.name),
-            segment: ident.segment.clone(),
+            name: VarName::User(ident.path.last().unwrap().name()),
+            segment: ident.segment(),
         },
         links,
         exploration,
@@ -2720,7 +2720,7 @@ mod tests {
 
     #[test]
     fn explicit_repeated_type_parameter() {
-        let source = Source::unknown("fun i[T, U](a: T, b: T) -> U; i[Int, String](4, 5)");
+        let source = Source::unknown("fun i[T, U](a: T, b: T) -> U; i::[Int, String](4, 5)");
         let res = extract_type(source);
         assert_eq!(res, Ok(STRING));
     }

--- a/analyzer/src/steps/typing/structure.rs
+++ b/analyzer/src/steps/typing/structure.rs
@@ -396,7 +396,6 @@ mod test {
     }
 
     #[test]
-    #[ignore] //FIXME see #167
     fn field_access_subscript() {
         let expr = extract_type(Source::unknown(
             r#"\
@@ -413,7 +412,6 @@ mod test {
     }
 
     #[test]
-    #[ignore] //FIXME see #167
     fn field_assign_subscript() {
         let expr = extract_type(Source::unknown(
             r#"\

--- a/ast/src/lib.rs
+++ b/ast/src/lib.rs
@@ -126,7 +126,7 @@ impl SourceSegmentHolder for Expr<'_> {
             Expr::Continue(source) => source.clone(),
             Expr::Break(source) => source.clone(),
             Expr::Return(return_) => return_.segment.clone(),
-            Expr::Identifier(identifier) => identifier.segment.clone(),
+            Expr::Identifier(identifier) => identifier.segment(),
             Expr::VarReference(var_reference) => var_reference.segment(),
             Expr::VarDeclaration(var_declaration) => var_declaration.segment.clone(),
             Expr::Range(range) => range.segment(),

--- a/ast/src/use.rs
+++ b/ast/src/use.rs
@@ -17,6 +17,15 @@ pub enum InclusionPathItem<'a> {
     Reef(SourceSegment),
 }
 
+impl InclusionPathItem<'_> {
+    pub fn name(&self) -> &str {
+        match self {
+            InclusionPathItem::Symbol(str, _) => str,
+            InclusionPathItem::Reef(_) => "reef",
+        }
+    }
+}
+
 impl SourceSegmentHolder for InclusionPathItem<'_> {
     fn segment(&self) -> SourceSegment {
         match self {

--- a/parser/src/aspects.rs
+++ b/parser/src/aspects.rs
@@ -1,7 +1,7 @@
 pub(super) mod binary_operation;
 pub(super) mod call;
 pub(super) mod detached;
-mod expr_list;
+pub(crate) mod expr_list;
 pub(super) mod function_declaration;
 pub(super) mod group;
 pub(super) mod if_else;

--- a/parser/src/aspects/expr_list.rs
+++ b/parser/src/aspects/expr_list.rs
@@ -8,7 +8,7 @@ use crate::moves::{blanks, eog, lookahead, of_type, MoveOperations};
 use crate::parser::{ParseResult, Parser};
 
 ///An aspect to parse expression lists
-pub(super) trait ExpressionListAspect<'a> {
+pub(crate) trait ExpressionListAspect<'a> {
     ///Implicit lists are whether A, (A), (A, B, ...) or () (if it can be empty)
     /// according that `(` and `)` are the [`start`]/[`end`] of the list expression.
     /// [`if_it_absent_msg`] used when an element is missing

--- a/parser/src/aspects/group.rs
+++ b/parser/src/aspects/group.rs
@@ -307,7 +307,7 @@ mod tests {
             val test = {\
                 val x = 8\n\n\n
                 8
-            }\n\
+            }\n
             (val x = 89; command call; 7)\
         }",
         );

--- a/parser/src/aspects/loop.rs
+++ b/parser/src/aspects/loop.rs
@@ -220,6 +220,7 @@ mod tests {
     use ast::group::{Block, Parenthesis};
     use ast::operation::BinaryOperator::And;
     use ast::operation::{BinaryOperation, BinaryOperator};
+    use ast::r#use::InclusionPathItem;
     use ast::range::{FilePattern, Iterable, NumericRange};
     use ast::value::Literal;
     use ast::variable::{
@@ -535,8 +536,10 @@ mod tests {
                     }),
                     increment: Expr::Assign(Assign {
                         left: Box::new(Expr::Identifier(Identifier {
-                            name: "i",
-                            segment: find_in_nth(source.source, "i", 2)
+                            path: vec![InclusionPathItem::Symbol(
+                                "i",
+                                find_in_nth(source.source, "i", 2)
+                            )],
                         })),
                         operator: AssignOperator::Assign,
                         value: Box::new(Expr::Binary(BinaryOperation {

--- a/parser/src/aspects/type.rs
+++ b/parser/src/aspects/type.rs
@@ -187,10 +187,10 @@ impl<'a> Parser<'a> {
 
     fn parse_parametrized(&mut self) -> ParseResult<ParametrizedType<'a>> {
         self.cursor.advance(spaces());
-        let path = self.parse_inclusion_path()?;
-        let mut segment = if let Some((first, last)) = path.first().zip(path.last()) {
-            first.segment().start..last.segment().end
-        } else {
+        if !matches!(
+            self.cursor.peek().token_type,
+            TokenType::Identifier | TokenType::Reef
+        ) {
             return self.expected(
                 format!(
                     "`{}` is not a valid type identifier.",
@@ -198,7 +198,9 @@ impl<'a> Parser<'a> {
                 ),
                 Unexpected,
             );
-        };
+        }
+        let path = self.parse_path()?;
+        let mut segment = path.segment();
 
         let (params, params_segment) = self.parse_optional_list(
             TokenType::SquaredLeftBracket,
@@ -210,7 +212,7 @@ impl<'a> Parser<'a> {
             segment.end = params_segment.end;
         }
         Ok(ParametrizedType {
-            path,
+            path: path.path,
             params,
             segment,
         })

--- a/parser/tests/integration/expr.rs
+++ b/parser/tests/integration/expr.rs
@@ -414,8 +414,10 @@ fn assign_iterable() {
         parsed,
         vec![Expr::Assign(Assign {
             left: Box::new(Expr::Identifier(Identifier {
-                name: "it",
-                segment: find_in(source.source, "it")
+                path: vec![InclusionPathItem::Symbol(
+                    "it",
+                    find_in(source.source, "it")
+                )],
             })),
             operator: AssignOperator::Assign,
             value: Box::new(Expr::Range(Iterable::Range(NumericRange {
@@ -493,8 +495,7 @@ fn constructor_assign() {
         parsed,
         vec![Expr::Assign(Assign {
             left: Box::new(Expr::Identifier(Identifier {
-                name: "a",
-                segment: find_in(source.source, "a")
+                path: vec![InclusionPathItem::Symbol("a", find_in(source.source, "a"))],
             })),
             operator: AssignOperator::Assign,
             value: Box::new(Expr::Unary(UnaryOperation {
@@ -643,7 +644,7 @@ fn block_method_call() {
 
 #[test]
 fn method_call_with_type_params_and_ref() {
-    let source = Source::unknown("$a.foo($d);echo \"${c.bar[T]()}\"");
+    let source = Source::unknown("$a.foo($d);echo \"${c.bar::[T]()}\"");
     let parsed = parse(source).expect("Failed to parse");
     assert_eq!(
         parsed,
@@ -680,7 +681,7 @@ fn method_call_with_type_params_and_ref() {
                                 params: Vec::new(),
                                 segment: find_in(source.source, "T")
                             })],
-                            segment: find_in(source.source, ".bar[T]()")
+                            segment: find_in(source.source, ".bar::[T]()")
                         })],
                         segment: find_between(source.source, "\"", "\"")
                     }),

--- a/parser/tests/integration/with_lexer.rs
+++ b/parser/tests/integration/with_lexer.rs
@@ -581,8 +581,10 @@ fn inner_var_ref() {
         parsed,
         vec![Expr::Assign(Assign {
             left: Box::new(Expr::Identifier(Identifier {
-                name: "dest",
-                segment: find_in(source.source, "dest"),
+                path: vec![InclusionPathItem::Symbol(
+                    "dest",
+                    find_in(source.source, "dest")
+                )],
             })),
             operator: AssignOperator::Assign,
             value: Box::new(Expr::TemplateString(TemplateString {

--- a/vm/tests/integration/objects.rs
+++ b/vm/tests/integration/objects.rs
@@ -67,7 +67,6 @@ fn test_structure_assign() {
 }
 
 #[test]
-#[ignore] //FIXME see #167
 fn test_structure_field_subscript() {
     let mut runner = Runner::default();
     let res = runner.try_eval(
@@ -87,7 +86,6 @@ fn test_structure_field_subscript() {
 }
 
 #[test]
-#[ignore] //FIXME see #167
 fn test_structure_field_subscript_assign() {
     let mut runner = Runner::default();
     let res = runner.try_eval(


### PR DESCRIPTION
Paths may only create programmatic calls, let's change that. Disambiguate the subscript syntax to not conflict with type parameters.

It may be used to import variables from other files:
```kt
val TAU = reef::math::PI
```
When ambiguous, type parameters must use the [turbo fish](https://turbo.fish) syntax:
```kt
foo().bar[0]() // Indexes with `0` and calls the result
foo().bar::[T]() // Call the `bar` method with the `T` type
```

To do that, the parser is less greedy and adapt the expression as it advance. For instance, a method call is now parsed as a field access first.

- Fixes #167 