### PR TITLE
Add process substitutions

### DIFF
--- a/analyzer/src/types/hir.rs
+++ b/analyzer/src/types/hir.rs
@@ -132,6 +132,12 @@ pub struct MethodCall {
 }
 
 #[derive(Clone, Debug, PartialEq)]
+pub enum Substitute {
+    In(Vec<TypedExpr>),
+    Out(Vec<TypedExpr>),
+}
+
+#[derive(Clone, Debug, PartialEq)]
 pub struct Subprocess {
     pub inner: Box<TypedExpr>,
     pub awaited: bool,
@@ -171,6 +177,7 @@ pub enum ExprKind {
     Return(Option<Box<TypedExpr>>),
     Pipeline(Vec<TypedExpr>),
     Capture(Vec<TypedExpr>),
+    Substitute(Substitute),
     Subprocess(Subprocess),
 
     Continue,

--- a/ast/src/substitution.rs
+++ b/ast/src/substitution.rs
@@ -16,11 +16,18 @@ impl SourceSegmentHolder for Substitution<'_> {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum Direction {
+    Input,
+    Output,
+}
+
 /// The kind of substitution that should be performed.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum SubstitutionKind {
-    /// An arithmetic evaluation with `$((...))`.
-    Arithmetic,
     /// A command standard output substitution with `$(...)`.
     Capture,
+
+    /// A process substitution with `<(...)` or `>(...)`.
+    Process { direction: Direction },
 }

--- a/cli/lang_tests/redir/process_substitution.msh
+++ b/cli/lang_tests/redir/process_substitution.msh
@@ -1,0 +1,11 @@
+// Run:
+//   status: success
+//   stdout:
+//          2c2
+//          < b
+//          ---
+//          > c
+//          text4
+
+diff <(echo a; echo b) <(echo "a\nc")
+tee >(wc -c | tr -d ' ') <<< "text"

--- a/vm/src/stdlib_natives.cpp
+++ b/vm/src/stdlib_natives.cpp
@@ -348,6 +348,14 @@ static void program_arguments(OperandStack &caller_stack, runtime_memory &mem) {
     }
 }
 
+static void get_fd_path(OperandStack &caller_stack, runtime_memory &mem) {
+    int fd = caller_stack.pop_int();
+    std::string path = "/dev/fd/";
+    path += std::to_string(fd);
+    msh::obj &str = mem.emplace(std::move(path));
+    caller_stack.push_reference(str);
+}
+
 static void process_wait(OperandStack &caller_stack, runtime_memory &) {
     pid_t pid = static_cast<pid_t>(caller_stack.pop_int());
     int status;
@@ -406,6 +414,7 @@ natives_functions_t load_natives() {
         {"std::convert::round", round},
         {"std::convert::parse_int_radix", parse_int_radix},
 
+        {"std::process::get_fd_path", get_fd_path},
         {"std::process::wait", process_wait},
         {"std::process::wait_all", process_wait_all},
     };


### PR DESCRIPTION
Implement Bash-like [process substitutions](https://en.wikipedia.org/wiki/Process_substitution). Tested on GNU/Linux and macOS.

It allows using the output or the input of a process as a file. The most notorious example is the diff command, which takes two files: `diff <(echo before) <(echo after)`.

Bytecode wise, one end of the pipe must be kept opened in the parent process while the process substitution consumer is created. In the `diff` example, the pipes for the two `echo`s is kept before the `diff` process is actually created. File closing is delayed using compiler generated locals.