### PR TITLE
Implement for in iterables

### DIFF
--- a/analyzer/src/steps/collect.rs
+++ b/analyzer/src/steps/collect.rs
@@ -552,6 +552,26 @@ impl<'a, 'b, 'e> SymbolCollector<'a, 'b, 'e> {
                 Iterable::Range(range) => {
                     self.tree_walk(state, &range.start, to_visit);
                     self.tree_walk(state, &range.end, to_visit);
+                    if let Some(step) = &range.step {
+                        self.tree_walk(state, step, to_visit);
+                    }
+                    let struct_name = if range.upper_inclusive {
+                        "InclusiveRange"
+                    } else {
+                        "Range"
+                    };
+                    let name = Name::from(vec!["std".to_owned(), struct_name.to_owned()]);
+                    let symbol = self.identify_symbol(
+                        *self.stack.last().unwrap(),
+                        state.module,
+                        SymbolLocation {
+                            name,
+                            is_current_reef_explicit: false,
+                        },
+                        range.segment(),
+                        SymbolRegistry::Objects,
+                    );
+                    self.current_env().annotate(range, symbol);
                 }
                 Iterable::Files(pattern) => {
                     self.tree_walk(state, &pattern.pattern, to_visit);

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -1582,8 +1582,8 @@ fn ascribe_types(
         }
         Expr::Unary(unary) => ascribe_unary(unary, exploration, links, diagnostics, state),
         Expr::Binary(bo) => ascribe_binary(bo, exploration, links, diagnostics, state),
-        Expr::Range(range) => ascribe_range(range, exploration, links, diagnostics, state),
         Expr::Subscript(sub) => ascribe_subscript(sub, exploration, links, diagnostics, state),
+        Expr::Range(range) => ascribe_range(range, exploration, links, diagnostics, state),
         Expr::Tilde(tilde) => ascribe_tilde(tilde, exploration, links, diagnostics, state),
         Expr::Casted(casted) => ascribe_casted(casted, exploration, links, diagnostics, state),
         Expr::Test(test) => ascribe_types(exploration, links, diagnostics, &test.expression, state),

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -25,7 +25,7 @@ use crate::steps::typing::assign::{
 use crate::steps::typing::bounds::TypesBounds;
 use crate::steps::typing::coercion::{
     check_type_annotation, coerce_condition, convert_description, convert_expression, convert_many,
-    resolve_type_annotation,
+    is_compatible, resolve_type_annotation,
 };
 use crate::steps::typing::exploration::{Exploration, Links};
 use crate::steps::typing::function::{
@@ -999,7 +999,68 @@ fn ascribe_range(
             }
             pattern
         }
-        r => todo!("ascribe range {r:?}"),
+        Iterable::Range(range) => {
+            let state = state.with_local_value(ExpressionValue::Expected(INT));
+            let start = ascribe_types(exploration, links, diagnostics, &range.start, state);
+            let end = ascribe_types(exploration, links, diagnostics, &range.end, state);
+            let step = range
+                .step
+                .as_ref()
+                .map(|step| ascribe_types(exploration, links, diagnostics, step, state))
+                .unwrap_or_else(|| TypedExpr {
+                    kind: ExprKind::Literal(LiteralValue::Int(1)),
+                    ty: INT,
+                    segment: range.segment(),
+                });
+
+            let args = [&start, &end, &step];
+            let not_integers = args
+                .into_iter()
+                .filter(|expr| !is_compatible(exploration, INT, expr.ty))
+                .collect::<Vec<_>>();
+            if !not_integers.is_empty() {
+                let mut diagnostic =
+                    Diagnostic::new(DiagnosticID::TypeMismatch, "Invalid integer range");
+                for &expr in &not_integers {
+                    diagnostic = diagnostic.with_observation(Observation::here(
+                        links.source,
+                        exploration.externals.current,
+                        expr.segment(),
+                        format!(
+                            "Got `{}`",
+                            exploration.new_type_view(expr.ty, &TypesBounds::inactive()),
+                        ),
+                    ));
+                }
+                diagnostics.push(diagnostic);
+                return start.poison();
+            }
+
+            let symbol = links.env().get_raw_symbol(range.segment()).unwrap();
+            let function_type_ref = exploration
+                .get_var(links.source, symbol, links.relations)
+                .unwrap()
+                .type_ref;
+            let Type::Structure(structure_source, _) =
+                exploration.get_type(function_type_ref).unwrap()
+            else {
+                unreachable!()
+            };
+            let constructor_id = exploration
+                .get_methods(function_type_ref, "<init>")
+                .unwrap()[0];
+            let function = exploration.get_function(ReefId(1), constructor_id).unwrap();
+            TypedExpr {
+                kind: ExprKind::FunctionCall(FunctionCall {
+                    function_id: constructor_id,
+                    arguments: vec![start, end, step],
+                    reef: ReefId(1),
+                    source_id: *structure_source,
+                }),
+                ty: function.return_type,
+                segment: range.segment(),
+            }
+        }
     }
 }
 

--- a/analyzer/src/steps/typing.rs
+++ b/analyzer/src/steps/typing.rs
@@ -31,6 +31,7 @@ use crate::steps::typing::exploration::{Exploration, Links};
 use crate::steps::typing::function::{
     declare_function, find_operand_implementation, infer_return, type_call, type_method, Return,
 };
+use crate::steps::typing::iterable::ascribe_for;
 use crate::steps::typing::lower::{convert_into_string, generate_unwrap};
 use crate::steps::typing::magic::{is_magic_variable_name, prepend_implicits};
 use crate::steps::typing::structure::{
@@ -58,6 +59,7 @@ mod lower;
 mod structure;
 mod view;
 
+mod iterable;
 pub mod magic;
 
 pub fn apply_types(
@@ -1519,14 +1521,15 @@ fn ascribe_types(
         }
         Expr::Unary(unary) => ascribe_unary(unary, exploration, links, diagnostics, state),
         Expr::Binary(bo) => ascribe_binary(bo, exploration, links, diagnostics, state),
-        Expr::Subscript(sub) => ascribe_subscript(sub, exploration, links, diagnostics, state),
         Expr::Range(range) => ascribe_range(range, exploration, links, diagnostics, state),
+        Expr::Subscript(sub) => ascribe_subscript(sub, exploration, links, diagnostics, state),
         Expr::Tilde(tilde) => ascribe_tilde(tilde, exploration, links, diagnostics, state),
         Expr::Casted(casted) => ascribe_casted(casted, exploration, links, diagnostics, state),
         Expr::Test(test) => ascribe_types(exploration, links, diagnostics, &test.expression, state),
         e @ (Expr::While(_) | Expr::Loop(_)) => {
             ascribe_loop(e, exploration, links, diagnostics, state)
         }
+        Expr::For(f) => ascribe_for(f, exploration, links, diagnostics, state),
         e @ (Expr::Continue(_) | Expr::Break(_)) => ascribe_continue_or_break(
             e,
             diagnostics,

--- a/analyzer/src/steps/typing/iterable.rs
+++ b/analyzer/src/steps/typing/iterable.rs
@@ -1,0 +1,198 @@
+use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
+use crate::relations::SymbolRef;
+use crate::steps::typing::bounds::TypesBounds;
+use crate::steps::typing::exploration::{Exploration, Links};
+use crate::steps::typing::{ascribe_types, ExpressionValue, TypingState};
+use crate::types::builtin::STRING_STRUCT;
+use crate::types::ctx::TypedVariable;
+use crate::types::hir::{ConditionalFor, ExprKind, ForLoop, RangeFor, TypedExpr};
+use crate::types::ty::Type;
+use crate::types::{hir, ERROR, GENERIC_VECTOR, UNIT};
+use ast::control_flow::{For, ForKind};
+use context::source::SourceSegmentHolder;
+
+pub(super) fn ascribe_for(
+    it: &For,
+    exploration: &mut Exploration,
+    links: Links,
+    diagnostics: &mut Vec<Diagnostic>,
+    state: TypingState,
+) -> TypedExpr {
+    match it.kind.as_ref() {
+        ForKind::Range(range) => {
+            let iterable = ascribe_types(exploration, links, diagnostics, &range.iterable, state);
+            let id = links.env().get_raw_symbol(range.segment.clone()).unwrap();
+            let SymbolRef::Local(receiver_id) = id else {
+                unreachable!()
+            };
+            exploration
+                .ctx
+                .set_local(links.source, receiver_id, TypedVariable::immutable(ERROR));
+            let iterable_type = exploration.get_type(iterable.ty).unwrap();
+            match iterable_type {
+                Type::Instantiated(vec, params) if *vec == GENERIC_VECTOR => {
+                    let param = params[0];
+                    exploration.ctx.set_local(
+                        links.source,
+                        receiver_id,
+                        TypedVariable::immutable(param),
+                    );
+                }
+                Type::Structure(_, string) if *string == STRING_STRUCT => {
+                    exploration.ctx.set_local(
+                        links.source,
+                        receiver_id,
+                        TypedVariable::immutable(iterable.ty),
+                    );
+                }
+                _ => {
+                    if iterable.ty.is_ok() {
+                        diagnostics.push(
+                            Diagnostic::new(DiagnosticID::TypeMismatch, "Expected iterable type")
+                                .with_observation(Observation::here(
+                                    links.source,
+                                    exploration.externals.current,
+                                    range.iterable.segment(),
+                                    format!(
+                                        "Found `{}`",
+                                        exploration
+                                            .new_type_view(iterable.ty, &TypesBounds::inactive())
+                                    ),
+                                )),
+                        );
+                    }
+                }
+            }
+            let body = ascribe_types(
+                exploration,
+                links,
+                diagnostics,
+                &it.body,
+                state
+                    .with_in_loop()
+                    .with_local_value(ExpressionValue::Unused),
+            );
+            TypedExpr {
+                kind: ExprKind::ForLoop(ForLoop {
+                    kind: Box::new(hir::ForKind::Range(RangeFor {
+                        receiver: receiver_id,
+                        receiver_type: exploration
+                            .ctx
+                            .get_local(links.source, receiver_id)
+                            .unwrap()
+                            .type_ref,
+                        iterable,
+                    })),
+                    body: Box::new(body),
+                }),
+                ty: UNIT,
+                segment: it.segment.clone(),
+            }
+        }
+        ForKind::Conditional(conditional) => {
+            let initializer = ascribe_types(
+                exploration,
+                links,
+                diagnostics,
+                &conditional.initializer,
+                state,
+            );
+            let condition = ascribe_types(
+                exploration,
+                links,
+                diagnostics,
+                &conditional.condition,
+                state,
+            );
+            let increment = ascribe_types(
+                exploration,
+                links,
+                diagnostics,
+                &conditional.increment,
+                state,
+            );
+            let body = ascribe_types(
+                exploration,
+                links,
+                diagnostics,
+                &it.body,
+                state
+                    .with_in_loop()
+                    .with_local_value(ExpressionValue::Unused),
+            );
+            TypedExpr {
+                kind: ExprKind::ForLoop(ForLoop {
+                    kind: Box::new(hir::ForKind::Conditional(ConditionalFor {
+                        initializer,
+                        condition,
+                        increment,
+                    })),
+                    body: Box::new(body),
+                }),
+                ty: UNIT,
+                segment: it.segment.clone(),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::diagnostic::{Diagnostic, DiagnosticID, Observation};
+    use crate::reef::ReefId;
+    use crate::relations::SourceId;
+    use crate::steps::typing::tests::extract_type;
+    use crate::types::{STRING, UNIT};
+    use context::source::Source;
+    use context::str_find::find_in;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn verify_body_when_error() {
+        let content = "for i in 11 - {} { i = 9 }";
+        let res = extract_type(Source::unknown(content));
+        assert_eq!(
+            res,
+            Err(vec![
+                Diagnostic::new(DiagnosticID::UnknownMethod, "Undefined operator",)
+                    .with_observation(Observation::here(
+                        SourceId(0),
+                        ReefId(1),
+                        find_in(content, "11 - {}"),
+                        "No operator `sub` between type `Int` and `Unit`",
+                    )),
+                Diagnostic::new(
+                    DiagnosticID::CannotReassign,
+                    "Cannot assign twice to immutable variable `i`",
+                )
+                .with_observation(Observation::here(
+                    SourceId(0),
+                    ReefId(1),
+                    find_in(content, "i = 9"),
+                    "Assignment happens here",
+                ))
+            ])
+        );
+    }
+
+    #[test]
+    fn iterate_glob() {
+        let source = Source::unknown("for f in p'*'.spread() { echo $f }");
+        let res = extract_type(source);
+        assert_eq!(res, Ok(UNIT));
+    }
+
+    #[test]
+    fn iterate_string() {
+        let source = Source::unknown("var last = ''; for c in 'hello' { last = $c }; $last");
+        let res = extract_type(source);
+        assert_eq!(res, Ok(STRING));
+    }
+
+    #[test]
+    fn iterate_condition() {
+        let source = Source::unknown("for ((var x = 0; $x < 0; $x += 0)) { echo $x }");
+        let res = extract_type(source);
+        assert_eq!(res, Ok(UNIT));
+    }
+}

--- a/analyzer/src/types.rs
+++ b/analyzer/src/types.rs
@@ -62,7 +62,6 @@ pub const GENERIC_VECTOR: TypeRef = TypeRef::new(LANG_REEF, TypeId(8));
 pub const GENERIC_OPTION: TypeRef = TypeRef::new(LANG_REEF, TypeId(9));
 pub const GLOB: TypeRef = TypeRef::new(LANG_REEF, TypeId(10));
 pub const PID: TypeRef = TypeRef::new(LANG_REEF, TypeId(11));
-pub const GENERIC_RANGE: TypeRef = TypeRef::new(LANG_REEF, TypeId(12));
 
 /// An error that occurs when two types are not compatible.
 #[derive(Debug, PartialEq)]

--- a/analyzer/src/types.rs
+++ b/analyzer/src/types.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::reef::LANG_REEF;
 use crate::types::ty::{Type, TypeId, TypeRef};
 
-pub(crate) mod builtin;
+pub mod builtin;
 pub mod ctx;
 pub mod engine;
 pub mod hir;
@@ -62,6 +62,7 @@ pub const GENERIC_VECTOR: TypeRef = TypeRef::new(LANG_REEF, TypeId(8));
 pub const GENERIC_OPTION: TypeRef = TypeRef::new(LANG_REEF, TypeId(9));
 pub const GLOB: TypeRef = TypeRef::new(LANG_REEF, TypeId(10));
 pub const PID: TypeRef = TypeRef::new(LANG_REEF, TypeId(11));
+pub const GENERIC_RANGE: TypeRef = TypeRef::new(LANG_REEF, TypeId(12));
 
 /// An error that occurs when two types are not compatible.
 #[derive(Debug, PartialEq)]

--- a/analyzer/src/types/hir.rs
+++ b/analyzer/src/types/hir.rs
@@ -76,6 +76,46 @@ pub struct Loop {
     pub body: Box<TypedExpr>,
 }
 
+/// A for loop.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ForLoop {
+    /// The type of the for loop.
+    pub kind: Box<ForKind>,
+    /// The body of the for loop.
+    pub body: Box<TypedExpr>,
+}
+
+/// A for loop can be either a range loop or a conditional loop.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ForKind {
+    Range(RangeFor),
+    Conditional(ConditionalFor),
+}
+
+/// A for in range loop, e.g. `for i in 1..10; ...`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RangeFor {
+    /// The variable name that will be used in the loop to designate the current item.
+    pub receiver: LocalId,
+
+    /// The type of the receiver.
+    pub receiver_type: TypeRef,
+
+    /// The range of values that will be iterated over.
+    pub iterable: TypedExpr,
+}
+
+/// A for in conditional loop, e.g. `for (( i = 0; i < 10; i++ )); ...`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ConditionalFor {
+    /// The initialization expression.
+    pub initializer: TypedExpr,
+    /// The condition expression.
+    pub condition: TypedExpr,
+    /// The increment expression.
+    pub increment: TypedExpr,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct FunctionCall {
     pub arguments: Vec<TypedExpr>,
@@ -123,6 +163,7 @@ pub enum ExprKind {
     Redirect(Redirect),
     Conditional(Conditional),
     ConditionalLoop(Loop),
+    ForLoop(ForLoop),
     Convert(Convert),
     ProcessCall(Vec<TypedExpr>),
     FunctionCall(FunctionCall),

--- a/analyzer/tests/collect_debug.rs
+++ b/analyzer/tests/collect_debug.rs
@@ -127,11 +127,11 @@ fn collect_sample() {
         usages,
         vec![(
             &SymbolLocation::unspecified(Name::new("LOG_FILE")),
-            RelationId(1)
+            RelationId(2)
         )]
     );
     assert_eq!(
-        relations[RelationId(1)],
+        relations[RelationId(2)],
         Relation {
             origin: SourceId(2),
             state: RelationState::Resolved(ResolvedSymbol {
@@ -155,20 +155,20 @@ fn collect_sample() {
         vec![
             (
                 &SymbolLocation::unspecified(Name::new("count")),
-                RelationId(2)
+                RelationId(3)
             ),
             (
                 &SymbolLocation::unspecified(Name::new("factorial")),
-                RelationId(3)
+                RelationId(4)
             ),
-            (&SymbolLocation::unspecified(Name::new("n")), RelationId(4)),
+            (&SymbolLocation::unspecified(Name::new("n")), RelationId(5)),
         ]
     );
 
     let reef_id = ReefId(2);
 
     assert_eq!(
-        relations[RelationId(2)],
+        relations[RelationId(3)],
         Relation {
             origin: SourceId(4),
             state: RelationState::Resolved(ResolvedSymbol {
@@ -180,7 +180,7 @@ fn collect_sample() {
         }
     );
     assert_eq!(
-        relations[RelationId(3)],
+        relations[RelationId(4)],
         Relation {
             origin: SourceId(4),
             state: RelationState::Resolved(ResolvedSymbol {
@@ -192,7 +192,7 @@ fn collect_sample() {
         }
     );
     assert_eq!(
-        relations[RelationId(4)],
+        relations[RelationId(5)],
         Relation {
             origin: SourceId(4),
             state: RelationState::Resolved(ResolvedSymbol {
@@ -211,6 +211,6 @@ fn collect_sample() {
     let variables = lambda_env.symbols.external_symbols().collect::<Vec<_>>();
     assert_eq!(
         variables,
-        vec![(&SymbolLocation::unspecified(Name::new("n")), RelationId(5))]
+        vec![(&SymbolLocation::unspecified(Name::new("n")), RelationId(6))]
     );
 }

--- a/compiler/src/emit/iterable.rs
+++ b/compiler/src/emit/iterable.rs
@@ -1,0 +1,165 @@
+use crate::bytecode::{Instructions, Opcode};
+use crate::constant_pool::ConstantPool;
+use crate::context::EmitterContext;
+use crate::emit::native::{STRING_INDEX, STRING_LEN, VEC_INDEX, VEC_LEN};
+use crate::emit::{emit, EmissionState};
+use crate::locals::LocalsLayout;
+use analyzer::types::builtin::STRING_STRUCT;
+use analyzer::types::hir::{ForKind, ForLoop, RangeFor, TypedExpr};
+use analyzer::types::ty::Type;
+use analyzer::types::{GENERIC_VECTOR, INT, STRING};
+
+pub(super) fn emit_for_loop(
+    it: &ForLoop,
+    instructions: &mut Instructions,
+    ctx: &EmitterContext,
+    cp: &mut ConstantPool,
+    locals: &mut LocalsLayout,
+    state: &mut EmissionState,
+) {
+    match it.kind.as_ref() {
+        ForKind::Range(range) => {
+            let iterable_type = ctx.get_type(range.iterable.ty);
+            match iterable_type {
+                Type::Instantiated(vec, params) if *vec == GENERIC_VECTOR => {
+                    let param = params[0];
+                    emit_for_iterable(
+                        range,
+                        &it.body,
+                        |instructions, cp| {
+                            instructions.emit_invoke(cp.insert_string(VEC_INDEX));
+                            if !param.is_obj() {
+                                instructions.emit_code(Opcode::Unbox);
+                            }
+                        },
+                        |instructions, cp| {
+                            instructions.emit_invoke(cp.insert_string(VEC_LEN));
+                        },
+                        |instructions, _, _| {
+                            instructions.emit_push_int(1);
+                        },
+                        instructions,
+                        ctx,
+                        cp,
+                        locals,
+                        state,
+                    );
+                }
+                Type::Structure(_, string) if *string == STRING_STRUCT => {
+                    emit_for_iterable(
+                        range,
+                        &it.body,
+                        |instructions, cp| {
+                            instructions.emit_invoke(cp.insert_string(STRING_INDEX));
+                        },
+                        |instructions, cp| {
+                            instructions.emit_invoke(cp.insert_string(STRING_LEN));
+                        },
+                        |instructions, cp, locals| {
+                            instructions.emit_get_local(range.receiver, STRING.into(), locals);
+                            instructions.emit_invoke(cp.insert_string(STRING_LEN));
+                        },
+                        instructions,
+                        ctx,
+                        cp,
+                        locals,
+                        state,
+                    );
+                }
+                _ => panic!("Unexpected iterable {iterable_type:?} type"),
+            }
+        }
+        ForKind::Conditional(cond) => {
+            emit(&cond.initializer, instructions, ctx, cp, locals, state);
+
+            let loop_start = instructions.current_ip();
+            let mut loop_state = EmissionState::in_loop();
+
+            let last_used = state.use_values(true);
+
+            // Evaluate the condition.
+            emit(&cond.condition, instructions, ctx, cp, locals, state);
+            state.use_values(last_used);
+
+            // If the condition is false, go to END.
+            let jump_to_end = instructions.emit_jump(Opcode::IfNotJump);
+            loop_state.enclosing_loop_end_placeholders.push(jump_to_end);
+
+            // Evaluate the loop body.
+            emit(&it.body, instructions, ctx, cp, locals, &mut loop_state);
+            for jump_to_increment in loop_state.enclosing_loop_start_placeholders {
+                instructions.patch_jump(jump_to_increment);
+            }
+            emit(&cond.increment, instructions, ctx, cp, locals, state);
+            // Go to START.
+            instructions.jump_back_to(loop_start);
+
+            // END:
+            for jump_to_end in loop_state.enclosing_loop_end_placeholders {
+                instructions.patch_jump(jump_to_end);
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn emit_for_iterable<
+    F: FnOnce(&mut Instructions, &mut ConstantPool),
+    S: FnOnce(&mut Instructions, &mut ConstantPool),
+    I: FnOnce(&mut Instructions, &mut ConstantPool, &mut LocalsLayout),
+>(
+    RangeFor {
+        receiver,
+        receiver_type,
+        iterable,
+    }: &RangeFor,
+    body: &TypedExpr,
+    indexer: F,
+    len: S,
+    increment: I,
+    instructions: &mut Instructions,
+    ctx: &EmitterContext,
+    cp: &mut ConstantPool,
+    locals: &mut LocalsLayout,
+    state: &mut EmissionState,
+) {
+    let iterator_id = locals.push_value_space(iterable.ty);
+    let last_used = state.use_values(true);
+    emit(iterable, instructions, ctx, cp, locals, state);
+    state.use_values(last_used);
+    instructions.emit_set_local(iterator_id, iterable.ty.into(), locals);
+
+    let index_id = locals.push_value_space(INT);
+    instructions.emit_push_int(0);
+    instructions.emit_set_local(index_id, INT.into(), locals);
+
+    let loop_start = instructions.current_ip();
+    let mut loop_state = EmissionState::in_loop();
+    instructions.emit_get_local(index_id, INT.into(), locals);
+    instructions.emit_get_local(iterator_id, iterable.ty.into(), locals);
+    len(instructions, cp);
+    instructions.emit_code(Opcode::IntLessThan);
+    let jump_to_end = instructions.emit_jump(Opcode::IfNotJump);
+    loop_state.enclosing_loop_end_placeholders.push(jump_to_end);
+
+    // Indexes the iterable and stores the result in the receiver.
+    locals.set_value_space(*receiver, *receiver_type);
+    instructions.emit_get_local(iterator_id, iterable.ty.into(), locals);
+    instructions.emit_get_local(index_id, INT.into(), locals);
+    indexer(instructions, cp);
+    instructions.emit_set_local(*receiver, (*receiver_type).into(), locals);
+
+    emit(body, instructions, ctx, cp, locals, &mut loop_state);
+    for jump_to_increment in loop_state.enclosing_loop_start_placeholders {
+        instructions.patch_jump(jump_to_increment);
+    }
+    instructions.emit_get_local(index_id, INT.into(), locals);
+    increment(instructions, cp, locals);
+    instructions.emit_code(Opcode::IntAdd);
+    instructions.emit_set_local(index_id, INT.into(), locals);
+
+    instructions.jump_back_to(loop_start);
+    for jump_to_end in loop_state.enclosing_loop_end_placeholders {
+        instructions.patch_jump(jump_to_end);
+    }
+}

--- a/compiler/src/emit/iterable.rs
+++ b/compiler/src/emit/iterable.rs
@@ -4,6 +4,7 @@ use crate::context::EmitterContext;
 use crate::emit::native::{STRING_INDEX, STRING_LEN, VEC_INDEX, VEC_LEN};
 use crate::emit::{emit, EmissionState};
 use crate::locals::LocalsLayout;
+use crate::r#type::ValueStackSize;
 use analyzer::reef::ReefId;
 use analyzer::relations::LocalId;
 use analyzer::types::builtin::STRING_STRUCT;
@@ -89,7 +90,10 @@ pub(super) fn emit_for_loop(
                             instructions.emit_get_local(iterator_id, type_ref.into(), locals);
                             instructions.emit_get_field(LocalId(0), layout);
                         },
-                        |_, _| {},
+                        |instructions, _| {
+                            instructions.emit_code(Opcode::Swap);
+                            instructions.emit_pop(ValueStackSize::QWord);
+                        },
                         |instructions, _| {
                             instructions.emit_get_field(LocalId(1), layout);
                         },

--- a/compiler/src/emit/native.rs
+++ b/compiler/src/emit/native.rs
@@ -12,12 +12,14 @@ const STRING_EQ: &str = "lang::String::eq";
 const STRING_CONCAT: &str = "lang::String::concat";
 const INT_TO_STRING: &str = "lang::Int::to_string";
 const FLOAT_TO_STRING: &str = "lang::Float::to_string";
-const VEC_INDEX: &str = "lang::Vec::[]";
+pub(super) const STRING_LEN: &str = "lang::String::len";
+pub(super) const STRING_INDEX: &str = "lang::String::[]";
+pub(super) const VEC_INDEX: &str = "lang::Vec::[]";
 const VEC_INDEX_EQ: &str = "lang::Vec::[]=";
 const VEC_POP: &str = "lang::Vec::pop";
 pub(super) const VEC_PUSH: &str = "lang::Vec::push";
 pub(super) const VEC_EXTEND: &str = "lang::Vec::extend";
-const VEC_LEN: &str = "lang::Vec::len";
+pub(super) const VEC_LEN: &str = "lang::Vec::len";
 const VEC_POP_HEAD: &str = "lang::Vec::pop_head";
 const STRING_SPLIT: &str = "lang::String::split";
 const STRING_BYTES: &str = "lang::String::bytes";
@@ -156,6 +158,10 @@ pub(crate) fn emit_natives(
         30 => {
             // Float -> String
             instructions.emit_invoke(cp.insert_string(FLOAT_TO_STRING));
+        }
+        32 => {
+            // String.len() -> Int
+            instructions.emit_invoke(cp.insert_string(STRING_LEN));
         }
         33 => {
             // String + String -> String

--- a/compiler/src/externals.rs
+++ b/compiler/src/externals.rs
@@ -27,10 +27,9 @@ impl CompilerExternals {
     }
 
     pub fn set(&mut self, id: ReefId, reef: CompiledReef) {
-        if self.compiled_reefs.len() <= id.0 {
-            self.compiled_reefs
-                .resize(id.0 + 1, CompiledReef::default())
+        if self.compiled_reefs.len() < id.0 {
+            self.compiled_reefs.resize(id.0, CompiledReef::default())
         }
-        self.compiled_reefs[id.0] = reef
+        self.compiled_reefs[id.0 - 1] = reef
     }
 }

--- a/compiler/src/locals.rs
+++ b/compiler/src/locals.rs
@@ -40,6 +40,15 @@ impl LocalsLayout {
         self.len += size as u32;
     }
 
+    /// Creates a new local and reserves the space for it.
+    pub fn push_value_space(&mut self, tpe: TypeRef) -> LocalId {
+        let id = LocalId(self.values_indexes.len());
+        let size: u8 = ValueStackSize::from(tpe).into();
+        self.values_indexes.push(Some((self.len, tpe.is_obj())));
+        self.len += size as u32;
+        id
+    }
+
     /// Reserves the space in local's of the external reference, if not already set.
     ///
     /// Different initialization orders will result in different indexes.

--- a/lib/std.msh
+++ b/lib/std.msh
@@ -63,3 +63,15 @@ fun home_dir(username: String) -> Option[String];
 ///
 /// @panics if the current user does not have a home directory specified.
 fun current_home_dir() -> String;
+
+struct Range {
+    start: Int,
+    end: Int,
+    step: Int,
+}
+
+struct InclusiveRange {
+    start: Int,
+    end: Int,
+    step: Int,
+}

--- a/vm/binding/value.rs
+++ b/vm/binding/value.rs
@@ -11,22 +11,32 @@ pub enum VmValue {
     Struct(Vec<Option<VmValue>>),
 }
 
-impl From<Vec<&str>> for VmValue {
-    fn from(value: Vec<&str>) -> Self {
-        let vec = value
-            .into_iter()
-            .map(|s| Some(Self::String(s.to_string())))
-            .collect();
+impl<T: Into<VmValue>> From<Vec<T>> for VmValue {
+    fn from(value: Vec<T>) -> Self {
+        let vec = value.into_iter().map(|s| Some(s.into())).collect();
 
         Self::Vec(vec)
     }
 }
 
-impl From<&str> for VmValue {
-    fn from(value: &str) -> Self {
-        Self::String(value.to_string())
+impl From<i64> for VmValue {
+    fn from(value: i64) -> Self {
+        Self::Int(value)
     }
 }
+
+impl From<f64> for VmValue {
+    fn from(value: f64) -> Self {
+        Self::Double(value)
+    }
+}
+
+impl From<&str> for VmValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_owned())
+    }
+}
+
 impl VmValue {
     /// retrieve maximum amount of information from a given value
     /// In case of structures, as the layout isn't provided by FFIs, the

--- a/vm/src/memory/operand_stack.cpp
+++ b/vm/src/memory/operand_stack.cpp
@@ -82,6 +82,7 @@ void OperandStack::dup_qword() {
         throw StackOverflowError("exceeded stack capacity via operand stack");
     }
     memcpy(this->bytes + current_pos, this->bytes + current_pos - sizeof(int64_t), sizeof(int64_t));
+    std::copy(operands_refs + current_pos - sizeof(int64_t), operands_refs + current_pos, operands_refs + current_pos);
     current_pos += sizeof(int64_t);
 }
 

--- a/vm/tests/integration/flow.rs
+++ b/vm/tests/integration/flow.rs
@@ -21,6 +21,62 @@ fn break_loop() {
 }
 
 #[test]
+fn factorial() {
+    let mut runner = Runner::default();
+    let res = runner.eval(
+        "
+        var res = 1
+        for ((var i = 1; $i <= 5; $i += 1)) {
+            $res *= $i
+        }
+        $res
+    ",
+    );
+    assert_eq!(res, Some(VmValue::Int(120)))
+}
+
+#[test]
+fn iter_utf8_string() {
+    let mut runner = Runner::default();
+    let res = runner.eval(
+        "
+        val v = std::new_vec::[String]()
+        for c in 'aé🦀 𓀀' {
+            if $c == ' ' {
+                continue
+            }
+            $v.push($c)
+        }
+        $v
+    ",
+    );
+    assert_eq!(res, Some(vec!["a", "é", "🦀", "𓀀"].into()))
+}
+
+#[test]
+fn iter_bool_vec() {
+    let mut runner = Runner::default();
+    let res = runner.eval(
+        "
+        var vec = std::new_vec::[Bool]()
+        $vec.push(true)
+        $vec.push(true)
+        $vec.push(false)
+        var builder = ''
+        for b in $vec {
+            if $b {
+                $builder += 't'
+            } else {
+                $builder += 'f'
+            }
+        }
+        $builder
+    ",
+    );
+    assert_eq!(res, Some("ttf".into()))
+}
+
+#[test]
 fn test_assertion() {
     let mut runner = Runner::default();
     assert_eq!(

--- a/vm/tests/integration/flow.rs
+++ b/vm/tests/integration/flow.rs
@@ -77,6 +77,21 @@ fn iter_bool_vec() {
 }
 
 #[test]
+fn iter_range() {
+    let mut runner = Runner::default();
+    let res = runner.eval(
+        "
+        var vec = std::new_vec::[Int]()
+        for i in 1..5 {
+            $vec.push($i)
+        }
+        $vec
+    ",
+    );
+    assert_eq!(res, Some(vec![1, 2, 3, 4].into()))
+}
+
+#[test]
 fn test_assertion() {
     let mut runner = Runner::default();
     assert_eq!(

--- a/vm/tests/integration/runner.rs
+++ b/vm/tests/integration/runner.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use analyzer::importer::{ASTImporter, ImportResult, StaticImporter};
 use analyzer::name::Name;
-use analyzer::reef::{Externals, Reef};
+use analyzer::reef::{Externals, Reef, ReefId};
 use analyzer::relations::SourceId;
 use analyzer::types::engine::ChunkKind;
 use analyzer::types::ty::{Type, TypeRef};
@@ -27,7 +27,7 @@ pub struct Runner<'a> {
 impl Default for Runner<'_> {
     fn default() -> Self {
         let mut externals = Externals::default();
-        let compiler_externals = CompilerExternals::default();
+        let mut compiler_externals = CompilerExternals::default();
         let mut std_importer = FileImporter::new(PathBuf::from("../lib"));
         let mut vm = VM::default();
 
@@ -35,7 +35,7 @@ impl Default for Runner<'_> {
         let analyzer = analyze(std_name.clone(), &mut std_importer, &externals);
         let mut buff = Vec::new();
 
-        compile_reef(
+        let compiled = compile_reef(
             &analyzer.engine,
             &analyzer.resolution.relations,
             &analyzer.typing,
@@ -48,6 +48,7 @@ impl Default for Runner<'_> {
             CompilerOptions::default(),
         )
         .expect("std did not compile successfully");
+        compiler_externals.set(ReefId(1), compiled);
 
         vm.register(&buff).expect("VM std register");
         unsafe {


### PR DESCRIPTION
Adds a simpler way to iterate over vectors, integer ranges and strings.

All those iteration types are hard-coded with internal int indexes. Indexes over a vector are always incremented by one, whereas indexes in strings use the length in bytes of the current char to account for multi bytes characters.

Strings are byte-indexed, and may not be indexed in the middle of a multibyte character.

Int ranges are describes as structures in the standard library, with a variant for inclusive ranges.